### PR TITLE
chore: PR 1 cleanup — pr-review-toolkit findings

### DIFF
--- a/TAELMacAgent/TAELMacAgent.xcodeproj/project.pbxproj
+++ b/TAELMacAgent/TAELMacAgent.xcodeproj/project.pbxproj
@@ -26,6 +26,7 @@
 		2B00000000000000000000B2 /* LocalLogService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A00000000000000000000B2 /* LocalLogService.swift */; };
 		2B00000000000000000000B3 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 1A00000000000000000000B3 /* Assets.xcassets */; };
 		2B00000000000000000000C1 /* PermissionsGateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A00000000000000000000C1 /* PermissionsGateTests.swift */; };
+		2B00000000000000000000C2 /* LocalLogServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A00000000000000000000C2 /* LocalLogServiceTests.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -60,6 +61,7 @@
 		1A00000000000000000000B4 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		1A00000000000000000000B5 /* TAELMacAgent.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = TAELMacAgent.entitlements; sourceTree = "<group>"; };
 		1A00000000000000000000C1 /* PermissionsGateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PermissionsGateTests.swift; sourceTree = "<group>"; };
+		1A00000000000000000000C2 /* LocalLogServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalLogServiceTests.swift; sourceTree = "<group>"; };
 		1A00000000000000000000F1 /* TAELMacAgent.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = TAELMacAgent.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		1A00000000000000000000F2 /* TAELMacAgentTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = TAELMacAgentTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
@@ -178,6 +180,7 @@
 			isa = PBXGroup;
 			children = (
 				1A00000000000000000000C1 /* PermissionsGateTests.swift */,
+				1A00000000000000000000C2 /* LocalLogServiceTests.swift */,
 			);
 			path = TAELMacAgentTests;
 			sourceTree = "<group>";
@@ -315,6 +318,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				2B00000000000000000000C1 /* PermissionsGateTests.swift in Sources */,
+				2B00000000000000000000C2 /* LocalLogServiceTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/TAELMacAgent/TAELMacAgent/HUD/HUDPanelController.swift
+++ b/TAELMacAgent/TAELMacAgent/HUD/HUDPanelController.swift
@@ -62,19 +62,24 @@ final class HUDPanelController: NSObject, PermissionGatePresenting {
         let host = NSHostingController(rootView: AnyView(content))
         host.view.frame = NSRect(x: 0, y: 0, width: 480, height: 280)
 
+        // v0.3 §23.11 defaults. Borderless + non-activating gives the
+        // overlay-on-top-of-the-user's-app feel; transient prevents
+        // the panel from showing in the app switcher. Explicit
+        // isReleasedWhenClosed = false because the controller owns
+        // the lifecycle via tearDown().
         let panel = NSPanel(
             contentRect: host.view.frame,
-            styleMask: [.titled, .closable, .nonactivatingPanel, .utilityWindow, .hudWindow],
+            styleMask: [.nonactivatingPanel, .borderless],
             backing: .buffered,
             defer: false
         )
-        panel.title = "TAEL"
         panel.contentViewController = host
         panel.isFloatingPanel = true
         panel.becomesKeyOnlyIfNeeded = true
         panel.hidesOnDeactivate = false
+        panel.isReleasedWhenClosed = false
         panel.level = .floating
-        panel.collectionBehavior = [.canJoinAllSpaces, .fullScreenAuxiliary]
+        panel.collectionBehavior = [.canJoinAllSpaces, .fullScreenAuxiliary, .transient]
         return panel
     }
 

--- a/TAELMacAgent/TAELMacAgent/HUD/HUDPanelController.swift
+++ b/TAELMacAgent/TAELMacAgent/HUD/HUDPanelController.swift
@@ -33,7 +33,9 @@ final class HUDPanelController: NSObject, PermissionGatePresenting {
     /// requirement; the body hops to `@MainActor` explicitly.
     nonisolated func showGate(for kind: PermissionKind) async {
         await MainActor.run {
-            self.presentNew(content: PermissionGateView(kind: kind))
+            self.presentNew(content: PermissionGateView(kind: kind) { [weak self] in
+                self?.tearDown()
+            })
         }
     }
 

--- a/TAELMacAgent/TAELMacAgent/HUD/HUDPanelController.swift
+++ b/TAELMacAgent/TAELMacAgent/HUD/HUDPanelController.swift
@@ -3,8 +3,8 @@
 //  TAELMacAgent
 //
 //  Owns the non-activating NSPanel that hosts the HUD. Implements
-//  `PermissionGateUI` so `PermissionsGate` can route missing-permission
-//  states through the same surface as the placeholder content.
+//  `PermissionGatePresenting` so `PermissionsGate` can route missing-
+//  permission states through the same surface as the placeholder content.
 //
 //  PR 1 ships an intentionally ugly placeholder. Real screenshot
 //  rendering lands in PR 2 (Week 1 ticket 10).
@@ -14,7 +14,7 @@ import AppKit
 import SwiftUI
 
 @MainActor
-final class HUDPanelController: NSObject, PermissionGateUI {
+final class HUDPanelController: NSObject, PermissionGatePresenting {
     private var panel: NSPanel?
 
     override init() {
@@ -27,7 +27,7 @@ final class HUDPanelController: NSObject, PermissionGateUI {
         presentNew(content: HUDView())
     }
 
-    /// `PermissionGateUI` implementation: show a sheet-like HUD that
+    /// `PermissionGatePresenting` implementation: show a sheet-like HUD that
     /// explains the missing permission and links to System Settings.
     /// `nonisolated` so it satisfies the non-isolated protocol
     /// requirement; the body hops to `@MainActor` explicitly.

--- a/TAELMacAgent/TAELMacAgent/HUD/PermissionGateView.swift
+++ b/TAELMacAgent/TAELMacAgent/HUD/PermissionGateView.swift
@@ -14,6 +14,7 @@ import SwiftUI
 
 struct PermissionGateView: View {
     let kind: PermissionKind
+    let onCancel: () -> Void
 
     var body: some View {
         VStack(alignment: .leading, spacing: 14) {
@@ -31,7 +32,7 @@ struct PermissionGateView: View {
                 .keyboardShortcut(.defaultAction)
 
                 Button("Cancel") {
-                    NSApp.keyWindow?.close()
+                    onCancel()
                 }
             }
 

--- a/TAELMacAgent/TAELMacAgent/Logging/LocalLogService.swift
+++ b/TAELMacAgent/TAELMacAgent/Logging/LocalLogService.swift
@@ -6,12 +6,21 @@
 //  Disk persistence (with size cap and rotation) lands when the
 //  executor lands.
 //
+//  PR-1-cleanup addition: surfaces overflow drops via `droppedCount`
+//  and an `os_log(.fault)` on the first drop per session, so a user
+//  reporting "TAEL didn't fire" doesn't quietly lose the evidence.
+//
 
 import Foundation
+import os.log
 
 public actor LocalLogService {
     private let capacity: Int
     private var buffer: [InvocationLog] = []
+    public private(set) var droppedCount: Int = 0
+    private var hasLoggedOverflow: Bool = false
+
+    private let log = Logger(subsystem: "ai.tael.macagent", category: "LocalLogService")
 
     public init(capacity: Int = 256) {
         precondition(capacity > 0)
@@ -21,7 +30,13 @@ public actor LocalLogService {
     public func record(_ log: InvocationLog) {
         buffer.append(log)
         if buffer.count > capacity {
-            buffer.removeFirst(buffer.count - capacity)
+            let drop = buffer.count - capacity
+            buffer.removeFirst(drop)
+            droppedCount += drop
+            if !hasLoggedOverflow {
+                hasLoggedOverflow = true
+                self.log.fault("LocalLogService ring buffer overflowed; entries are now being dropped. Capacity=\(self.capacity, privacy: .public). Subsequent drops are tracked in droppedCount.")
+            }
         }
     }
 
@@ -32,5 +47,6 @@ public actor LocalLogService {
 
     public func clear() {
         buffer.removeAll(keepingCapacity: true)
+        // droppedCount intentionally NOT reset - it's a session metric.
     }
 }

--- a/TAELMacAgent/TAELMacAgent/Permissions/PermissionStatus.swift
+++ b/TAELMacAgent/TAELMacAgent/Permissions/PermissionStatus.swift
@@ -22,6 +22,6 @@ public enum PermissionStatus: String, Sendable, Hashable {
     /// Note: PR 1's gate UI receives only `PermissionKind`, not status,
     /// so it cannot yet differentiate `.restricted` from `.denied` in
     /// the presented sheet — that hook lands when status is threaded
-    /// through `PermissionGateUI`.
+    /// through `PermissionGatePresenting`.
     case restricted
 }

--- a/TAELMacAgent/TAELMacAgent/Permissions/PermissionsChecker.swift
+++ b/TAELMacAgent/TAELMacAgent/Permissions/PermissionsChecker.swift
@@ -18,11 +18,11 @@ import Foundation
 import CoreGraphics
 #endif
 
-public protocol PermissionsCheckerProtocol: Sendable {
+public protocol PermissionChecking: Sendable {
     func status(for kind: PermissionKind) async -> PermissionStatus
 }
 
-public final class PermissionsChecker: PermissionsCheckerProtocol {
+public final class PermissionsChecker: PermissionChecking {
     public init() {}
 
     public func status(for kind: PermissionKind) async -> PermissionStatus {

--- a/TAELMacAgent/TAELMacAgent/Permissions/PermissionsChecker.swift
+++ b/TAELMacAgent/TAELMacAgent/Permissions/PermissionsChecker.swift
@@ -44,16 +44,17 @@ public final class PermissionsChecker: PermissionChecking {
         // `CGRequestScreenCaptureAccess` here — prompting is the gate
         // UI's job, not the checker's.
         //
+        // Apple's preflight returns `false` for BOTH "user denied" AND
+        // "never asked." We can't distinguish those two without a
+        // prompting call, so the honest mapping is `.notDetermined`.
+        // The gate UI surfaces the recovery path either way.
+        //
         // Note: in some macOS 14 minor versions, preflight can return
         // `true` even when ScreenCaptureKit later fails. PR 2 may add
         // an `SCShareableContent` sanity probe on top of preflight.
-        if CGPreflightScreenCaptureAccess() {
-            return .granted
-        } else {
-            return .denied
-        }
+        return CGPreflightScreenCaptureAccess() ? .granted : .notDetermined
         #else
-        return .denied
+        return .notDetermined
         #endif
     }
 }

--- a/TAELMacAgent/TAELMacAgent/Permissions/PermissionsGate.swift
+++ b/TAELMacAgent/TAELMacAgent/Permissions/PermissionsGate.swift
@@ -81,6 +81,14 @@ public final class PermissionsGate: Sendable {
         _ kind: PermissionKind,
         operation: (PermissionGrant) async throws -> T
     ) async throws -> T {
+        // Unimplemented kinds short-circuit before the checker. Showing
+        // a "grant Microphone" sheet for a kind we don't actually wire
+        // is misleading — the user can't recover. Throw a typed error
+        // so callers can branch on "not yet supported" vs "user denied".
+        guard kind.isImplemented else {
+            throw PermissionError.notImplemented(kind)
+        }
+
         let status = await checker.status(for: kind)
 
         guard status == .granted else {

--- a/TAELMacAgent/TAELMacAgent/Permissions/PermissionsGate.swift
+++ b/TAELMacAgent/TAELMacAgent/Permissions/PermissionsGate.swift
@@ -55,11 +55,11 @@ public struct NoopPermissionGateUI: PermissionGateUI {
 // MARK: - PermissionsGate
 
 public final class PermissionsGate: Sendable {
-    private let checker: PermissionsCheckerProtocol
+    private let checker: PermissionChecking
     private let permissionUI: PermissionGateUI
 
     public init(
-        checker: PermissionsCheckerProtocol = PermissionsChecker(),
+        checker: PermissionChecking = PermissionsChecker(),
         permissionUI: PermissionGateUI = NoopPermissionGateUI()
     ) {
         self.checker = checker

--- a/TAELMacAgent/TAELMacAgent/Permissions/PermissionsGate.swift
+++ b/TAELMacAgent/TAELMacAgent/Permissions/PermissionsGate.swift
@@ -32,22 +32,22 @@ public struct PermissionGrant: Sendable, Hashable {
     }
 }
 
-// MARK: - Permission gate UI
+// MARK: - Permission gate presenting
 
 /// Minimal hook the gate uses to surface a permission sheet to the
 /// user. The HUD layer provides the real implementation; tests inject
 /// a stub.
 ///
 /// The method is `async` (no actor isolation in the protocol itself)
-/// so non-UI conformers (`NoopPermissionGateUI`, test spies) don't
+/// so non-UI conformers (`NoopPermissionGatePresenter`, test spies) don't
 /// need to hop. UI conformers (e.g. `HUDPanelController`) hop to
 /// `@MainActor` explicitly inside the implementation.
-public protocol PermissionGateUI: Sendable {
+public protocol PermissionGatePresenting: Sendable {
     func showGate(for kind: PermissionKind) async
 }
 
-/// No-op UI used when the gate runs in a non-UI context (tests, CLI).
-public struct NoopPermissionGateUI: PermissionGateUI {
+/// No-op presenter used when the gate runs in a non-UI context (tests, CLI).
+public struct NoopPermissionGatePresenter: PermissionGatePresenting {
     public init() {}
     public func showGate(for kind: PermissionKind) async {}
 }
@@ -56,11 +56,11 @@ public struct NoopPermissionGateUI: PermissionGateUI {
 
 public final class PermissionsGate: Sendable {
     private let checker: PermissionChecking
-    private let permissionUI: PermissionGateUI
+    private let permissionUI: PermissionGatePresenting
 
     public init(
         checker: PermissionChecking = PermissionsChecker(),
-        permissionUI: PermissionGateUI = NoopPermissionGateUI()
+        permissionUI: PermissionGatePresenting = NoopPermissionGatePresenter()
     ) {
         self.checker = checker
         self.permissionUI = permissionUI

--- a/TAELMacAgent/TAELMacAgent/Permissions/PermissionsGate.swift
+++ b/TAELMacAgent/TAELMacAgent/Permissions/PermissionsGate.swift
@@ -24,7 +24,7 @@ import Foundation
 /// `PermissionsGate.withPermission` (in this file) can mint one.
 /// Protected services should accept a `PermissionGrant` and
 /// `precondition` on the kind they expect.
-public struct PermissionGrant: Sendable, Hashable {
+public struct PermissionGrant: Sendable, Equatable {
     public let kind: PermissionKind
 
     fileprivate init(kind: PermissionKind) {

--- a/TAELMacAgent/TAELMacAgentTests/LocalLogServiceTests.swift
+++ b/TAELMacAgent/TAELMacAgentTests/LocalLogServiceTests.swift
@@ -1,0 +1,56 @@
+//
+//  LocalLogServiceTests.swift
+//  TAELMacAgentTests
+//
+//  Verifies the ring buffer's overflow accounting. PR-1-cleanup
+//  addition: previously the service silently dropped entries past
+//  capacity with no signal.
+//
+
+import XCTest
+@testable import TAELMacAgent
+
+final class LocalLogServiceTests: XCTestCase {
+
+    private func makeLog(_ id: Int) -> InvocationLog {
+        InvocationLog(
+            id: UUID(),
+            hotkeyTimestamp: Date(timeIntervalSince1970: TimeInterval(id)),
+            gateOutcome: .granted
+        )
+    }
+
+    func test_recordingUpToCapacity_doesNotDrop() async {
+        let log = LocalLogService(capacity: 3)
+        for i in 0..<3 { await log.record(makeLog(i)) }
+        let dropped = await log.droppedCount
+        XCTAssertEqual(dropped, 0)
+        let recent = await log.recent(10)
+        XCTAssertEqual(recent.count, 3)
+    }
+
+    func test_recordingPastCapacity_dropsOldestAndCountsDrops() async {
+        let log = LocalLogService(capacity: 3)
+        for i in 0..<5 { await log.record(makeLog(i)) }
+        let dropped = await log.droppedCount
+        XCTAssertEqual(dropped, 2, "Two entries should have been dropped to keep capacity at 3.")
+        let recent = await log.recent(10)
+        XCTAssertEqual(recent.count, 3)
+        XCTAssertEqual(recent.map(\.hotkeyTimestamp.timeIntervalSince1970), [2, 3, 4])
+    }
+
+    func test_clear_resetsBufferButPreservesDroppedCount() async {
+        let log = LocalLogService(capacity: 2)
+        for i in 0..<5 { await log.record(makeLog(i)) }
+        let droppedBefore = await log.droppedCount
+        XCTAssertEqual(droppedBefore, 3)
+
+        await log.clear()
+        let recent = await log.recent(10)
+        XCTAssertTrue(recent.isEmpty)
+
+        // droppedCount intentionally survives clear() - it's a session metric, not a buffer count.
+        let droppedAfter = await log.droppedCount
+        XCTAssertEqual(droppedAfter, 3)
+    }
+}

--- a/TAELMacAgent/TAELMacAgentTests/PermissionsGateTests.swift
+++ b/TAELMacAgent/TAELMacAgentTests/PermissionsGateTests.swift
@@ -25,7 +25,7 @@ final class PermissionsGateTests: XCTestCase {
 
     // MARK: - Test doubles
 
-    private actor StubChecker: PermissionsCheckerProtocol {
+    private actor StubChecker: PermissionChecking {
         private var statuses: [PermissionKind: PermissionStatus]
         private(set) var queryCount: Int = 0
 

--- a/TAELMacAgent/TAELMacAgentTests/PermissionsGateTests.swift
+++ b/TAELMacAgent/TAELMacAgentTests/PermissionsGateTests.swift
@@ -144,4 +144,30 @@ final class PermissionsGateTests: XCTestCase {
         let shown = await ui.shownKinds
         XCTAssertTrue(shown.isEmpty, "Gate UI must not appear when the operation itself errors.")
     }
+
+    // MARK: - Unimplemented kind path
+
+    func test_withPermission_whenKindNotImplemented_throwsNotImplemented_andDoesNotShowGate() async {
+        let checker = StubChecker([:])  // empty: status() defaults to .notDetermined for any kind
+        let ui = SpyUI()
+        let gate = PermissionsGate(checker: checker, permissionUI: ui)
+
+        var operationRan = false
+
+        do {
+            _ = try await gate.withPermission(.microphone) { _ in
+                operationRan = true
+                return ()
+            }
+            XCTFail("Expected PermissionError.notImplemented to be thrown.")
+        } catch let error as PermissionError {
+            XCTAssertEqual(error, .notImplemented(.microphone))
+        } catch {
+            XCTFail("Unexpected error: \(error)")
+        }
+
+        XCTAssertFalse(operationRan, "Operation must not run for unimplemented kinds.")
+        let shown = await ui.shownKinds
+        XCTAssertTrue(shown.isEmpty, "Gate UI must not appear for unimplemented kinds — there is nothing the user can grant.")
+    }
 }

--- a/TAELMacAgent/TAELMacAgentTests/PermissionsGateTests.swift
+++ b/TAELMacAgent/TAELMacAgentTests/PermissionsGateTests.swift
@@ -6,7 +6,7 @@
 //
 //    1. `withPermission` does NOT invoke the operation when status is
 //       not `.granted`. It throws `PermissionError.missing` and routes
-//       through `PermissionGateUI.showGate`.
+//       through `PermissionGatePresenting.showGate`.
 //    2. `withPermission` invokes the operation EXACTLY once on
 //       `.granted`, and the closure receives a `PermissionGrant`
 //       whose `kind` matches the requested kind.
@@ -39,7 +39,7 @@ final class PermissionsGateTests: XCTestCase {
         }
     }
 
-    private actor SpyUI: PermissionGateUI {
+    private actor SpyUI: PermissionGatePresenting {
         private(set) var shownKinds: [PermissionKind] = []
 
         func showGate(for kind: PermissionKind) async {

--- a/docs/Architecture.md
+++ b/docs/Architecture.md
@@ -37,7 +37,7 @@ TAELMacAgent (menubar app, native macOS)
 │                                  missing permissions.
 ├── Capture
 │   ├── ScreenshotTarget.swift     displayContainingCursor / mainDisplay
-│   ├── CapturedScreenshot.swift   Value type wrapping CGImage + metadata
+│   ├── CapturedScreenshot.swift   Screenshot value type + metadata
 │   └── ScreenCaptureService.swift Stub. Real SCScreenshotManager call
 │                                  lands in PR 2, ticket 8. Requires a
 │                                  PermissionGrant of kind .screenRecording.

--- a/docs/ProtectedAPICallPolicy.md
+++ b/docs/ProtectedAPICallPolicy.md
@@ -37,7 +37,7 @@ struct PermissionGrant {
 final class PermissionsGate {
     func withPermission<T>(
         _ kind: PermissionKind,
-        operation: @escaping (PermissionGrant) async throws -> T
+        operation: (PermissionGrant) async throws -> T
     ) async throws -> T {
         let status = await checker.status(for: kind)
 
@@ -77,7 +77,7 @@ Protected services accept the grant and assert their expected kind:
 
 ```swift
 final class ScreenCaptureService {
-    func captureDisplayScreenshot(_ grant: PermissionGrant) async throws -> CGImage {
+    func captureDisplayScreenshot(_ grant: PermissionGrant) async throws -> CapturedScreenshot {
         precondition(grant.kind == .screenRecording)
         // ScreenCaptureKit call here.
     }

--- a/docs/Week1Heartbeat.md
+++ b/docs/Week1Heartbeat.md
@@ -66,7 +66,7 @@ struct PermissionGrant {
 final class PermissionsGate {
     func withPermission<T>(
         _ kind: PermissionKind,
-        operation: @escaping (PermissionGrant) async throws -> T
+        operation: (PermissionGrant) async throws -> T
     ) async throws -> T {
         let status = await checker.status(for: kind)
 
@@ -84,7 +84,7 @@ Protected services require the grant:
 
 ```swift
 final class ScreenCaptureService {
-    func captureDisplayScreenshot(_ grant: PermissionGrant) async throws -> CGImage {
+    func captureDisplayScreenshot(_ grant: PermissionGrant) async throws -> CapturedScreenshot {
         precondition(grant.kind == .screenRecording)
         // Week 1 implementation later.
     }

--- a/scripts/reset-tcc-dev.sh
+++ b/scripts/reset-tcc-dev.sh
@@ -68,22 +68,25 @@ for svc in "${SERVICES[@]}"; do
   # We capture combined output and the exit code so we can distinguish
   # the typical "no existing entry" case (suppress, keep going) from
   # real failures like an unknown service name (warn loudly).
-  output=$("${cmd[@]}" 2>&1)
-  rc=$?
-  if [[ $rc -eq 0 ]]; then
-    continue
-  fi
+  #
+  # Note: the `if !` form is REQUIRED. A bare `output=$(...); rc=$?` would
+  # let `set -e` abort the whole script on the first non-zero tccutil
+  # exit, making the rest of this block dead code. Bash flips `$?` after
+  # `!`, so PIPESTATUS preserves the original tccutil exit code.
+  if ! output=$("${cmd[@]}" 2>&1); then
+    rc=${PIPESTATUS[0]}
 
-  # tccutil's "nothing to reset" message looks like:
-  #   tccutil: Failed to reset all approval status for ai.tael.macagent
-  # That is benign — there was simply no entry yet. Anything else is
-  # surfaced and counted as a real failure so debugging is not hidden.
-  if [[ "$output" == *"Failed to reset"* ]]; then
-    echo "  (no existing entry for ${svc}, skipping)"
-  else
-    echo "  warning: tccutil exited ${rc} for ${svc}:" >&2
-    echo "  ${output}" >&2
-    had_real_failure=1
+    # tccutil's "nothing to reset" message looks like:
+    #   tccutil: Failed to reset all approval status for ai.tael.macagent
+    # That is benign — there was simply no entry yet. Anything else is
+    # surfaced and counted as a real failure so debugging is not hidden.
+    if [[ "$output" == *"Failed to reset"* ]]; then
+      echo "  (no existing entry for ${svc}, skipping)"
+    else
+      echo "  warning: tccutil exited ${rc} for ${svc}:" >&2
+      echo "  ${output}" >&2
+      had_real_failure=1
+    fi
   fi
 done
 


### PR DESCRIPTION
## Summary

Applies the 11 items from the pr-review-toolkit pass on PR #14 (see `docs/PR1_review.md` addendum). Two were criticals (reset-tcc-dev script bug, Cancel button no-op); the rest are typed-error refinements, naming, defensive logging, doc sync.

Plan: `docs/superpowers/plans/2026-04-25-pr1-cleanup.md`. Executed Codex-driven (gpt-5.5/high), maestro-reviewed per task, one commit per task.

## Items landed (10 commits)

| # | Commit | Description |
|---|---|---|
| 1 | `873f7b7` | `PermissionsCheckerProtocol` → `PermissionChecking` |
| 2 | `f7e473e` | `PermissionGateUI` → `PermissionGatePresenting` (and noop type) |
| 3 | `d1ab61d` | `PermissionsChecker` returns `.notDetermined` (not `.denied`) when preflight is false |
| 4 | `66e81d2` | `PermissionGrant: Hashable` → `Equatable` (caching is policy-banned) |
| 5 | `1d89b94` | `PermissionsGate.withPermission` short-circuits unimplemented kinds with `.notImplemented(kind)` (TDD, +1 test) |
| 6 | `e03a059` | `PermissionGateView` Cancel button now calls `HUDPanelController.tearDown()` |
| 7 | `7467f21` | `HUDPanelController` panel style mask back to v0.3 §23.11 spec |
| 8 | `471b977` | `LocalLogService` overflow now exposes `droppedCount` + `os_log(.fault)` (TDD, +3 tests, new test file) |
| 9 | `625cbb1` | `reset-tcc-dev.sh` no longer exits on first tccutil failure (`set -e` interaction) |
| 10 | `3122268` | Doc snippets in `ProtectedAPICallPolicy.md` + `Week1Heartbeat.md` + `Architecture.md` synced to current closure shape |

## Test plan

- [x] `xcodebuild ... clean test` passes locally — 8 tests, 0 failures (5 PermissionsGate + 3 LocalLogService)
- [x] `./scripts/reset-tcc-dev.sh --dry-run` iterates all 5 services and reaches "Done."
- [ ] Manual: hotkey path triggers gate sheet → Cancel button dismisses → tearDown called (PR 2 will wire the hotkey; until then, validate via menubar "Show HUD" → close → menubar "Show HUD" again works)

## Items intentionally NOT included (deferred)

- Codex's `PermissionKind` enum expansion (`.clipboardWrite`, `.subprocessAction`, `.keyboardMouseAutomation`) — not TCC-gated; don't belong in a permission enum
- `CapturedScreenshot` widening (defer to PR 2 with real capture)
- `InvocationLog` schema refactor to `phaseTimings` (defer to PR 2)
- `PermissionError.missing` carrying `PermissionStatus` for retry distinction (defer)
- `HUDPanelController.showGate` timeout wrapper (defer; small enough to land here if reviewers want)

## Sources

- `docs/PR1_review.md` (addendum section)
- `docs/superpowers/plans/2026-04-25-pr1-cleanup.md` (the executed plan)