### PR TITLE
chore: scaffold native macOS menubar prototype

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,36 @@
+---
+name: Bug report
+about: Report a reproducible defect in the TAEL AI mac agent
+title: "[Bug] "
+labels: bug
+assignees: ""
+---
+
+## Summary
+
+What failed?
+
+## Steps to reproduce
+
+1.
+2.
+3.
+
+## Expected result
+
+What should happen?
+
+## Actual result
+
+What happened instead?
+
+## Environment
+
+- macOS version:
+- App build:
+- Bundle ID:
+- Signing team set: yes/no
+
+## Logs or screenshots
+
+Paste relevant local logs. Do not include captured screenshots that contain private data.

--- a/.github/ISSUE_TEMPLATE/implementation_ticket.md
+++ b/.github/ISSUE_TEMPLATE/implementation_ticket.md
@@ -1,0 +1,31 @@
+---
+name: Implementation ticket
+about: Track one scoped implementation step
+title: "[Week 1] "
+labels: implementation
+assignees: ""
+---
+
+## Goal
+
+What should this ticket deliver?
+
+## Acceptance criteria
+
+- [ ]
+
+## Scope limits
+
+- No AI planner.
+- No speech capture.
+- No AX tree.
+- No executor.
+- No screenshot persistence.
+
+## Validation
+
+Commands or manual checks required before closing:
+
+```sh
+xcodebuild -project TAELMacAgent/TAELMacAgent.xcodeproj -scheme TAELMacAgent -configuration Debug -destination 'platform=macOS' CODE_SIGNING_ALLOWED=NO build
+```

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,25 @@
+## Summary
+
+-
+
+## Scope
+
+- [ ] Native macOS menubar utility scope only
+- [ ] No protected API bypass added
+- [ ] No out-of-scope Week 1 features added
+
+## Validation
+
+```sh
+xcodebuild -project TAELMacAgent/TAELMacAgent.xcodeproj -scheme TAELMacAgent -configuration Debug -destination 'platform=macOS' CODE_SIGNING_ALLOWED=NO build
+```
+
+```sh
+xcodebuild -project TAELMacAgent/TAELMacAgent.xcodeproj -scheme TAELMacAgent -configuration Debug -destination 'platform=macOS' CODE_SIGNING_ALLOWED=NO test
+```
+
+## Notes for reviewers
+
+- Stable bundle ID: `ai.tael.macagent`
+- Deployment target: macOS 14.0+
+- `DEVELOPMENT_TEAM` may be blank until Ozzy sets the local team in Xcode.

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,25 @@
+# macOS
+.DS_Store
+
+# Xcode
+DerivedData/
+*.xcuserstate
+*.xcuserdata/
+*.moved-aside
+*.xccheckout
+*.xcscmblueprint
+
+# Swift Package Manager
+.build/
+Packages/
+Package.resolved
+
+# Local env
+.env
+.env.*
+
+# Logs
+*.log
+
+# Build products
+build/

--- a/README.md
+++ b/README.md
@@ -1,0 +1,64 @@
+# tael-ai
+
+Native macOS menubar utility scaffold for the TAEL AI mac agent.
+
+The source of truth for this implementation pass is `TAEL_AI_mac_agent_build_plan_v0_3.md`. Older planning files are historical context only when they conflict with v0.3.
+
+## PR 1 scope
+
+PR 1 creates the native macOS foundation only:
+
+- macOS app target in `TAELMacAgent/`
+- stable bundle ID `ai.tael.macagent`
+- macOS deployment target `14.0`
+- SwiftUI app with AppKit menubar utility shell
+- quit action from the menubar
+- Week 1 permission boundary types
+- protected API policy docs
+- manual test checklist and Week 1 heartbeat checklist
+
+PR 1 does not implement screenshot capture, speech capture, AX reads, executor paths, AI planner work, packaging, analytics, or product naming work.
+
+## Build
+
+Open `TAELMacAgent/TAELMacAgent.xcodeproj` in Xcode and set the Apple Development Team before regular local development builds.
+
+For compile validation without signing:
+
+```sh
+xcodebuild \
+  -project TAELMacAgent/TAELMacAgent.xcodeproj \
+  -scheme TAELMacAgent \
+  -configuration Debug \
+  -destination 'platform=macOS' \
+  CODE_SIGNING_ALLOWED=NO \
+  build
+```
+
+Run tests:
+
+```sh
+xcodebuild \
+  -project TAELMacAgent/TAELMacAgent.xcodeproj \
+  -scheme TAELMacAgent \
+  -configuration Debug \
+  -destination 'platform=macOS' \
+  CODE_SIGNING_ALLOWED=NO \
+  test
+```
+
+## Week 1 heartbeat
+
+The Week 1 heartbeat is:
+
+```text
+global hotkey -> PermissionsGate -> SCScreenshotManager.captureImage(contentFilter:configuration:) -> non-activating NSPanel HUD with screenshot PNG
+```
+
+The screenshot target will be the display containing the cursor, with fallback to the main display.
+
+## Protected API boundary
+
+No protected macOS API call may bypass `PermissionsGate`. Protected services require a `PermissionGrant`, and the grant is only issued inside the gate.
+
+See `docs/ProtectedAPICallPolicy.md`.

--- a/TAELMacAgent/TAELMacAgent.xcodeproj/project.pbxproj
+++ b/TAELMacAgent/TAELMacAgent.xcodeproj/project.pbxproj
@@ -1,0 +1,582 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 56;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		A10000000000000000000070 /* TAELMacAgentApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = A10000000000000000000040 /* TAELMacAgentApp.swift */; };
+		A10000000000000000000071 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = A10000000000000000000041 /* AppDelegate.swift */; };
+		A10000000000000000000072 /* MenuBarController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A10000000000000000000042 /* MenuBarController.swift */; };
+		A10000000000000000000073 /* HotkeyManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = A10000000000000000000043 /* HotkeyManager.swift */; };
+		A10000000000000000000074 /* PermissionKind.swift in Sources */ = {isa = PBXBuildFile; fileRef = A10000000000000000000044 /* PermissionKind.swift */; };
+		A10000000000000000000075 /* PermissionStatus.swift in Sources */ = {isa = PBXBuildFile; fileRef = A10000000000000000000045 /* PermissionStatus.swift */; };
+		A10000000000000000000076 /* PermissionError.swift in Sources */ = {isa = PBXBuildFile; fileRef = A10000000000000000000046 /* PermissionError.swift */; };
+		A10000000000000000000077 /* PermissionGrant.swift in Sources */ = {isa = PBXBuildFile; fileRef = A10000000000000000000047 /* PermissionGrant.swift */; };
+		A10000000000000000000078 /* PermissionsChecker.swift in Sources */ = {isa = PBXBuildFile; fileRef = A10000000000000000000048 /* PermissionsChecker.swift */; };
+		A10000000000000000000079 /* PermissionsGate.swift in Sources */ = {isa = PBXBuildFile; fileRef = A10000000000000000000049 /* PermissionsGate.swift */; };
+		A10000000000000000000080 /* HUDPanelController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A10000000000000000000050 /* HUDPanelController.swift */; };
+		A10000000000000000000081 /* HUDView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A10000000000000000000051 /* HUDView.swift */; };
+		A10000000000000000000082 /* PermissionGateView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A10000000000000000000052 /* PermissionGateView.swift */; };
+		A10000000000000000000083 /* ScreenCaptureService.swift in Sources */ = {isa = PBXBuildFile; fileRef = A10000000000000000000053 /* ScreenCaptureService.swift */; };
+		A10000000000000000000084 /* ScreenshotTarget.swift in Sources */ = {isa = PBXBuildFile; fileRef = A10000000000000000000054 /* ScreenshotTarget.swift */; };
+		A10000000000000000000085 /* CapturedScreenshot.swift in Sources */ = {isa = PBXBuildFile; fileRef = A10000000000000000000055 /* CapturedScreenshot.swift */; };
+		A10000000000000000000086 /* LocalLogService.swift in Sources */ = {isa = PBXBuildFile; fileRef = A10000000000000000000056 /* LocalLogService.swift */; };
+		A10000000000000000000087 /* InvocationLog.swift in Sources */ = {isa = PBXBuildFile; fileRef = A10000000000000000000057 /* InvocationLog.swift */; };
+		A10000000000000000000088 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = A10000000000000000000058 /* Assets.xcassets */; };
+		A10000000000000000000089 /* PermissionsGateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A10000000000000000000059 /* PermissionsGateTests.swift */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXContainerItemProxy section */
+		A10000000000000000000015 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = A10000000000000000000001 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = A10000000000000000000004;
+			remoteInfo = TAELMacAgent;
+		};
+/* End PBXContainerItemProxy section */
+
+/* Begin PBXFileReference section */
+		A10000000000000000000006 /* TAELMacAgent.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = TAELMacAgent.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		A10000000000000000000007 /* TAELMacAgentTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = TAELMacAgentTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		A10000000000000000000040 /* TAELMacAgentApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TAELMacAgentApp.swift; sourceTree = "<group>"; };
+		A10000000000000000000041 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
+		A10000000000000000000042 /* MenuBarController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MenuBarController.swift; sourceTree = "<group>"; };
+		A10000000000000000000043 /* HotkeyManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HotkeyManager.swift; sourceTree = "<group>"; };
+		A10000000000000000000044 /* PermissionKind.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PermissionKind.swift; sourceTree = "<group>"; };
+		A10000000000000000000045 /* PermissionStatus.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PermissionStatus.swift; sourceTree = "<group>"; };
+		A10000000000000000000046 /* PermissionError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PermissionError.swift; sourceTree = "<group>"; };
+		A10000000000000000000047 /* PermissionGrant.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PermissionGrant.swift; sourceTree = "<group>"; };
+		A10000000000000000000048 /* PermissionsChecker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PermissionsChecker.swift; sourceTree = "<group>"; };
+		A10000000000000000000049 /* PermissionsGate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PermissionsGate.swift; sourceTree = "<group>"; };
+		A10000000000000000000050 /* HUDPanelController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HUDPanelController.swift; sourceTree = "<group>"; };
+		A10000000000000000000051 /* HUDView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HUDView.swift; sourceTree = "<group>"; };
+		A10000000000000000000052 /* PermissionGateView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PermissionGateView.swift; sourceTree = "<group>"; };
+		A10000000000000000000053 /* ScreenCaptureService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScreenCaptureService.swift; sourceTree = "<group>"; };
+		A10000000000000000000054 /* ScreenshotTarget.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScreenshotTarget.swift; sourceTree = "<group>"; };
+		A10000000000000000000055 /* CapturedScreenshot.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CapturedScreenshot.swift; sourceTree = "<group>"; };
+		A10000000000000000000056 /* LocalLogService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalLogService.swift; sourceTree = "<group>"; };
+		A10000000000000000000057 /* InvocationLog.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InvocationLog.swift; sourceTree = "<group>"; };
+		A10000000000000000000058 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
+		A10000000000000000000059 /* PermissionsGateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PermissionsGateTests.swift; sourceTree = "<group>"; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		A10000000000000000000009 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		A10000000000000000000012 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		A10000000000000000000002 = {
+			isa = PBXGroup;
+			children = (
+				A10000000000000000000025 /* TAELMacAgent */,
+				A10000000000000000000026 /* TAELMacAgentTests */,
+				A10000000000000000000003 /* Products */,
+			);
+			sourceTree = "<group>";
+		};
+		A10000000000000000000003 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				A10000000000000000000006 /* TAELMacAgent.app */,
+				A10000000000000000000007 /* TAELMacAgentTests.xctest */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		A10000000000000000000025 /* TAELMacAgent */ = {
+			isa = PBXGroup;
+			children = (
+				A10000000000000000000027 /* App */,
+				A10000000000000000000028 /* Hotkey */,
+				A10000000000000000000029 /* Permissions */,
+				A10000000000000000000030 /* HUD */,
+				A10000000000000000000031 /* Capture */,
+				A10000000000000000000032 /* Logging */,
+				A10000000000000000000033 /* Resources */,
+			);
+			path = TAELMacAgent;
+			sourceTree = "<group>";
+		};
+		A10000000000000000000026 /* TAELMacAgentTests */ = {
+			isa = PBXGroup;
+			children = (
+				A10000000000000000000059 /* PermissionsGateTests.swift */,
+			);
+			path = TAELMacAgentTests;
+			sourceTree = "<group>";
+		};
+		A10000000000000000000027 /* App */ = {
+			isa = PBXGroup;
+			children = (
+				A10000000000000000000040 /* TAELMacAgentApp.swift */,
+				A10000000000000000000041 /* AppDelegate.swift */,
+				A10000000000000000000042 /* MenuBarController.swift */,
+			);
+			path = App;
+			sourceTree = "<group>";
+		};
+		A10000000000000000000028 /* Hotkey */ = {
+			isa = PBXGroup;
+			children = (
+				A10000000000000000000043 /* HotkeyManager.swift */,
+			);
+			path = Hotkey;
+			sourceTree = "<group>";
+		};
+		A10000000000000000000029 /* Permissions */ = {
+			isa = PBXGroup;
+			children = (
+				A10000000000000000000044 /* PermissionKind.swift */,
+				A10000000000000000000045 /* PermissionStatus.swift */,
+				A10000000000000000000046 /* PermissionError.swift */,
+				A10000000000000000000047 /* PermissionGrant.swift */,
+				A10000000000000000000048 /* PermissionsChecker.swift */,
+				A10000000000000000000049 /* PermissionsGate.swift */,
+			);
+			path = Permissions;
+			sourceTree = "<group>";
+		};
+		A10000000000000000000030 /* HUD */ = {
+			isa = PBXGroup;
+			children = (
+				A10000000000000000000050 /* HUDPanelController.swift */,
+				A10000000000000000000051 /* HUDView.swift */,
+				A10000000000000000000052 /* PermissionGateView.swift */,
+			);
+			path = HUD;
+			sourceTree = "<group>";
+		};
+		A10000000000000000000031 /* Capture */ = {
+			isa = PBXGroup;
+			children = (
+				A10000000000000000000053 /* ScreenCaptureService.swift */,
+				A10000000000000000000054 /* ScreenshotTarget.swift */,
+				A10000000000000000000055 /* CapturedScreenshot.swift */,
+			);
+			path = Capture;
+			sourceTree = "<group>";
+		};
+		A10000000000000000000032 /* Logging */ = {
+			isa = PBXGroup;
+			children = (
+				A10000000000000000000056 /* LocalLogService.swift */,
+				A10000000000000000000057 /* InvocationLog.swift */,
+			);
+			path = Logging;
+			sourceTree = "<group>";
+		};
+		A10000000000000000000033 /* Resources */ = {
+			isa = PBXGroup;
+			children = (
+				A10000000000000000000058 /* Assets.xcassets */,
+			);
+			path = Resources;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		A10000000000000000000004 /* TAELMacAgent */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = A10000000000000000000017 /* Build configuration list for PBXNativeTarget "TAELMacAgent" */;
+			buildPhases = (
+				A10000000000000000000008 /* Sources */,
+				A10000000000000000000009 /* Frameworks */,
+				A10000000000000000000010 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = TAELMacAgent;
+			productName = TAELMacAgent;
+			productReference = A10000000000000000000006 /* TAELMacAgent.app */;
+			productType = "com.apple.product-type.application";
+		};
+		A10000000000000000000005 /* TAELMacAgentTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = A10000000000000000000018 /* Build configuration list for PBXNativeTarget "TAELMacAgentTests" */;
+			buildPhases = (
+				A10000000000000000000011 /* Sources */,
+				A10000000000000000000012 /* Frameworks */,
+				A10000000000000000000013 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				A10000000000000000000014 /* PBXTargetDependency */,
+			);
+			name = TAELMacAgentTests;
+			productName = TAELMacAgentTests;
+			productReference = A10000000000000000000007 /* TAELMacAgentTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		A10000000000000000000001 /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				BuildIndependentTargetsInParallel = 1;
+				LastSwiftUpdateCheck = 2640;
+				LastUpgradeCheck = 2640;
+				TargetAttributes = {
+					A10000000000000000000004 = {
+						CreatedOnToolsVersion = 26.4.1;
+					};
+					A10000000000000000000005 = {
+						CreatedOnToolsVersion = 26.4.1;
+						TestTargetID = A10000000000000000000004;
+					};
+				};
+			};
+			buildConfigurationList = A10000000000000000000016 /* Build configuration list for PBXProject "TAELMacAgent" */;
+			compatibilityVersion = "Xcode 14.0";
+			developmentRegion = en;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+				Base,
+			);
+			mainGroup = A10000000000000000000002;
+			productRefGroup = A10000000000000000000003 /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				A10000000000000000000004 /* TAELMacAgent */,
+				A10000000000000000000005 /* TAELMacAgentTests */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		A10000000000000000000010 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				A10000000000000000000088 /* Assets.xcassets in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		A10000000000000000000013 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		A10000000000000000000008 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				A10000000000000000000070 /* TAELMacAgentApp.swift in Sources */,
+				A10000000000000000000071 /* AppDelegate.swift in Sources */,
+				A10000000000000000000072 /* MenuBarController.swift in Sources */,
+				A10000000000000000000073 /* HotkeyManager.swift in Sources */,
+				A10000000000000000000074 /* PermissionKind.swift in Sources */,
+				A10000000000000000000075 /* PermissionStatus.swift in Sources */,
+				A10000000000000000000076 /* PermissionError.swift in Sources */,
+				A10000000000000000000077 /* PermissionGrant.swift in Sources */,
+				A10000000000000000000078 /* PermissionsChecker.swift in Sources */,
+				A10000000000000000000079 /* PermissionsGate.swift in Sources */,
+				A10000000000000000000080 /* HUDPanelController.swift in Sources */,
+				A10000000000000000000081 /* HUDView.swift in Sources */,
+				A10000000000000000000082 /* PermissionGateView.swift in Sources */,
+				A10000000000000000000083 /* ScreenCaptureService.swift in Sources */,
+				A10000000000000000000084 /* ScreenshotTarget.swift in Sources */,
+				A10000000000000000000085 /* CapturedScreenshot.swift in Sources */,
+				A10000000000000000000086 /* LocalLogService.swift in Sources */,
+				A10000000000000000000087 /* InvocationLog.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		A10000000000000000000011 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				A10000000000000000000089 /* PermissionsGateTests.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin PBXTargetDependency section */
+		A10000000000000000000014 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = A10000000000000000000004 /* TAELMacAgent */;
+			targetProxy = A10000000000000000000015 /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
+
+/* Begin XCBuildConfiguration section */
+		A10000000000000000000019 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu17;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				MACOSX_DEPLOYMENT_TARGET = 14.0;
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = macosx;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+			};
+			name = Debug;
+		};
+		A10000000000000000000020 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu17;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				MACOSX_DEPLOYMENT_TARGET = 14.0;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				MTL_FAST_MATH = YES;
+				SDKROOT = macosx;
+				SWIFT_COMPILATION_MODE = wholemodule;
+				SWIFT_OPTIMIZATION_LEVEL = "-O";
+			};
+			name = Release;
+		};
+		A10000000000000000000021 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_IDENTITY = "Apple Development";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = "";
+				ENABLE_HARDENED_RUNTIME = YES;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_CFBundleDisplayName = "TAEL AI";
+				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.productivity";
+				INFOPLIST_KEY_LSUIElement = YES;
+				INFOPLIST_KEY_NSHumanReadableCopyright = "";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/../Frameworks",
+				);
+				MACOSX_DEPLOYMENT_TARGET = 14.0;
+				MARKETING_VERSION = 0.1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = ai.tael.macagent;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+			};
+			name = Debug;
+		};
+		A10000000000000000000022 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_IDENTITY = "Apple Development";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = "";
+				ENABLE_HARDENED_RUNTIME = YES;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_CFBundleDisplayName = "TAEL AI";
+				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.productivity";
+				INFOPLIST_KEY_LSUIElement = YES;
+				INFOPLIST_KEY_NSHumanReadableCopyright = "";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/../Frameworks",
+				);
+				MACOSX_DEPLOYMENT_TARGET = 14.0;
+				MARKETING_VERSION = 0.1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = ai.tael.macagent;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+			};
+			name = Release;
+		};
+		A10000000000000000000023 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CODE_SIGN_IDENTITY = "Apple Development";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = "";
+				GENERATE_INFOPLIST_FILE = YES;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/../Frameworks",
+					"@loader_path/../Frameworks",
+				);
+				MACOSX_DEPLOYMENT_TARGET = 14.0;
+				MARKETING_VERSION = 0.1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = ai.tael.macagent.tests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/TAELMacAgent.app/Contents/MacOS/TAELMacAgent";
+			};
+			name = Debug;
+		};
+		A10000000000000000000024 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CODE_SIGN_IDENTITY = "Apple Development";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = "";
+				GENERATE_INFOPLIST_FILE = YES;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/../Frameworks",
+					"@loader_path/../Frameworks",
+				);
+				MACOSX_DEPLOYMENT_TARGET = 14.0;
+				MARKETING_VERSION = 0.1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = ai.tael.macagent.tests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/TAELMacAgent.app/Contents/MacOS/TAELMacAgent";
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		A10000000000000000000016 /* Build configuration list for PBXProject "TAELMacAgent" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				A10000000000000000000019 /* Debug */,
+				A10000000000000000000020 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		A10000000000000000000017 /* Build configuration list for PBXNativeTarget "TAELMacAgent" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				A10000000000000000000021 /* Debug */,
+				A10000000000000000000022 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		A10000000000000000000018 /* Build configuration list for PBXNativeTarget "TAELMacAgentTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				A10000000000000000000023 /* Debug */,
+				A10000000000000000000024 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = A10000000000000000000001 /* Project object */;
+}

--- a/TAELMacAgent/TAELMacAgent.xcodeproj/xcshareddata/xcschemes/TAELMacAgent.xcscheme
+++ b/TAELMacAgent/TAELMacAgent.xcodeproj/xcshareddata/xcschemes/TAELMacAgent.xcscheme
@@ -1,0 +1,91 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "2640"
+   version = "1.7">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES"
+      buildArchitectures = "Automatic">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "A10000000000000000000004"
+               BuildableName = "TAELMacAgent.app"
+               BlueprintName = "TAELMacAgent"
+               ReferencedContainer = "container:TAELMacAgent.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      shouldAutocreateTestPlan = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO"
+            parallelizable = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "A10000000000000000000005"
+               BuildableName = "TAELMacAgentTests.xctest"
+               BlueprintName = "TAELMacAgentTests"
+               ReferencedContainer = "container:TAELMacAgent.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "A10000000000000000000004"
+            BuildableName = "TAELMacAgent.app"
+            BlueprintName = "TAELMacAgent"
+            ReferencedContainer = "container:TAELMacAgent.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "A10000000000000000000004"
+            BuildableName = "TAELMacAgent.app"
+            BlueprintName = "TAELMacAgent"
+            ReferencedContainer = "container:TAELMacAgent.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/TAELMacAgent/TAELMacAgent/App/AppDelegate.swift
+++ b/TAELMacAgent/TAELMacAgent/App/AppDelegate.swift
@@ -1,0 +1,47 @@
+import AppKit
+import Foundation
+
+@MainActor
+final class AppDelegate: NSObject, NSApplicationDelegate {
+    private var menuBarController: MenuBarController?
+    private let hudPanelController = HUDPanelController()
+    private let logService = LocalLogService()
+    private var hotkeyManager: HotkeyManager?
+
+    func applicationDidFinishLaunching(_ notification: Notification) {
+        NSApp.setActivationPolicy(.accessory)
+
+        hotkeyManager = HotkeyManager { [weak self] in
+            self?.showScaffoldHUD(source: .hotkeyPlaceholder)
+        }
+        hotkeyManager?.start()
+
+        menuBarController = MenuBarController(
+            onShowHUD: { [weak self] in
+                self?.showScaffoldHUD(source: .menuBar)
+            },
+            onQuit: {
+                NSApp.terminate(nil)
+            }
+        )
+    }
+
+    func applicationWillTerminate(_ notification: Notification) {
+        hotkeyManager?.stop()
+    }
+
+    private func showScaffoldHUD(source: InvocationLog.Source) {
+        hudPanelController.showPlaceholder()
+
+        let log = InvocationLog(
+            source: source,
+            occurredAt: Date(),
+            permissionStatus: nil,
+            message: "Scaffold HUD placeholder shown"
+        )
+
+        Task {
+            await logService.record(log)
+        }
+    }
+}

--- a/TAELMacAgent/TAELMacAgent/App/MenuBarController.swift
+++ b/TAELMacAgent/TAELMacAgent/App/MenuBarController.swift
@@ -1,0 +1,39 @@
+import AppKit
+
+@MainActor
+final class MenuBarController {
+    private let statusItem: NSStatusItem
+
+    init(onShowHUD: @escaping () -> Void, onQuit: @escaping () -> Void) {
+        statusItem = NSStatusBar.system.statusItem(withLength: NSStatusItem.variableLength)
+
+        if let button = statusItem.button {
+            button.image = NSImage(systemSymbolName: "bolt.fill", accessibilityDescription: "TAEL AI")
+            button.imagePosition = .imageOnly
+        }
+
+        let menu = NSMenu()
+        menu.addItem(MenuActionItem(title: "Show HUD placeholder", actionHandler: onShowHUD))
+        menu.addItem(.separator())
+        menu.addItem(MenuActionItem(title: "Quit TAEL AI", actionHandler: onQuit))
+        statusItem.menu = menu
+    }
+}
+
+private final class MenuActionItem: NSMenuItem {
+    private let actionHandler: () -> Void
+
+    init(title: String, actionHandler: @escaping () -> Void) {
+        self.actionHandler = actionHandler
+        super.init(title: title, action: #selector(runAction), keyEquivalent: "")
+        target = self
+    }
+
+    required init(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    @objc private func runAction() {
+        actionHandler()
+    }
+}

--- a/TAELMacAgent/TAELMacAgent/App/TAELMacAgentApp.swift
+++ b/TAELMacAgent/TAELMacAgent/App/TAELMacAgentApp.swift
@@ -1,0 +1,12 @@
+import SwiftUI
+
+@main
+struct TAELMacAgentApp: App {
+    @NSApplicationDelegateAdaptor(AppDelegate.self) private var appDelegate
+
+    var body: some Scene {
+        Settings {
+            EmptyView()
+        }
+    }
+}

--- a/TAELMacAgent/TAELMacAgent/Capture/CapturedScreenshot.swift
+++ b/TAELMacAgent/TAELMacAgent/Capture/CapturedScreenshot.swift
@@ -1,0 +1,8 @@
+import CoreGraphics
+import Foundation
+
+struct CapturedScreenshot {
+    let image: CGImage
+    let target: ScreenshotTarget
+    let capturedAt: Date
+}

--- a/TAELMacAgent/TAELMacAgent/Capture/ScreenCaptureService.swift
+++ b/TAELMacAgent/TAELMacAgent/Capture/ScreenCaptureService.swift
@@ -1,0 +1,13 @@
+import CoreGraphics
+import Foundation
+
+enum ScreenCaptureServiceError: Error, Equatable {
+    case notImplementedInPR1
+}
+
+final class ScreenCaptureService {
+    func captureDisplayScreenshot(_ grant: PermissionGrant) async throws -> CGImage {
+        precondition(grant.kind == .screenRecording)
+        throw ScreenCaptureServiceError.notImplementedInPR1
+    }
+}

--- a/TAELMacAgent/TAELMacAgent/Capture/ScreenshotTarget.swift
+++ b/TAELMacAgent/TAELMacAgent/Capture/ScreenshotTarget.swift
@@ -1,0 +1,12 @@
+import CoreGraphics
+import Foundation
+
+struct ScreenshotTarget: Equatable, Sendable {
+    enum ResolutionReason: String, Equatable, Sendable {
+        case displayContainingCursor
+        case mainDisplayFallback
+    }
+
+    let displayID: CGDirectDisplayID?
+    let reason: ResolutionReason
+}

--- a/TAELMacAgent/TAELMacAgent/HUD/HUDPanelController.swift
+++ b/TAELMacAgent/TAELMacAgent/HUD/HUDPanelController.swift
@@ -1,0 +1,69 @@
+import AppKit
+import SwiftUI
+
+@MainActor
+final class HUDPanelController: PermissionGatePresenting {
+    private var panel: NSPanel?
+
+    func showPlaceholder() {
+        show(
+            HUDView(
+                title: "TAEL AI",
+                detail: "Menubar scaffold is running."
+            )
+        )
+    }
+
+    func showGate(for kind: PermissionKind) async {
+        show(PermissionGateView(kind: kind))
+    }
+
+    func close() {
+        panel?.orderOut(nil)
+    }
+
+    private func show<Content: View>(_ content: Content) {
+        let panel = panel ?? makePanel()
+        self.panel = panel
+
+        panel.contentView = NSHostingView(rootView: content)
+        position(panel)
+        panel.orderFrontRegardless()
+    }
+
+    private func makePanel() -> NSPanel {
+        let panel = NSPanel(
+            contentRect: NSRect(x: 0, y: 0, width: 420, height: 220),
+            styleMask: [.nonactivatingPanel, .borderless],
+            backing: .buffered,
+            defer: false
+        )
+        panel.level = .floating
+        panel.collectionBehavior = [.canJoinAllSpaces, .fullScreenAuxiliary, .transient]
+        panel.hidesOnDeactivate = false
+        panel.isReleasedWhenClosed = false
+        panel.isOpaque = false
+        panel.backgroundColor = .clear
+        panel.isMovableByWindowBackground = true
+        return panel
+    }
+
+    private func position(_ panel: NSPanel) {
+        let mouseLocation = NSEvent.mouseLocation
+        let screen = NSScreen.screens.first { screen in
+            NSMouseInRect(mouseLocation, screen.frame, false)
+        } ?? NSScreen.main
+
+        guard let frame = screen?.visibleFrame else {
+            panel.center()
+            return
+        }
+
+        let panelSize = panel.frame.size
+        let origin = NSPoint(
+            x: frame.maxX - panelSize.width - 24,
+            y: frame.maxY - panelSize.height - 24
+        )
+        panel.setFrameOrigin(origin)
+    }
+}

--- a/TAELMacAgent/TAELMacAgent/HUD/HUDView.swift
+++ b/TAELMacAgent/TAELMacAgent/HUD/HUDView.swift
@@ -1,0 +1,21 @@
+import SwiftUI
+
+struct HUDView: View {
+    let title: String
+    let detail: String
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Text(title)
+                .font(.headline)
+            Text(detail)
+                .font(.body)
+                .foregroundStyle(.secondary)
+        }
+        .padding(20)
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+        .background(.regularMaterial)
+        .clipShape(RoundedRectangle(cornerRadius: 8, style: .continuous))
+        .shadow(radius: 18)
+    }
+}

--- a/TAELMacAgent/TAELMacAgent/HUD/PermissionGateView.swift
+++ b/TAELMacAgent/TAELMacAgent/HUD/PermissionGateView.swift
@@ -1,0 +1,33 @@
+import AppKit
+import SwiftUI
+
+struct PermissionGateView: View {
+    let kind: PermissionKind
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 14) {
+            Text("\(kind.displayName) required")
+                .font(.headline)
+            Text("Grant permission in System Settings, then retry the invocation.")
+                .foregroundStyle(.secondary)
+            Button("Open System Settings") {
+                openSettings()
+            }
+        }
+        .padding(20)
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+        .background(.regularMaterial)
+        .clipShape(RoundedRectangle(cornerRadius: 8, style: .continuous))
+        .shadow(radius: 18)
+    }
+
+    private func openSettings() {
+        guard kind == .screenRecording,
+              let url = URL(string: "x-apple.systempreferences:com.apple.preference.security?Privacy_ScreenCapture")
+        else {
+            return
+        }
+
+        NSWorkspace.shared.open(url)
+    }
+}

--- a/TAELMacAgent/TAELMacAgent/Hotkey/HotkeyManager.swift
+++ b/TAELMacAgent/TAELMacAgent/Hotkey/HotkeyManager.swift
@@ -1,0 +1,27 @@
+import Foundation
+
+@MainActor
+final class HotkeyManager {
+    private let onInvoke: () -> Void
+    private(set) var isRunning = false
+
+    init(onInvoke: @escaping () -> Void) {
+        self.onInvoke = onInvoke
+    }
+
+    func start() {
+        isRunning = true
+    }
+
+    func stop() {
+        isRunning = false
+    }
+
+    func simulateInvocationForDebug() {
+        guard isRunning else {
+            return
+        }
+
+        onInvoke()
+    }
+}

--- a/TAELMacAgent/TAELMacAgent/Logging/InvocationLog.swift
+++ b/TAELMacAgent/TAELMacAgent/Logging/InvocationLog.swift
@@ -1,0 +1,33 @@
+import Foundation
+
+struct InvocationLog: Sendable {
+    enum Source: String, Sendable {
+        case menuBar
+        case hotkeyPlaceholder
+    }
+
+    let id: UUID
+    let source: Source
+    let occurredAt: Date
+    let permissionStatus: PermissionStatus?
+    let message: String
+
+    init(
+        id: UUID = UUID(),
+        source: Source,
+        occurredAt: Date,
+        permissionStatus: PermissionStatus?,
+        message: String
+    ) {
+        self.id = id
+        self.source = source
+        self.occurredAt = occurredAt
+        self.permissionStatus = permissionStatus
+        self.message = message
+    }
+
+    var summary: String {
+        let status = permissionStatus?.rawValue ?? "notChecked"
+        return "invocation id=\(id.uuidString) source=\(source.rawValue) permissionStatus=\(status) message=\(message)"
+    }
+}

--- a/TAELMacAgent/TAELMacAgent/Logging/LocalLogService.swift
+++ b/TAELMacAgent/TAELMacAgent/Logging/LocalLogService.swift
@@ -1,0 +1,10 @@
+import Foundation
+import OSLog
+
+actor LocalLogService {
+    private let logger = Logger(subsystem: "ai.tael.macagent", category: "invocation")
+
+    func record(_ invocation: InvocationLog) {
+        logger.info("\(invocation.summary, privacy: .public)")
+    }
+}

--- a/TAELMacAgent/TAELMacAgent/Permissions/PermissionError.swift
+++ b/TAELMacAgent/TAELMacAgent/Permissions/PermissionError.swift
@@ -1,0 +1,15 @@
+import Foundation
+
+enum PermissionError: Error, Equatable, LocalizedError {
+    case missing(PermissionKind)
+    case unsupported(PermissionKind)
+
+    var errorDescription: String? {
+        switch self {
+        case .missing(let kind):
+            return "\(kind.displayName) permission is required."
+        case .unsupported(let kind):
+            return "\(kind.displayName) permission is not implemented yet."
+        }
+    }
+}

--- a/TAELMacAgent/TAELMacAgent/Permissions/PermissionGrant.swift
+++ b/TAELMacAgent/TAELMacAgent/Permissions/PermissionGrant.swift
@@ -1,0 +1,4 @@
+import Foundation
+
+// PermissionGrant is declared in PermissionsGate.swift so its fileprivate
+// initializer can stay in the same file as the only issuer.

--- a/TAELMacAgent/TAELMacAgent/Permissions/PermissionKind.swift
+++ b/TAELMacAgent/TAELMacAgent/Permissions/PermissionKind.swift
@@ -1,0 +1,33 @@
+import Foundation
+
+enum PermissionKind: String, CaseIterable, Equatable, Sendable {
+    case screenRecording
+    case accessibility
+    case microphone
+    case appleEvents
+    case inputMonitoring
+    case clipboardWrite
+    case subprocessAction
+    case keyboardMouseAutomation
+
+    var displayName: String {
+        switch self {
+        case .screenRecording:
+            return "Screen Recording"
+        case .accessibility:
+            return "Accessibility"
+        case .microphone:
+            return "Microphone"
+        case .appleEvents:
+            return "Apple Events"
+        case .inputMonitoring:
+            return "Input Monitoring"
+        case .clipboardWrite:
+            return "Clipboard Write"
+        case .subprocessAction:
+            return "Subprocess Action"
+        case .keyboardMouseAutomation:
+            return "Keyboard and Mouse Automation"
+        }
+    }
+}

--- a/TAELMacAgent/TAELMacAgent/Permissions/PermissionStatus.swift
+++ b/TAELMacAgent/TAELMacAgent/Permissions/PermissionStatus.swift
@@ -1,0 +1,9 @@
+import Foundation
+
+enum PermissionStatus: String, Equatable, Sendable {
+    case granted
+    case denied
+    case notDetermined
+    case restricted
+    case unsupported
+}

--- a/TAELMacAgent/TAELMacAgent/Permissions/PermissionsChecker.swift
+++ b/TAELMacAgent/TAELMacAgent/Permissions/PermissionsChecker.swift
@@ -1,0 +1,19 @@
+import CoreGraphics
+import Foundation
+
+final class PermissionsChecker: PermissionChecking {
+    func status(for kind: PermissionKind) async -> PermissionStatus {
+        switch kind {
+        case .screenRecording:
+            return CGPreflightScreenCaptureAccess() ? .granted : .notDetermined
+        case .accessibility,
+             .microphone,
+             .appleEvents,
+             .inputMonitoring,
+             .clipboardWrite,
+             .subprocessAction,
+             .keyboardMouseAutomation:
+            return .unsupported
+        }
+    }
+}

--- a/TAELMacAgent/TAELMacAgent/Permissions/PermissionsGate.swift
+++ b/TAELMacAgent/TAELMacAgent/Permissions/PermissionsGate.swift
@@ -1,0 +1,48 @@
+import Foundation
+
+protocol PermissionChecking: AnyObject {
+    func status(for kind: PermissionKind) async -> PermissionStatus
+}
+
+protocol PermissionGatePresenting: AnyObject {
+    @MainActor func showGate(for kind: PermissionKind) async
+}
+
+final class NoopPermissionGatePresenter: PermissionGatePresenting {
+    @MainActor func showGate(for kind: PermissionKind) async {}
+}
+
+struct PermissionGrant: Sendable {
+    let kind: PermissionKind
+
+    fileprivate init(kind: PermissionKind) {
+        self.kind = kind
+    }
+}
+
+final class PermissionsGate {
+    private let checker: PermissionChecking
+    private let permissionUI: any PermissionGatePresenting
+
+    init(
+        checker: PermissionChecking = PermissionsChecker(),
+        permissionUI: any PermissionGatePresenting = NoopPermissionGatePresenter()
+    ) {
+        self.checker = checker
+        self.permissionUI = permissionUI
+    }
+
+    func withPermission<T>(
+        _ kind: PermissionKind,
+        operation: @escaping (PermissionGrant) async throws -> T
+    ) async throws -> T {
+        let status = await checker.status(for: kind)
+
+        guard status == .granted else {
+            await permissionUI.showGate(for: kind)
+            throw PermissionError.missing(kind)
+        }
+
+        return try await operation(PermissionGrant(kind: kind))
+    }
+}

--- a/TAELMacAgent/TAELMacAgent/Resources/Assets.xcassets/Contents.json
+++ b/TAELMacAgent/TAELMacAgent/Resources/Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/TAELMacAgent/TAELMacAgentTests/PermissionsGateTests.swift
+++ b/TAELMacAgent/TAELMacAgentTests/PermissionsGateTests.swift
@@ -1,0 +1,65 @@
+import XCTest
+@testable import TAELMacAgent
+
+final class PermissionsGateTests: XCTestCase {
+    @MainActor
+    func testWithPermissionIssuesGrantWhenGranted() async throws {
+        let presenter = StubPresenter()
+        let gate = PermissionsGate(
+            checker: StubChecker(status: .granted),
+            permissionUI: presenter
+        )
+
+        let result = try await gate.withPermission(.screenRecording) { grant in
+            XCTAssertEqual(grant.kind, .screenRecording)
+            return "ok"
+        }
+
+        XCTAssertEqual(result, "ok")
+        XCTAssertEqual(presenter.shownKinds, [])
+    }
+
+    @MainActor
+    func testWithPermissionShowsGateAndThrowsWhenMissing() async {
+        let presenter = StubPresenter()
+        let gate = PermissionsGate(
+            checker: StubChecker(status: .notDetermined),
+            permissionUI: presenter
+        )
+
+        do {
+            _ = try await gate.withPermission(.screenRecording) { _ in
+                XCTFail("Operation should not run without permission.")
+                return "unexpected"
+            }
+            XCTFail("Gate should throw when permission is missing.")
+        } catch PermissionError.missing(let kind) {
+            XCTAssertEqual(kind, .screenRecording)
+        } catch {
+            XCTFail("Unexpected error: \(error)")
+        }
+
+        XCTAssertEqual(presenter.shownKinds, [.screenRecording])
+    }
+}
+
+private final class StubChecker: PermissionChecking {
+    private let statusToReturn: PermissionStatus
+
+    init(status: PermissionStatus) {
+        statusToReturn = status
+    }
+
+    func status(for kind: PermissionKind) async -> PermissionStatus {
+        statusToReturn
+    }
+}
+
+@MainActor
+private final class StubPresenter: PermissionGatePresenting {
+    private(set) var shownKinds: [PermissionKind] = []
+
+    func showGate(for kind: PermissionKind) async {
+        shownKinds.append(kind)
+    }
+}

--- a/TODO_FOR_OZZY.md
+++ b/TODO_FOR_OZZY.md
@@ -1,0 +1,17 @@
+# TODO for Ozzy
+
+## Signing and identity
+
+- Set the Apple Developer Team ID in Xcode for `TAELMacAgent`.
+- Confirm the preferred local Apple Development signing identity.
+- Keep the intended dev path on Apple Development signing, not ad-hoc signing.
+
+## Repository and project ownership
+
+- Decide later whether this repo should remain `tael-ai` or move to `tael-mac-agent`. This run keeps `tael-ai` because the task explicitly required it.
+- Week 1 GitHub Issues were created by CLI as `#1` through `#13`. Decide whether future issues should be managed manually or by CLI.
+
+## Local validation
+
+- If a regular signed Xcode build fails locally, set `DEVELOPMENT_TEAM` in `TAELMacAgent/TAELMacAgent.xcodeproj`.
+- Use `scripts/reset-tcc-dev.sh` only after the bundle ID and signing identity are stable.

--- a/docs/Architecture.md
+++ b/docs/Architecture.md
@@ -1,0 +1,69 @@
+# Architecture
+
+## Current scope
+
+This repository currently contains the PR 1 foundation for the native TAEL AI mac agent.
+
+The app shape is a native macOS menubar utility:
+
+- Swift app lifecycle
+- SwiftUI views
+- AppKit menubar controller
+- AppKit `NSPanel` HUD placeholder
+- permission boundary types for future protected work
+
+## Week 1 heartbeat
+
+The Week 1 heartbeat is:
+
+```text
+global hotkey -> PermissionsGate -> SCScreenshotManager.captureImage(contentFilter:configuration:) -> non-activating NSPanel HUD with screenshot PNG
+```
+
+PR 1 does not implement that full heartbeat. It creates the shell and policy structure needed to implement it safely next.
+
+## Protected boundary
+
+Protected services must require a `PermissionGrant`. The grant can only be issued by `PermissionsGate`.
+
+```swift
+let image = try await permissionsGate.withPermission(.screenRecording) { grant in
+    try await screenCaptureService.captureDisplayScreenshot(grant)
+}
+```
+
+`ScreenCaptureService` has no public screenshot method that can run without a grant.
+
+## Week 1 screenshot target
+
+The Week 1 screenshot target will be the display containing the cursor, with fallback to the main display.
+
+It must use:
+
+```text
+SCScreenshotManager.captureImage(contentFilter:configuration:)
+```
+
+It must not use `captureImage(in:)` while the app targets macOS 14.0+.
+
+## Out of scope for PR 1
+
+- AI planner
+- speech capture
+- WhisperKit
+- AX tree
+- focused-window metadata
+- YAML skills
+- executor paths
+- clipboard actions
+- shell actions
+- AppleScript
+- CGEvent automation
+- settings UI
+- polished onboarding
+- DMG packaging
+- Sparkle
+- analytics
+- token tracking
+- screenshot persistence
+- landing page work

--- a/docs/ManualTestChecklist.md
+++ b/docs/ManualTestChecklist.md
@@ -1,0 +1,29 @@
+# Manual test checklist
+
+## PR 1 shell
+
+- [ ] Open `TAELMacAgent/TAELMacAgent.xcodeproj`.
+- [ ] Set the Apple Development Team ID in Xcode.
+- [ ] Build the `TAELMacAgent` scheme.
+- [ ] Launch the app.
+- [ ] Confirm the app appears as a menubar utility.
+- [ ] Confirm no normal app window opens on launch.
+- [ ] Open the menubar menu.
+- [ ] Select `Show HUD placeholder`.
+- [ ] Confirm the HUD appears without switching focus unnecessarily.
+- [ ] Select `Quit TAEL AI`.
+- [ ] Confirm the app exits cleanly.
+
+## Week 1 heartbeat
+
+- [ ] Press the hotkey while Terminal is focused.
+- [ ] Confirm HUD appears without switching app focus unnecessarily.
+- [ ] Deny Screen Recording and confirm the permission gate appears.
+- [ ] Grant Screen Recording and confirm the screenshot appears.
+- [ ] Confirm the screenshot is not persisted to disk.
+- [ ] Confirm invocation timing is logged locally.
+- [ ] Confirm the app does not crash if permission is denied.
+- [ ] Confirm the app does not crash in full-screen mode.
+- [ ] Confirm display-containing-cursor targeting works.
+- [ ] Confirm fallback to main display works.
+- [ ] Confirm the app can be quit cleanly from the menubar.

--- a/docs/PermissionNotes.md
+++ b/docs/PermissionNotes.md
@@ -1,0 +1,36 @@
+# Permission notes
+
+## Stable identity
+
+Screen Recording permission is tied to the app identity. Before TCC testing, keep these stable:
+
+- bundle ID: `ai.tael.macagent`
+- deployment target: macOS 14.0+
+- signing identity: Apple Development
+- Apple Development Team ID: set locally by Ozzy
+
+`DEVELOPMENT_TEAM` is intentionally blank in the scaffold because the local team ID was not available in this environment.
+
+## Screen Recording
+
+Week 1 only implements real permission work for Screen Recording.
+
+`PermissionsChecker` v0 reports `.screenRecording` with the macOS preflight path. Future permissions return `.unsupported` until their milestones.
+
+## Missing permission behavior
+
+When Screen Recording is missing, `PermissionsGate` must:
+
+1. ask the permission UI to show the gate state,
+2. throw `PermissionError.missing(.screenRecording)`,
+3. avoid running the protected operation.
+
+## TCC reset
+
+After the bundle ID and signing identity are stable, reset local Screen Recording state with:
+
+```sh
+scripts/reset-tcc-dev.sh
+```
+
+Use this only for local development debugging.

--- a/docs/ProtectedAPICallPolicy.md
+++ b/docs/ProtectedAPICallPolicy.md
@@ -1,0 +1,47 @@
+# Protected API call policy
+
+No ScreenCaptureKit call, AX read, microphone access, Apple Events call, keyboard/mouse event synthesis, subprocess action, or clipboard write may bypass the appropriate policy/gate.
+
+## Active in Week 1
+
+Only Screen Recording is active in Week 1.
+
+ScreenCaptureKit work must go through `PermissionsGate` with `.screenRecording`, and the protected screenshot service must require a `PermissionGrant`.
+
+Required call shape:
+
+```swift
+let image = try await permissionsGate.withPermission(.screenRecording) { grant in
+    try await screenCaptureService.captureDisplayScreenshot(grant)
+}
+```
+
+`ScreenCaptureService` must assert that the grant is for Screen Recording:
+
+```swift
+precondition(grant.kind == .screenRecording)
+```
+
+## Future policy entries
+
+These are policy placeholders only until their milestones:
+
+- Accessibility and AX tree reads
+- Microphone capture
+- Apple Events
+- Input Monitoring
+- keyboard and mouse event synthesis
+- clipboard writes
+- subprocess actions
+
+Do not add real calls for these paths in PR 1.
+
+## Screenshot API rule
+
+For macOS 14.0+, screenshot capture must use:
+
+```text
+SCScreenshotManager.captureImage(contentFilter:configuration:)
+```
+
+Do not use `captureImage(in:)` unless the deployment target intentionally moves to macOS 15.2+.

--- a/docs/Week1Heartbeat.md
+++ b/docs/Week1Heartbeat.md
@@ -1,0 +1,63 @@
+# Week 1 heartbeat
+
+## Definition of done
+
+```text
+Press hotkey while Terminal is focused.
+HUD appears without switching app focus unnecessarily.
+If Screen Recording is missing, permission gate appears.
+If Screen Recording is granted, screenshot appears.
+Screenshot is not persisted to disk.
+Invocation timing is logged locally.
+App does not crash if permission is denied.
+App does not crash in full-screen mode.
+App can be quit cleanly from menubar.
+```
+
+## Screenshot target
+
+The Week 1 screenshot target is the display containing the cursor, with fallback to the main display.
+
+The ScreenCaptureKit path must use:
+
+```text
+SCScreenshotManager.captureImage(contentFilter:configuration:)
+```
+
+Do not use `captureImage(in:)` for the macOS 14.0+ target.
+
+## Implementation ticket checklist
+
+- [ ] 0. Lock bundle ID, macOS 14.0+ target, signing team, and debug signing identity.
+- [ ] 1. Create native macOS menubar shell.
+- [ ] 2. Add ProtectedAPICallPolicy.md.
+- [ ] 3. Add PermissionKind and PermissionStatus.
+- [ ] 4. Implement PermissionsChecker v0 for Screen Recording only.
+- [ ] 5. Implement PermissionsGate v0.
+- [ ] 6. Add KeyboardShortcuts package.
+- [ ] 7. Add HUDPanelController placeholder.
+- [ ] 8. Add ScreenCaptureService.
+- [ ] 9. Wire hotkey -> screen gate -> screenshot capture.
+- [ ] 10. Render screenshot in HUD.
+- [ ] 11. Add local invocation log.
+- [ ] 12. Add manual test checklist.
+
+## PR 1 status
+
+PR 1 creates the shell, docs, boundary types, and placeholders. It does not implement screenshot capture or the real global hotkey.
+
+## GitHub issues
+
+- `#1` - 0. Lock bundle ID, macOS 14.0+ target, signing team, and debug signing identity.
+- `#2` - 1. Create native macOS menubar shell.
+- `#3` - 2. Add ProtectedAPICallPolicy.md.
+- `#4` - 3. Add PermissionKind and PermissionStatus.
+- `#5` - 4. Implement PermissionsChecker v0 for Screen Recording only.
+- `#6` - 5. Implement PermissionsGate v0.
+- `#7` - 6. Add KeyboardShortcuts package.
+- `#8` - 7. Add HUDPanelController placeholder.
+- `#9` - 8. Add ScreenCaptureService.
+- `#10` - 9. Wire hotkey -> screen gate -> screenshot capture.
+- `#11` - 10. Render screenshot in HUD.
+- `#12` - 11. Add local invocation log.
+- `#13` - 12. Add manual test checklist.

--- a/scripts/reset-tcc-dev.sh
+++ b/scripts/reset-tcc-dev.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+BUNDLE_ID="ai.tael.macagent"
+
+echo "Resetting Screen Recording TCC state for ${BUNDLE_ID}"
+tccutil reset ScreenCapture "${BUNDLE_ID}"


### PR DESCRIPTION
## Summary
- Scaffolded `TAELMacAgent` as a native macOS menubar utility with bundle ID `ai.tael.macagent` and macOS 14.0+ target.
- Added permission boundary types, tokenized `PermissionsGate`, Screen Recording checker, HUD placeholder, capture placeholder, local invocation logging, docs, templates, and owner TODOs.
- Created Week 1 GitHub issues #1 through #13 and linked them from `docs/Week1Heartbeat.md`.

## Scope
- PR 1 foundation only.
- No screenshot capture implementation yet.
- No AI planner, speech capture, AX tree, executor, persistence, packaging, analytics, or product naming work.

## Validation
```sh
xcodebuild -list -project TAELMacAgent/TAELMacAgent.xcodeproj
```

```sh
xcodebuild -project TAELMacAgent/TAELMacAgent.xcodeproj -scheme TAELMacAgent -configuration Debug -destination 'platform=macOS' CODE_SIGNING_ALLOWED=NO build\n```\n\n```sh\nxcodebuild -project TAELMacAgent/TAELMacAgent.xcodeproj -scheme TAELMacAgent -configuration Debug -destination 'platform=macOS' CODE_SIGNING_ALLOWED=NO test\n```\n\n## Notes\n- `DEVELOPMENT_TEAM` is intentionally blank until Ozzy sets the Apple Developer Team ID locally.\n- Formatting tools `swift-format`, `swiftformat`, and `swiftlint` were not installed locally.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Native macOS menubar utility application with SwiftUI interface
  * Global hotkey support with permission gating for Screen Recording access
  * Non-intrusive HUD panel for user interactions
  * Screenshot capture functionality
  * Automatic invocation logging with timestamps
  * Menu-based application control and quit functionality

<!-- end of auto-generated comment: release notes by coderabbit.ai -->