### PR TITLE
feat: PR 2 — Week 1 heartbeat (hotkey → gate → capture → HUD)

### DIFF
--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -1,0 +1,6 @@
+{
+  "default": true,
+  "MD013": false,
+  "MD041": false,
+  "MD060": false
+}

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ heartbeat and the Week 1 implementation ticket order.
 
 ## Layout
 
-```
+```text
 tael-ai/
   README.md
   .gitignore

--- a/TAELMacAgent/TAELMacAgent.xcodeproj/project.pbxproj
+++ b/TAELMacAgent/TAELMacAgent.xcodeproj/project.pbxproj
@@ -3,404 +3,335 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 56;
+	objectVersion = 77;
 	objects = {
 
 /* Begin PBXBuildFile section */
-		2B00000000000000000000A1 /* TAELMacAgentApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A00000000000000000000A1 /* TAELMacAgentApp.swift */; };
-		2B00000000000000000000A2 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A00000000000000000000A2 /* AppDelegate.swift */; };
-		2B00000000000000000000A3 /* MenuBarController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A00000000000000000000A3 /* MenuBarController.swift */; };
-		2B00000000000000000000A4 /* HotkeyManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A00000000000000000000A4 /* HotkeyManager.swift */; };
-		2B00000000000000000000A5 /* PermissionKind.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A00000000000000000000A5 /* PermissionKind.swift */; };
-		2B00000000000000000000A6 /* PermissionStatus.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A00000000000000000000A6 /* PermissionStatus.swift */; };
-		2B00000000000000000000A7 /* PermissionError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A00000000000000000000A7 /* PermissionError.swift */; };
-		2B00000000000000000000A9 /* PermissionsChecker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A00000000000000000000A9 /* PermissionsChecker.swift */; };
-		2B00000000000000000000AA /* PermissionsGate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A00000000000000000000AA /* PermissionsGate.swift */; };
-		2B00000000000000000000AB /* HUDPanelController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A00000000000000000000AB /* HUDPanelController.swift */; };
-		2B00000000000000000000AC /* HUDView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A00000000000000000000AC /* HUDView.swift */; };
-		2B00000000000000000000AD /* PermissionGateView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A00000000000000000000AD /* PermissionGateView.swift */; };
-		2B00000000000000000000AE /* ScreenshotTarget.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A00000000000000000000AE /* ScreenshotTarget.swift */; };
-		2B00000000000000000000AF /* CapturedScreenshot.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A00000000000000000000AF /* CapturedScreenshot.swift */; };
-		2B00000000000000000000B0 /* ScreenCaptureService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A00000000000000000000B0 /* ScreenCaptureService.swift */; };
-		2B00000000000000000000B1 /* InvocationLog.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A00000000000000000000B1 /* InvocationLog.swift */; };
-		2B00000000000000000000B2 /* LocalLogService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A00000000000000000000B2 /* LocalLogService.swift */; };
-		2B00000000000000000000B3 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 1A00000000000000000000B3 /* Assets.xcassets */; };
-		2B00000000000000000000C1 /* PermissionsGateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A00000000000000000000C1 /* PermissionsGateTests.swift */; };
-		2B00000000000000000000C2 /* LocalLogServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A00000000000000000000C2 /* LocalLogServiceTests.swift */; };
+		0330637AAF26CC3C25DCD10F /* CapturedScreenshot.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6DEC30773055C5F4AE735610 /* CapturedScreenshot.swift */; };
+		033A279961698D88188A33AD /* MenuBarController.swift in Sources */ = {isa = PBXBuildFile; fileRef = EBD624AFDCE20EF4B613B9A4 /* MenuBarController.swift */; };
+		0B0660E9860988CD91DA599E /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB704571A9597F9AF9313D65 /* AppDelegate.swift */; };
+		1EFB0EA699153ADC53EA4286 /* LocalLogServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C654DA20715C3C6F29B9E6F4 /* LocalLogServiceTests.swift */; };
+		34F3D8094B35A969BEFEFE4A /* LocalLogService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F5C315999DFCC84BE675BE2 /* LocalLogService.swift */; };
+		3F34E0D14D96EB8D52BE71A0 /* TAELMacAgentApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 69DDCCAE89FD5A160E17AE49 /* TAELMacAgentApp.swift */; };
+		5AD70596B8B5BEBD936F2F60 /* PermissionsGateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14306A2EBDA587DA5C4E6182 /* PermissionsGateTests.swift */; };
+		6AB4701304241B41166818BB /* HotkeyManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 917682B8FDBFE7C755263E19 /* HotkeyManager.swift */; };
+		6BA0CBE1B80E6592A9C6983A /* PermissionGateView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 422D881643EB42E6E96F6073 /* PermissionGateView.swift */; };
+		7A08515211A39DD11A6E370B /* PermissionsGate.swift in Sources */ = {isa = PBXBuildFile; fileRef = F46F76B62679E79E964F4EAE /* PermissionsGate.swift */; };
+		8AC8665020F765D063A96609 /* HUDPanelController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9363E4D91044162835D20FAA /* HUDPanelController.swift */; };
+		C3C9015E4F181F2FC2A056BB /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 3900941745D06B0194400E8E /* Assets.xcassets */; };
+		CACD72769410271CF6577CC0 /* InvocationLog.swift in Sources */ = {isa = PBXBuildFile; fileRef = A74AE945B8920595491B2B29 /* InvocationLog.swift */; };
+		CF17A6BDF21FD1B3F8690D13 /* PermissionError.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED47D03840F40871272ED13C /* PermissionError.swift */; };
+		D4D7892F3C39042079C92DEC /* PermissionsChecker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D36CFA939327054CE038538 /* PermissionsChecker.swift */; };
+		E22538B7BAFDD6DE67CD39A6 /* PermissionKind.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E3601A9D97DFCC20CB1B190 /* PermissionKind.swift */; };
+		EE4E5F822C40DF6233CBDD2A /* ScreenshotTarget.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6C80394C10DB95ACE8B23410 /* ScreenshotTarget.swift */; };
+		F213518191A0D0FBED62E67B /* ScreenCaptureService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 198A12FCDFC021700C887DC3 /* ScreenCaptureService.swift */; };
+		F8A8B61233E0F29CD0725388 /* HUDView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1469160F2705F009163C15E0 /* HUDView.swift */; };
+		FC2769F84CA630E5B0E73F55 /* PermissionStatus.swift in Sources */ = {isa = PBXBuildFile; fileRef = 639F88F50828EB01F823718B /* PermissionStatus.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
-		9A00000000000000000000A1 /* PBXContainerItemProxy */ = {
+		A47BAD4074508EE5400D1CDF /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
-			containerPortal = 8A00000000000000000000A1 /* Project object */;
+			containerPortal = 5D9768FD172621FBD47CDD94 /* Project object */;
 			proxyType = 1;
-			remoteGlobalIDString = 7A00000000000000000000A1;
+			remoteGlobalIDString = 19B5206FF51EAAA5D9DD33BD;
 			remoteInfo = TAELMacAgent;
 		};
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
-		1A00000000000000000000A1 /* TAELMacAgentApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TAELMacAgentApp.swift; sourceTree = "<group>"; };
-		1A00000000000000000000A2 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
-		1A00000000000000000000A3 /* MenuBarController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MenuBarController.swift; sourceTree = "<group>"; };
-		1A00000000000000000000A4 /* HotkeyManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HotkeyManager.swift; sourceTree = "<group>"; };
-		1A00000000000000000000A5 /* PermissionKind.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PermissionKind.swift; sourceTree = "<group>"; };
-		1A00000000000000000000A6 /* PermissionStatus.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PermissionStatus.swift; sourceTree = "<group>"; };
-		1A00000000000000000000A7 /* PermissionError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PermissionError.swift; sourceTree = "<group>"; };
-		1A00000000000000000000A9 /* PermissionsChecker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PermissionsChecker.swift; sourceTree = "<group>"; };
-		1A00000000000000000000AA /* PermissionsGate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PermissionsGate.swift; sourceTree = "<group>"; };
-		1A00000000000000000000AB /* HUDPanelController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HUDPanelController.swift; sourceTree = "<group>"; };
-		1A00000000000000000000AC /* HUDView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HUDView.swift; sourceTree = "<group>"; };
-		1A00000000000000000000AD /* PermissionGateView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PermissionGateView.swift; sourceTree = "<group>"; };
-		1A00000000000000000000AE /* ScreenshotTarget.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScreenshotTarget.swift; sourceTree = "<group>"; };
-		1A00000000000000000000AF /* CapturedScreenshot.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CapturedScreenshot.swift; sourceTree = "<group>"; };
-		1A00000000000000000000B0 /* ScreenCaptureService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScreenCaptureService.swift; sourceTree = "<group>"; };
-		1A00000000000000000000B1 /* InvocationLog.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InvocationLog.swift; sourceTree = "<group>"; };
-		1A00000000000000000000B2 /* LocalLogService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalLogService.swift; sourceTree = "<group>"; };
-		1A00000000000000000000B3 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
-		1A00000000000000000000B4 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
-		1A00000000000000000000B5 /* TAELMacAgent.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = TAELMacAgent.entitlements; sourceTree = "<group>"; };
-		1A00000000000000000000C1 /* PermissionsGateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PermissionsGateTests.swift; sourceTree = "<group>"; };
-		1A00000000000000000000C2 /* LocalLogServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalLogServiceTests.swift; sourceTree = "<group>"; };
-		1A00000000000000000000F1 /* TAELMacAgent.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = TAELMacAgent.app; sourceTree = BUILT_PRODUCTS_DIR; };
-		1A00000000000000000000F2 /* TAELMacAgentTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = TAELMacAgentTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		09182C33476D9D80D775700D /* TAELMacAgent.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = TAELMacAgent.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		14306A2EBDA587DA5C4E6182 /* PermissionsGateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PermissionsGateTests.swift; sourceTree = "<group>"; };
+		1469160F2705F009163C15E0 /* HUDView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HUDView.swift; sourceTree = "<group>"; };
+		198A12FCDFC021700C887DC3 /* ScreenCaptureService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScreenCaptureService.swift; sourceTree = "<group>"; };
+		1D36CFA939327054CE038538 /* PermissionsChecker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PermissionsChecker.swift; sourceTree = "<group>"; };
+		3900941745D06B0194400E8E /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
+		422D881643EB42E6E96F6073 /* PermissionGateView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PermissionGateView.swift; sourceTree = "<group>"; };
+		639F88F50828EB01F823718B /* PermissionStatus.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PermissionStatus.swift; sourceTree = "<group>"; };
+		69DDCCAE89FD5A160E17AE49 /* TAELMacAgentApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TAELMacAgentApp.swift; sourceTree = "<group>"; };
+		6C80394C10DB95ACE8B23410 /* ScreenshotTarget.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScreenshotTarget.swift; sourceTree = "<group>"; };
+		6DEC30773055C5F4AE735610 /* CapturedScreenshot.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CapturedScreenshot.swift; sourceTree = "<group>"; };
+		6E3601A9D97DFCC20CB1B190 /* PermissionKind.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PermissionKind.swift; sourceTree = "<group>"; };
+		6F5C315999DFCC84BE675BE2 /* LocalLogService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalLogService.swift; sourceTree = "<group>"; };
+		917682B8FDBFE7C755263E19 /* HotkeyManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HotkeyManager.swift; sourceTree = "<group>"; };
+		9363E4D91044162835D20FAA /* HUDPanelController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HUDPanelController.swift; sourceTree = "<group>"; };
+		9A76044EF0F9B7BE7C3F5C00 /* TAELMacAgentTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = TAELMacAgentTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		A74AE945B8920595491B2B29 /* InvocationLog.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InvocationLog.swift; sourceTree = "<group>"; };
+		AB704571A9597F9AF9313D65 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
+		C654DA20715C3C6F29B9E6F4 /* LocalLogServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalLogServiceTests.swift; sourceTree = "<group>"; };
+		EBD624AFDCE20EF4B613B9A4 /* MenuBarController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MenuBarController.swift; sourceTree = "<group>"; };
+		ED47D03840F40871272ED13C /* PermissionError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PermissionError.swift; sourceTree = "<group>"; };
+		F46F76B62679E79E964F4EAE /* PermissionsGate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PermissionsGate.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
-/* Begin PBXFrameworksBuildPhase section */
-		4A00000000000000000000A2 /* Frameworks */ = {
-			isa = PBXFrameworksBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		4A00000000000000000000C2 /* Frameworks */ = {
-			isa = PBXFrameworksBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-/* End PBXFrameworksBuildPhase section */
-
 /* Begin PBXGroup section */
-		3A00000000000000000000A1 /* / */ = {
+		1D955BDFBFFB1E992ABC4E95 /* TAELMacAgentTests */ = {
 			isa = PBXGroup;
 			children = (
-				3A00000000000000000000A2 /* TAELMacAgent */,
-				3A00000000000000000000C0 /* TAELMacAgentTests */,
-				3A00000000000000000000F0 /* Products */,
-			);
-			sourceTree = "<group>";
-		};
-		3A00000000000000000000A2 /* TAELMacAgent */ = {
-			isa = PBXGroup;
-			children = (
-				3A00000000000000000000A3 /* App */,
-				3A00000000000000000000A4 /* Hotkey */,
-				3A00000000000000000000A5 /* Permissions */,
-				3A00000000000000000000A6 /* HUD */,
-				3A00000000000000000000A7 /* Capture */,
-				3A00000000000000000000A8 /* Logging */,
-				3A00000000000000000000A9 /* Resources */,
-			);
-			path = TAELMacAgent;
-			sourceTree = "<group>";
-		};
-		3A00000000000000000000A3 /* App */ = {
-			isa = PBXGroup;
-			children = (
-				1A00000000000000000000A1 /* TAELMacAgentApp.swift */,
-				1A00000000000000000000A2 /* AppDelegate.swift */,
-				1A00000000000000000000A3 /* MenuBarController.swift */,
-			);
-			path = App;
-			sourceTree = "<group>";
-		};
-		3A00000000000000000000A4 /* Hotkey */ = {
-			isa = PBXGroup;
-			children = (
-				1A00000000000000000000A4 /* HotkeyManager.swift */,
-			);
-			path = Hotkey;
-			sourceTree = "<group>";
-		};
-		3A00000000000000000000A5 /* Permissions */ = {
-			isa = PBXGroup;
-			children = (
-				1A00000000000000000000A5 /* PermissionKind.swift */,
-				1A00000000000000000000A6 /* PermissionStatus.swift */,
-				1A00000000000000000000A7 /* PermissionError.swift */,
-				1A00000000000000000000A9 /* PermissionsChecker.swift */,
-				1A00000000000000000000AA /* PermissionsGate.swift */,
-			);
-			path = Permissions;
-			sourceTree = "<group>";
-		};
-		3A00000000000000000000A6 /* HUD */ = {
-			isa = PBXGroup;
-			children = (
-				1A00000000000000000000AB /* HUDPanelController.swift */,
-				1A00000000000000000000AC /* HUDView.swift */,
-				1A00000000000000000000AD /* PermissionGateView.swift */,
-			);
-			path = HUD;
-			sourceTree = "<group>";
-		};
-		3A00000000000000000000A7 /* Capture */ = {
-			isa = PBXGroup;
-			children = (
-				1A00000000000000000000AE /* ScreenshotTarget.swift */,
-				1A00000000000000000000AF /* CapturedScreenshot.swift */,
-				1A00000000000000000000B0 /* ScreenCaptureService.swift */,
-			);
-			path = Capture;
-			sourceTree = "<group>";
-		};
-		3A00000000000000000000A8 /* Logging */ = {
-			isa = PBXGroup;
-			children = (
-				1A00000000000000000000B1 /* InvocationLog.swift */,
-				1A00000000000000000000B2 /* LocalLogService.swift */,
-			);
-			path = Logging;
-			sourceTree = "<group>";
-		};
-		3A00000000000000000000A9 /* Resources */ = {
-			isa = PBXGroup;
-			children = (
-				1A00000000000000000000B3 /* Assets.xcassets */,
-				1A00000000000000000000B4 /* Info.plist */,
-				1A00000000000000000000B5 /* TAELMacAgent.entitlements */,
-			);
-			path = Resources;
-			sourceTree = "<group>";
-		};
-		3A00000000000000000000C0 /* TAELMacAgentTests */ = {
-			isa = PBXGroup;
-			children = (
-				1A00000000000000000000C1 /* PermissionsGateTests.swift */,
-				1A00000000000000000000C2 /* LocalLogServiceTests.swift */,
+				C654DA20715C3C6F29B9E6F4 /* LocalLogServiceTests.swift */,
+				14306A2EBDA587DA5C4E6182 /* PermissionsGateTests.swift */,
 			);
 			path = TAELMacAgentTests;
 			sourceTree = "<group>";
 		};
-		3A00000000000000000000F0 /* Products */ = {
+		25F2B0347D98A8AADDF902E0 /* HUD */ = {
 			isa = PBXGroup;
 			children = (
-				1A00000000000000000000F1 /* TAELMacAgent.app */,
-				1A00000000000000000000F2 /* TAELMacAgentTests.xctest */,
+				9363E4D91044162835D20FAA /* HUDPanelController.swift */,
+				1469160F2705F009163C15E0 /* HUDView.swift */,
+				422D881643EB42E6E96F6073 /* PermissionGateView.swift */,
+			);
+			path = HUD;
+			sourceTree = "<group>";
+		};
+		79CF0DC83C35B3DE92D7BB44 = {
+			isa = PBXGroup;
+			children = (
+				97DC61CEC80B8232B91B4BA6 /* TAELMacAgent */,
+				1D955BDFBFFB1E992ABC4E95 /* TAELMacAgentTests */,
+				C965C9197045CDCA448A4FB4 /* Products */,
+			);
+			sourceTree = "<group>";
+		};
+		8CB452CA408F114826DD96AE /* App */ = {
+			isa = PBXGroup;
+			children = (
+				AB704571A9597F9AF9313D65 /* AppDelegate.swift */,
+				EBD624AFDCE20EF4B613B9A4 /* MenuBarController.swift */,
+				69DDCCAE89FD5A160E17AE49 /* TAELMacAgentApp.swift */,
+			);
+			path = App;
+			sourceTree = "<group>";
+		};
+		97DC61CEC80B8232B91B4BA6 /* TAELMacAgent */ = {
+			isa = PBXGroup;
+			children = (
+				8CB452CA408F114826DD96AE /* App */,
+				99C93CFB96CF8F9301DF4757 /* Capture */,
+				CBA9F060F0EAA0AC77F03091 /* Hotkey */,
+				25F2B0347D98A8AADDF902E0 /* HUD */,
+				C2646529B7BB101A453D1AD4 /* Logging */,
+				B93A3ED5294E22762F9486DE /* Permissions */,
+				E1AEF778526EC40069A64DB6 /* Resources */,
+			);
+			path = TAELMacAgent;
+			sourceTree = "<group>";
+		};
+		99C93CFB96CF8F9301DF4757 /* Capture */ = {
+			isa = PBXGroup;
+			children = (
+				6DEC30773055C5F4AE735610 /* CapturedScreenshot.swift */,
+				198A12FCDFC021700C887DC3 /* ScreenCaptureService.swift */,
+				6C80394C10DB95ACE8B23410 /* ScreenshotTarget.swift */,
+			);
+			path = Capture;
+			sourceTree = "<group>";
+		};
+		B93A3ED5294E22762F9486DE /* Permissions */ = {
+			isa = PBXGroup;
+			children = (
+				ED47D03840F40871272ED13C /* PermissionError.swift */,
+				6E3601A9D97DFCC20CB1B190 /* PermissionKind.swift */,
+				1D36CFA939327054CE038538 /* PermissionsChecker.swift */,
+				F46F76B62679E79E964F4EAE /* PermissionsGate.swift */,
+				639F88F50828EB01F823718B /* PermissionStatus.swift */,
+			);
+			path = Permissions;
+			sourceTree = "<group>";
+		};
+		C2646529B7BB101A453D1AD4 /* Logging */ = {
+			isa = PBXGroup;
+			children = (
+				A74AE945B8920595491B2B29 /* InvocationLog.swift */,
+				6F5C315999DFCC84BE675BE2 /* LocalLogService.swift */,
+			);
+			path = Logging;
+			sourceTree = "<group>";
+		};
+		C965C9197045CDCA448A4FB4 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				09182C33476D9D80D775700D /* TAELMacAgent.app */,
+				9A76044EF0F9B7BE7C3F5C00 /* TAELMacAgentTests.xctest */,
 			);
 			name = Products;
+			sourceTree = "<group>";
+		};
+		CBA9F060F0EAA0AC77F03091 /* Hotkey */ = {
+			isa = PBXGroup;
+			children = (
+				917682B8FDBFE7C755263E19 /* HotkeyManager.swift */,
+			);
+			path = Hotkey;
+			sourceTree = "<group>";
+		};
+		E1AEF778526EC40069A64DB6 /* Resources */ = {
+			isa = PBXGroup;
+			children = (
+				3900941745D06B0194400E8E /* Assets.xcassets */,
+			);
+			path = Resources;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
-		7A00000000000000000000A1 /* TAELMacAgent */ = {
+		19B5206FF51EAAA5D9DD33BD /* TAELMacAgent */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = 6A00000000000000000000A2 /* Build configuration list for PBXNativeTarget "TAELMacAgent" */;
+			buildConfigurationList = 117EFF58E2C38224B38B8B12 /* Build configuration list for PBXNativeTarget "TAELMacAgent" */;
 			buildPhases = (
-				4A00000000000000000000A1 /* Sources */,
-				4A00000000000000000000A2 /* Frameworks */,
-				4A00000000000000000000A3 /* Resources */,
+				A804338716259752E11524FD /* Sources */,
+				D18C72E98AF490A89259C1D9 /* Resources */,
 			);
 			buildRules = (
 			);
 			dependencies = (
 			);
 			name = TAELMacAgent;
+			packageProductDependencies = (
+			);
 			productName = TAELMacAgent;
-			productReference = 1A00000000000000000000F1 /* TAELMacAgent.app */;
+			productReference = 09182C33476D9D80D775700D /* TAELMacAgent.app */;
 			productType = "com.apple.product-type.application";
 		};
-		7A00000000000000000000C1 /* TAELMacAgentTests */ = {
+		7BBF771A19B870A8BDB655E7 /* TAELMacAgentTests */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = 6A00000000000000000000C2 /* Build configuration list for PBXNativeTarget "TAELMacAgentTests" */;
+			buildConfigurationList = 76317FEDB9101E1DC4C2585C /* Build configuration list for PBXNativeTarget "TAELMacAgentTests" */;
 			buildPhases = (
-				4A00000000000000000000C1 /* Sources */,
-				4A00000000000000000000C2 /* Frameworks */,
-				4A00000000000000000000C3 /* Resources */,
+				BF41B36D68ED461F93AE9C02 /* Sources */,
 			);
 			buildRules = (
 			);
 			dependencies = (
-				9A00000000000000000000B1 /* PBXTargetDependency */,
+				6C4ED6EB1C9863C9CCFC4C51 /* PBXTargetDependency */,
 			);
 			name = TAELMacAgentTests;
+			packageProductDependencies = (
+			);
 			productName = TAELMacAgentTests;
-			productReference = 1A00000000000000000000F2 /* TAELMacAgentTests.xctest */;
+			productReference = 9A76044EF0F9B7BE7C3F5C00 /* TAELMacAgentTests.xctest */;
 			productType = "com.apple.product-type.bundle.unit-test";
 		};
 /* End PBXNativeTarget section */
 
 /* Begin PBXProject section */
-		8A00000000000000000000A1 /* Project object */ = {
+		5D9768FD172621FBD47CDD94 /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
 				BuildIndependentTargetsInParallel = YES;
-				LastSwiftUpdateCheck = 1530;
-				LastUpgradeCheck = 1530;
+				LastUpgradeCheck = 1430;
 				TargetAttributes = {
-					7A00000000000000000000A1 = {
-						CreatedOnToolsVersion = 15.3;
+					19B5206FF51EAAA5D9DD33BD = {
+						DevelopmentTeam = "";
+						ProvisioningStyle = Automatic;
 					};
-					7A00000000000000000000C1 = {
-						CreatedOnToolsVersion = 15.3;
-						TestTargetID = 7A00000000000000000000A1;
+					7BBF771A19B870A8BDB655E7 = {
+						DevelopmentTeam = "";
 					};
 				};
 			};
-			buildConfigurationList = 6A00000000000000000000A1 /* Build configuration list for PBXProject "TAELMacAgent" */;
-			compatibilityVersion = "Xcode 14.0";
+			buildConfigurationList = 9EE8029557141161462E8753 /* Build configuration list for PBXProject "TAELMacAgent" */;
 			developmentRegion = en;
 			hasScannedForEncodings = 0;
 			knownRegions = (
-				en,
 				Base,
+				en,
 			);
-			mainGroup = 3A00000000000000000000A1;
-			productRefGroup = 3A00000000000000000000F0 /* Products */;
+			mainGroup = 79CF0DC83C35B3DE92D7BB44;
+			minimizedProjectReferenceProxies = 1;
+			preferredProjectObjectVersion = 77;
+			productRefGroup = C965C9197045CDCA448A4FB4 /* Products */;
 			projectDirPath = "";
 			projectRoot = "";
 			targets = (
-				7A00000000000000000000A1 /* TAELMacAgent */,
-				7A00000000000000000000C1 /* TAELMacAgentTests */,
+				19B5206FF51EAAA5D9DD33BD /* TAELMacAgent */,
+				7BBF771A19B870A8BDB655E7 /* TAELMacAgentTests */,
 			);
 		};
 /* End PBXProject section */
 
 /* Begin PBXResourcesBuildPhase section */
-		4A00000000000000000000A3 /* Resources */ = {
+		D18C72E98AF490A89259C1D9 /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				2B00000000000000000000B3 /* Assets.xcassets in Resources */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		4A00000000000000000000C3 /* Resources */ = {
-			isa = PBXResourcesBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
+				C3C9015E4F181F2FC2A056BB /* Assets.xcassets in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
-		4A00000000000000000000A1 /* Sources */ = {
+		A804338716259752E11524FD /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				2B00000000000000000000A1 /* TAELMacAgentApp.swift in Sources */,
-				2B00000000000000000000A2 /* AppDelegate.swift in Sources */,
-				2B00000000000000000000A3 /* MenuBarController.swift in Sources */,
-				2B00000000000000000000A4 /* HotkeyManager.swift in Sources */,
-				2B00000000000000000000A5 /* PermissionKind.swift in Sources */,
-				2B00000000000000000000A6 /* PermissionStatus.swift in Sources */,
-				2B00000000000000000000A7 /* PermissionError.swift in Sources */,
-				2B00000000000000000000A9 /* PermissionsChecker.swift in Sources */,
-				2B00000000000000000000AA /* PermissionsGate.swift in Sources */,
-				2B00000000000000000000AB /* HUDPanelController.swift in Sources */,
-				2B00000000000000000000AC /* HUDView.swift in Sources */,
-				2B00000000000000000000AD /* PermissionGateView.swift in Sources */,
-				2B00000000000000000000AE /* ScreenshotTarget.swift in Sources */,
-				2B00000000000000000000AF /* CapturedScreenshot.swift in Sources */,
-				2B00000000000000000000B0 /* ScreenCaptureService.swift in Sources */,
-				2B00000000000000000000B1 /* InvocationLog.swift in Sources */,
-				2B00000000000000000000B2 /* LocalLogService.swift in Sources */,
+				0B0660E9860988CD91DA599E /* AppDelegate.swift in Sources */,
+				0330637AAF26CC3C25DCD10F /* CapturedScreenshot.swift in Sources */,
+				8AC8665020F765D063A96609 /* HUDPanelController.swift in Sources */,
+				F8A8B61233E0F29CD0725388 /* HUDView.swift in Sources */,
+				6AB4701304241B41166818BB /* HotkeyManager.swift in Sources */,
+				CACD72769410271CF6577CC0 /* InvocationLog.swift in Sources */,
+				34F3D8094B35A969BEFEFE4A /* LocalLogService.swift in Sources */,
+				033A279961698D88188A33AD /* MenuBarController.swift in Sources */,
+				CF17A6BDF21FD1B3F8690D13 /* PermissionError.swift in Sources */,
+				6BA0CBE1B80E6592A9C6983A /* PermissionGateView.swift in Sources */,
+				E22538B7BAFDD6DE67CD39A6 /* PermissionKind.swift in Sources */,
+				FC2769F84CA630E5B0E73F55 /* PermissionStatus.swift in Sources */,
+				D4D7892F3C39042079C92DEC /* PermissionsChecker.swift in Sources */,
+				7A08515211A39DD11A6E370B /* PermissionsGate.swift in Sources */,
+				F213518191A0D0FBED62E67B /* ScreenCaptureService.swift in Sources */,
+				EE4E5F822C40DF6233CBDD2A /* ScreenshotTarget.swift in Sources */,
+				3F34E0D14D96EB8D52BE71A0 /* TAELMacAgentApp.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		4A00000000000000000000C1 /* Sources */ = {
+		BF41B36D68ED461F93AE9C02 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				2B00000000000000000000C1 /* PermissionsGateTests.swift in Sources */,
-				2B00000000000000000000C2 /* LocalLogServiceTests.swift in Sources */,
+				1EFB0EA699153ADC53EA4286 /* LocalLogServiceTests.swift in Sources */,
+				5AD70596B8B5BEBD936F2F60 /* PermissionsGateTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
-		9A00000000000000000000B1 /* PBXTargetDependency */ = {
+		6C4ED6EB1C9863C9CCFC4C51 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
-			target = 7A00000000000000000000A1 /* TAELMacAgent */;
-			targetProxy = 9A00000000000000000000A1 /* PBXContainerItemProxy */;
+			target = 19B5206FF51EAAA5D9DD33BD /* TAELMacAgent */;
+			targetProxy = A47BAD4074508EE5400D1CDF /* PBXContainerItemProxy */;
 		};
 /* End PBXTargetDependency section */
 
 /* Begin XCBuildConfiguration section */
-		5A00000000000000000000A1 /* Debug */ = {
+		0E16266BE06C30C4664F152D /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				ALWAYS_SEARCH_USER_PATHS = NO;
-				CLANG_ANALYZER_NONNULL = YES;
-				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
-				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
-				CLANG_ENABLE_MODULES = YES;
-				CLANG_ENABLE_OBJC_ARC = YES;
-				CLANG_ENABLE_OBJC_WEAK = YES;
-				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
-				CLANG_WARN_BOOL_CONVERSION = YES;
-				CLANG_WARN_COMMA = YES;
-				CLANG_WARN_CONSTANT_CONVERSION = YES;
-				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
-				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
-				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
-				CLANG_WARN_EMPTY_BODY = YES;
-				CLANG_WARN_ENUM_CONVERSION = YES;
-				CLANG_WARN_INFINITE_RECURSION = YES;
-				CLANG_WARN_INT_CONVERSION = YES;
-				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
-				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
-				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
-				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
-				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
-				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
-				CLANG_WARN_STRICT_PROTOTYPES = YES;
-				CLANG_WARN_SUSPICIOUS_MOVE = YES;
-				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
-				CLANG_WARN_UNREACHABLE_CODE = YES;
-				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
-				COPY_PHASE_STRIP = NO;
-				DEBUG_INFORMATION_FORMAT = dwarf;
-				ENABLE_STRICT_OBJC_MSGSEND = YES;
-				ENABLE_TESTABILITY = YES;
-				GCC_C_LANGUAGE_STANDARD = gnu17;
-				GCC_DYNAMIC_NO_PIC = NO;
-				GCC_NO_COMMON_BLOCKS = YES;
-				GCC_OPTIMIZATION_LEVEL = 0;
-				GCC_PREPROCESSOR_DEFINITIONS = (
-					"DEBUG=1",
-					"$(inherited)",
-				);
-				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
-				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
-				GCC_WARN_UNDECLARED_SELECTOR = YES;
-				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
-				GCC_WARN_UNUSED_FUNCTION = YES;
-				GCC_WARN_UNUSED_VARIABLE = YES;
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CODE_SIGN_ENTITLEMENTS = TAELMacAgent/Resources/TAELMacAgent.entitlements;
+				CODE_SIGN_STYLE = Automatic;
+				COMBINE_HIDPI_IMAGES = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = YES;
+				GENERATE_INFOPLIST_FILE = NO;
+				INFOPLIST_FILE = TAELMacAgent/Resources/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 14.0;
-				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
-				MTL_FAST_MATH = YES;
-				ONLY_ACTIVE_ARCH = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = ai.tael.macagent;
+				PRODUCT_NAME = TAELMacAgent;
 				SDKROOT = macosx;
-				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
-				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				SWIFT_STRICT_CONCURRENCY = complete;
 			};
-			name = Debug;
+			name = Release;
 		};
-		5A00000000000000000000A2 /* Release */ = {
+		2F433CDCD1DA99C432DADA1A /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				CLANG_ANALYZER_NONNULL = YES;
 				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
-				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_CXX_LIBRARY = "libc++";
 				CLANG_ENABLE_MODULES = YES;
 				CLANG_ENABLE_OBJC_ARC = YES;
 				CLANG_ENABLE_OBJC_WEAK = YES;
@@ -428,9 +359,11 @@
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				COPY_PHASE_STRIP = NO;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				DEVELOPMENT_TEAM = "";
+				ENABLE_HARDENED_RUNTIME = YES;
 				ENABLE_NS_ASSERTIONS = NO;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
-				GCC_C_LANGUAGE_STANDARD = gnu17;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
 				GCC_NO_COMMON_BLOCKS = YES;
 				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
 				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
@@ -441,96 +374,131 @@
 				MACOSX_DEPLOYMENT_TARGET = 14.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				MTL_FAST_MATH = YES;
+				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = macosx;
 				SWIFT_COMPILATION_MODE = wholemodule;
+				SWIFT_OPTIMIZATION_LEVEL = "-O";
 				SWIFT_STRICT_CONCURRENCY = complete;
-			};
-			name = Release;
-		};
-		5A00000000000000000000A3 /* Debug */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
-				CODE_SIGN_ENTITLEMENTS = TAELMacAgent/Resources/TAELMacAgent.entitlements;
-				CODE_SIGN_STYLE = Automatic;
-				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = "";
-				ENABLE_HARDENED_RUNTIME = YES;
-				ENABLE_PREVIEWS = YES;
-				GENERATE_INFOPLIST_FILE = NO;
-				INFOPLIST_FILE = TAELMacAgent/Resources/Info.plist;
-				LD_RUNPATH_SEARCH_PATHS = (
-					"$(inherited)",
-					"@executable_path/../Frameworks",
-				);
-				MACOSX_DEPLOYMENT_TARGET = 14.0;
-				MARKETING_VERSION = 0.1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = ai.tael.macagent;
-				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_EMIT_LOC_STRINGS = YES;
-				SWIFT_VERSION = 5.0;
-			};
-			name = Debug;
-		};
-		5A00000000000000000000A4 /* Release */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
-				CODE_SIGN_ENTITLEMENTS = TAELMacAgent/Resources/TAELMacAgent.entitlements;
-				CODE_SIGN_STYLE = Automatic;
-				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = "";
-				ENABLE_HARDENED_RUNTIME = YES;
-				ENABLE_PREVIEWS = YES;
-				GENERATE_INFOPLIST_FILE = NO;
-				INFOPLIST_FILE = TAELMacAgent/Resources/Info.plist;
-				LD_RUNPATH_SEARCH_PATHS = (
-					"$(inherited)",
-					"@executable_path/../Frameworks",
-				);
-				MACOSX_DEPLOYMENT_TARGET = 14.0;
-				MARKETING_VERSION = 0.1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = ai.tael.macagent;
-				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_VERSION = 5.0;
 			};
 			name = Release;
 		};
-		5A00000000000000000000C1 /* Debug */ = {
+		30CD9C0A39029D9324927179 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
-				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = "";
-				GENERATE_INFOPLIST_FILE = YES;
+				COMBINE_HIDPI_IMAGES = YES;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/../Frameworks",
+					"@loader_path/../Frameworks",
+				);
 				MACOSX_DEPLOYMENT_TARGET = 14.0;
-				MARKETING_VERSION = 1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = ai.tael.macagent.tests;
-				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_EMIT_LOC_STRINGS = NO;
-				SWIFT_VERSION = 5.0;
+				PRODUCT_NAME = TAELMacAgentTests;
+				SDKROOT = macosx;
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/TAELMacAgent.app/Contents/MacOS/TAELMacAgent";
 			};
 			name = Debug;
 		};
-		5A00000000000000000000C2 /* Release */ = {
+		3D3753EFBE210BA568497A6B /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				DEVELOPMENT_TEAM = "";
+				ENABLE_HARDENED_RUNTIME = YES;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"$(inherited)",
+					"DEBUG=1",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				MACOSX_DEPLOYMENT_TARGET = 14.0;
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = macosx;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_STRICT_CONCURRENCY = complete;
+				SWIFT_VERSION = 5.0;
+			};
+			name = Debug;
+		};
+		97E6B9E4270F081105DFF762 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CODE_SIGN_ENTITLEMENTS = TAELMacAgent/Resources/TAELMacAgent.entitlements;
+				CODE_SIGN_STYLE = Automatic;
+				COMBINE_HIDPI_IMAGES = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = YES;
+				GENERATE_INFOPLIST_FILE = NO;
+				INFOPLIST_FILE = TAELMacAgent/Resources/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks";
+				MACOSX_DEPLOYMENT_TARGET = 14.0;
+				PRODUCT_BUNDLE_IDENTIFIER = ai.tael.macagent;
+				PRODUCT_NAME = TAELMacAgent;
+				SDKROOT = macosx;
+			};
+			name = Debug;
+		};
+		EDA2C5DF0A791BA5388D23C2 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
-				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = "";
-				GENERATE_INFOPLIST_FILE = YES;
+				COMBINE_HIDPI_IMAGES = YES;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/../Frameworks",
+					"@loader_path/../Frameworks",
+				);
 				MACOSX_DEPLOYMENT_TARGET = 14.0;
-				MARKETING_VERSION = 1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = ai.tael.macagent.tests;
-				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_EMIT_LOC_STRINGS = NO;
-				SWIFT_VERSION = 5.0;
+				PRODUCT_NAME = TAELMacAgentTests;
+				SDKROOT = macosx;
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/TAELMacAgent.app/Contents/MacOS/TAELMacAgent";
 			};
 			name = Release;
@@ -538,34 +506,34 @@
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
-		6A00000000000000000000A1 /* Build configuration list for PBXProject "TAELMacAgent" */ = {
+		117EFF58E2C38224B38B8B12 /* Build configuration list for PBXNativeTarget "TAELMacAgent" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				5A00000000000000000000A1 /* Debug */,
-				5A00000000000000000000A2 /* Release */,
+				97E6B9E4270F081105DFF762 /* Debug */,
+				0E16266BE06C30C4664F152D /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = Release;
+			defaultConfigurationName = Debug;
 		};
-		6A00000000000000000000A2 /* Build configuration list for PBXNativeTarget "TAELMacAgent" */ = {
+		76317FEDB9101E1DC4C2585C /* Build configuration list for PBXNativeTarget "TAELMacAgentTests" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				5A00000000000000000000A3 /* Debug */,
-				5A00000000000000000000A4 /* Release */,
+				30CD9C0A39029D9324927179 /* Debug */,
+				EDA2C5DF0A791BA5388D23C2 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = Release;
+			defaultConfigurationName = Debug;
 		};
-		6A00000000000000000000C2 /* Build configuration list for PBXNativeTarget "TAELMacAgentTests" */ = {
+		9EE8029557141161462E8753 /* Build configuration list for PBXProject "TAELMacAgent" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				5A00000000000000000000C1 /* Debug */,
-				5A00000000000000000000C2 /* Release */,
+				3D3753EFBE210BA568497A6B /* Debug */,
+				2F433CDCD1DA99C432DADA1A /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = Release;
+			defaultConfigurationName = Debug;
 		};
 /* End XCConfigurationList section */
 	};
-	rootObject = 8A00000000000000000000A1 /* Project object */;
+	rootObject = 5D9768FD172621FBD47CDD94 /* Project object */;
 }

--- a/TAELMacAgent/TAELMacAgent.xcodeproj/project.pbxproj
+++ b/TAELMacAgent/TAELMacAgent.xcodeproj/project.pbxproj
@@ -19,6 +19,7 @@
 		6BA0CBE1B80E6592A9C6983A /* PermissionGateView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 422D881643EB42E6E96F6073 /* PermissionGateView.swift */; };
 		7A08515211A39DD11A6E370B /* PermissionsGate.swift in Sources */ = {isa = PBXBuildFile; fileRef = F46F76B62679E79E964F4EAE /* PermissionsGate.swift */; };
 		8AC8665020F765D063A96609 /* HUDPanelController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9363E4D91044162835D20FAA /* HUDPanelController.swift */; };
+		9565442421E66D83C0B03CDF /* HotkeyName.swift in Sources */ = {isa = PBXBuildFile; fileRef = C96D7E9A9156DA07866B2574 /* HotkeyName.swift */; };
 		C3C9015E4F181F2FC2A056BB /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 3900941745D06B0194400E8E /* Assets.xcassets */; };
 		CACD72769410271CF6577CC0 /* InvocationLog.swift in Sources */ = {isa = PBXBuildFile; fileRef = A74AE945B8920595491B2B29 /* InvocationLog.swift */; };
 		CF17A6BDF21FD1B3F8690D13 /* PermissionError.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED47D03840F40871272ED13C /* PermissionError.swift */; };
@@ -60,6 +61,7 @@
 		A74AE945B8920595491B2B29 /* InvocationLog.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InvocationLog.swift; sourceTree = "<group>"; };
 		AB704571A9597F9AF9313D65 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		C654DA20715C3C6F29B9E6F4 /* LocalLogServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalLogServiceTests.swift; sourceTree = "<group>"; };
+		C96D7E9A9156DA07866B2574 /* HotkeyName.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HotkeyName.swift; sourceTree = "<group>"; };
 		EBD624AFDCE20EF4B613B9A4 /* MenuBarController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MenuBarController.swift; sourceTree = "<group>"; };
 		ED47D03840F40871272ED13C /* PermissionError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PermissionError.swift; sourceTree = "<group>"; };
 		F46F76B62679E79E964F4EAE /* PermissionsGate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PermissionsGate.swift; sourceTree = "<group>"; };
@@ -173,6 +175,7 @@
 			isa = PBXGroup;
 			children = (
 				917682B8FDBFE7C755263E19 /* HotkeyManager.swift */,
+				C96D7E9A9156DA07866B2574 /* HotkeyName.swift */,
 			);
 			path = Hotkey;
 			sourceTree = "<group>";
@@ -288,6 +291,7 @@
 				8AC8665020F765D063A96609 /* HUDPanelController.swift in Sources */,
 				F8A8B61233E0F29CD0725388 /* HUDView.swift in Sources */,
 				6AB4701304241B41166818BB /* HotkeyManager.swift in Sources */,
+				9565442421E66D83C0B03CDF /* HotkeyName.swift in Sources */,
 				CACD72769410271CF6577CC0 /* InvocationLog.swift in Sources */,
 				34F3D8094B35A969BEFEFE4A /* LocalLogService.swift in Sources */,
 				033A279961698D88188A33AD /* MenuBarController.swift in Sources */,

--- a/TAELMacAgent/TAELMacAgent.xcodeproj/project.pbxproj
+++ b/TAELMacAgent/TAELMacAgent.xcodeproj/project.pbxproj
@@ -24,6 +24,7 @@
 		CACD72769410271CF6577CC0 /* InvocationLog.swift in Sources */ = {isa = PBXBuildFile; fileRef = A74AE945B8920595491B2B29 /* InvocationLog.swift */; };
 		CF17A6BDF21FD1B3F8690D13 /* PermissionError.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED47D03840F40871272ED13C /* PermissionError.swift */; };
 		D4D7892F3C39042079C92DEC /* PermissionsChecker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D36CFA939327054CE038538 /* PermissionsChecker.swift */; };
+		DF3BAB13D3897B30011FF8B2 /* HUDScreenshotView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 659ECE5A728C28C51E500F35 /* HUDScreenshotView.swift */; };
 		E22538B7BAFDD6DE67CD39A6 /* PermissionKind.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E3601A9D97DFCC20CB1B190 /* PermissionKind.swift */; };
 		EE4E5F822C40DF6233CBDD2A /* ScreenshotTarget.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6C80394C10DB95ACE8B23410 /* ScreenshotTarget.swift */; };
 		F213518191A0D0FBED62E67B /* ScreenCaptureService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 198A12FCDFC021700C887DC3 /* ScreenCaptureService.swift */; };
@@ -50,6 +51,7 @@
 		3900941745D06B0194400E8E /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		422D881643EB42E6E96F6073 /* PermissionGateView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PermissionGateView.swift; sourceTree = "<group>"; };
 		639F88F50828EB01F823718B /* PermissionStatus.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PermissionStatus.swift; sourceTree = "<group>"; };
+		659ECE5A728C28C51E500F35 /* HUDScreenshotView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HUDScreenshotView.swift; sourceTree = "<group>"; };
 		69DDCCAE89FD5A160E17AE49 /* TAELMacAgentApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TAELMacAgentApp.swift; sourceTree = "<group>"; };
 		6C80394C10DB95ACE8B23410 /* ScreenshotTarget.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScreenshotTarget.swift; sourceTree = "<group>"; };
 		6DEC30773055C5F4AE735610 /* CapturedScreenshot.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CapturedScreenshot.swift; sourceTree = "<group>"; };
@@ -92,6 +94,7 @@
 			isa = PBXGroup;
 			children = (
 				9363E4D91044162835D20FAA /* HUDPanelController.swift */,
+				659ECE5A728C28C51E500F35 /* HUDScreenshotView.swift */,
 				1469160F2705F009163C15E0 /* HUDView.swift */,
 				422D881643EB42E6E96F6073 /* PermissionGateView.swift */,
 			);
@@ -289,6 +292,7 @@
 				0B0660E9860988CD91DA599E /* AppDelegate.swift in Sources */,
 				0330637AAF26CC3C25DCD10F /* CapturedScreenshot.swift in Sources */,
 				8AC8665020F765D063A96609 /* HUDPanelController.swift in Sources */,
+				DF3BAB13D3897B30011FF8B2 /* HUDScreenshotView.swift in Sources */,
 				F8A8B61233E0F29CD0725388 /* HUDView.swift in Sources */,
 				6AB4701304241B41166818BB /* HotkeyManager.swift in Sources */,
 				9565442421E66D83C0B03CDF /* HotkeyName.swift in Sources */,

--- a/TAELMacAgent/TAELMacAgent.xcodeproj/project.pbxproj
+++ b/TAELMacAgent/TAELMacAgent.xcodeproj/project.pbxproj
@@ -9,6 +9,7 @@
 /* Begin PBXBuildFile section */
 		0330637AAF26CC3C25DCD10F /* CapturedScreenshot.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6DEC30773055C5F4AE735610 /* CapturedScreenshot.swift */; };
 		033A279961698D88188A33AD /* MenuBarController.swift in Sources */ = {isa = PBXBuildFile; fileRef = EBD624AFDCE20EF4B613B9A4 /* MenuBarController.swift */; };
+		06ADDF6182CAEDB9CC8191F9 /* HotkeyHandlerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 600507D8811CFB057BB49AA4 /* HotkeyHandlerTests.swift */; };
 		0B0660E9860988CD91DA599E /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB704571A9597F9AF9313D65 /* AppDelegate.swift */; };
 		1EFB0EA699153ADC53EA4286 /* LocalLogServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C654DA20715C3C6F29B9E6F4 /* LocalLogServiceTests.swift */; };
 		2BAF280AA3FB18E55785FAD8 /* KeyboardShortcuts in Frameworks */ = {isa = PBXBuildFile; productRef = 271157EB2BA4172C872A7408 /* KeyboardShortcuts */; };
@@ -28,6 +29,7 @@
 		E22538B7BAFDD6DE67CD39A6 /* PermissionKind.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E3601A9D97DFCC20CB1B190 /* PermissionKind.swift */; };
 		EE4E5F822C40DF6233CBDD2A /* ScreenshotTarget.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6C80394C10DB95ACE8B23410 /* ScreenshotTarget.swift */; };
 		F213518191A0D0FBED62E67B /* ScreenCaptureService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 198A12FCDFC021700C887DC3 /* ScreenCaptureService.swift */; };
+		F6E2AD25AAD3F1AE6D0CA2A6 /* HotkeyInvocationHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = C778F76C2BA992BFF35FF455 /* HotkeyInvocationHandler.swift */; };
 		F8A8B61233E0F29CD0725388 /* HUDView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1469160F2705F009163C15E0 /* HUDView.swift */; };
 		FC2769F84CA630E5B0E73F55 /* PermissionStatus.swift in Sources */ = {isa = PBXBuildFile; fileRef = 639F88F50828EB01F823718B /* PermissionStatus.swift */; };
 /* End PBXBuildFile section */
@@ -50,6 +52,7 @@
 		1D36CFA939327054CE038538 /* PermissionsChecker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PermissionsChecker.swift; sourceTree = "<group>"; };
 		3900941745D06B0194400E8E /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		422D881643EB42E6E96F6073 /* PermissionGateView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PermissionGateView.swift; sourceTree = "<group>"; };
+		600507D8811CFB057BB49AA4 /* HotkeyHandlerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HotkeyHandlerTests.swift; sourceTree = "<group>"; };
 		639F88F50828EB01F823718B /* PermissionStatus.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PermissionStatus.swift; sourceTree = "<group>"; };
 		659ECE5A728C28C51E500F35 /* HUDScreenshotView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HUDScreenshotView.swift; sourceTree = "<group>"; };
 		69DDCCAE89FD5A160E17AE49 /* TAELMacAgentApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TAELMacAgentApp.swift; sourceTree = "<group>"; };
@@ -63,6 +66,7 @@
 		A74AE945B8920595491B2B29 /* InvocationLog.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InvocationLog.swift; sourceTree = "<group>"; };
 		AB704571A9597F9AF9313D65 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		C654DA20715C3C6F29B9E6F4 /* LocalLogServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalLogServiceTests.swift; sourceTree = "<group>"; };
+		C778F76C2BA992BFF35FF455 /* HotkeyInvocationHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HotkeyInvocationHandler.swift; sourceTree = "<group>"; };
 		C96D7E9A9156DA07866B2574 /* HotkeyName.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HotkeyName.swift; sourceTree = "<group>"; };
 		EBD624AFDCE20EF4B613B9A4 /* MenuBarController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MenuBarController.swift; sourceTree = "<group>"; };
 		ED47D03840F40871272ED13C /* PermissionError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PermissionError.swift; sourceTree = "<group>"; };
@@ -84,6 +88,7 @@
 		1D955BDFBFFB1E992ABC4E95 /* TAELMacAgentTests */ = {
 			isa = PBXGroup;
 			children = (
+				600507D8811CFB057BB49AA4 /* HotkeyHandlerTests.swift */,
 				C654DA20715C3C6F29B9E6F4 /* LocalLogServiceTests.swift */,
 				14306A2EBDA587DA5C4E6182 /* PermissionsGateTests.swift */,
 			);
@@ -114,6 +119,7 @@
 			isa = PBXGroup;
 			children = (
 				AB704571A9597F9AF9313D65 /* AppDelegate.swift */,
+				C778F76C2BA992BFF35FF455 /* HotkeyInvocationHandler.swift */,
 				EBD624AFDCE20EF4B613B9A4 /* MenuBarController.swift */,
 				69DDCCAE89FD5A160E17AE49 /* TAELMacAgentApp.swift */,
 			);
@@ -294,6 +300,7 @@
 				8AC8665020F765D063A96609 /* HUDPanelController.swift in Sources */,
 				DF3BAB13D3897B30011FF8B2 /* HUDScreenshotView.swift in Sources */,
 				F8A8B61233E0F29CD0725388 /* HUDView.swift in Sources */,
+				F6E2AD25AAD3F1AE6D0CA2A6 /* HotkeyInvocationHandler.swift in Sources */,
 				6AB4701304241B41166818BB /* HotkeyManager.swift in Sources */,
 				9565442421E66D83C0B03CDF /* HotkeyName.swift in Sources */,
 				CACD72769410271CF6577CC0 /* InvocationLog.swift in Sources */,
@@ -315,6 +322,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				06ADDF6182CAEDB9CC8191F9 /* HotkeyHandlerTests.swift in Sources */,
 				1EFB0EA699153ADC53EA4286 /* LocalLogServiceTests.swift in Sources */,
 				5AD70596B8B5BEBD936F2F60 /* PermissionsGateTests.swift in Sources */,
 			);

--- a/TAELMacAgent/TAELMacAgent.xcodeproj/project.pbxproj
+++ b/TAELMacAgent/TAELMacAgent.xcodeproj/project.pbxproj
@@ -11,6 +11,7 @@
 		033A279961698D88188A33AD /* MenuBarController.swift in Sources */ = {isa = PBXBuildFile; fileRef = EBD624AFDCE20EF4B613B9A4 /* MenuBarController.swift */; };
 		0B0660E9860988CD91DA599E /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB704571A9597F9AF9313D65 /* AppDelegate.swift */; };
 		1EFB0EA699153ADC53EA4286 /* LocalLogServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C654DA20715C3C6F29B9E6F4 /* LocalLogServiceTests.swift */; };
+		2BAF280AA3FB18E55785FAD8 /* KeyboardShortcuts in Frameworks */ = {isa = PBXBuildFile; productRef = 271157EB2BA4172C872A7408 /* KeyboardShortcuts */; };
 		34F3D8094B35A969BEFEFE4A /* LocalLogService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F5C315999DFCC84BE675BE2 /* LocalLogService.swift */; };
 		3F34E0D14D96EB8D52BE71A0 /* TAELMacAgentApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 69DDCCAE89FD5A160E17AE49 /* TAELMacAgentApp.swift */; };
 		5AD70596B8B5BEBD936F2F60 /* PermissionsGateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14306A2EBDA587DA5C4E6182 /* PermissionsGateTests.swift */; };
@@ -63,6 +64,17 @@
 		ED47D03840F40871272ED13C /* PermissionError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PermissionError.swift; sourceTree = "<group>"; };
 		F46F76B62679E79E964F4EAE /* PermissionsGate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PermissionsGate.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		B46A07C92351F24C2BF9395E /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				2BAF280AA3FB18E55785FAD8 /* KeyboardShortcuts in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
 		1D955BDFBFFB1E992ABC4E95 /* TAELMacAgentTests */ = {
@@ -182,6 +194,7 @@
 			buildPhases = (
 				A804338716259752E11524FD /* Sources */,
 				D18C72E98AF490A89259C1D9 /* Resources */,
+				B46A07C92351F24C2BF9395E /* Frameworks */,
 			);
 			buildRules = (
 			);
@@ -189,6 +202,7 @@
 			);
 			name = TAELMacAgent;
 			packageProductDependencies = (
+				271157EB2BA4172C872A7408 /* KeyboardShortcuts */,
 			);
 			productName = TAELMacAgent;
 			productReference = 09182C33476D9D80D775700D /* TAELMacAgent.app */;
@@ -239,6 +253,9 @@
 			);
 			mainGroup = 79CF0DC83C35B3DE92D7BB44;
 			minimizedProjectReferenceProxies = 1;
+			packageReferences = (
+				85553E6FF0113F1817B596E9 /* XCRemoteSwiftPackageReference "KeyboardShortcuts" */,
+			);
 			preferredProjectObjectVersion = 77;
 			productRefGroup = C965C9197045CDCA448A4FB4 /* Products */;
 			projectDirPath = "";
@@ -534,6 +551,25 @@
 			defaultConfigurationName = Debug;
 		};
 /* End XCConfigurationList section */
+
+/* Begin XCRemoteSwiftPackageReference section */
+		85553E6FF0113F1817B596E9 /* XCRemoteSwiftPackageReference "KeyboardShortcuts" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/sindresorhus/KeyboardShortcuts";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 2.0.0;
+			};
+		};
+/* End XCRemoteSwiftPackageReference section */
+
+/* Begin XCSwiftPackageProductDependency section */
+		271157EB2BA4172C872A7408 /* KeyboardShortcuts */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 85553E6FF0113F1817B596E9 /* XCRemoteSwiftPackageReference "KeyboardShortcuts" */;
+			productName = KeyboardShortcuts;
+		};
+/* End XCSwiftPackageProductDependency section */
 	};
 	rootObject = 5D9768FD172621FBD47CDD94 /* Project object */;
 }

--- a/TAELMacAgent/TAELMacAgent.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/TAELMacAgent/TAELMacAgent.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,0 +1,15 @@
+{
+  "originHash" : "69c39523ac0471922b625cc56b8722155cfd2afd660bdd4f5ff67335b5b87714",
+  "pins" : [
+    {
+      "identity" : "keyboardshortcuts",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/sindresorhus/KeyboardShortcuts",
+      "state" : {
+        "revision" : "1aef85578fdd4f9eaeeb8d53b7b4fc31bf08fe27",
+        "version" : "2.4.0"
+      }
+    }
+  ],
+  "version" : 3
+}

--- a/TAELMacAgent/TAELMacAgent.xcodeproj/xcshareddata/xcschemes/TAELMacAgent.xcscheme
+++ b/TAELMacAgent/TAELMacAgent.xcodeproj/xcshareddata/xcschemes/TAELMacAgent.xcscheme
@@ -1,10 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1530"
+   LastUpgradeVersion = "1430"
    version = "1.7">
    <BuildAction
       parallelizeBuildables = "YES"
-      buildImplicitDependencies = "YES">
+      buildImplicitDependencies = "YES"
+      runPostActionsOnFailure = "NO">
       <BuildActionEntries>
          <BuildActionEntry
             buildForTesting = "YES"
@@ -14,7 +15,7 @@
             buildForAnalyzing = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "7A00000000000000000000A1"
+               BlueprintIdentifier = "19B5206FF51EAAA5D9DD33BD"
                BuildableName = "TAELMacAgent.app"
                BlueprintName = "TAELMacAgent"
                ReferencedContainer = "container:TAELMacAgent.xcodeproj">
@@ -28,7 +29,7 @@
             buildForAnalyzing = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "7A00000000000000000000C1"
+               BlueprintIdentifier = "7BBF771A19B870A8BDB655E7"
                BuildableName = "TAELMacAgentTests.xctest"
                BlueprintName = "TAELMacAgentTests"
                ReferencedContainer = "container:TAELMacAgent.xcodeproj">
@@ -40,19 +41,32 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      shouldUseLaunchSchemeArgsEnv = "YES">
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      onlyGenerateCoverageForSpecifiedTargets = "NO">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "19B5206FF51EAAA5D9DD33BD"
+            BuildableName = "TAELMacAgent.app"
+            BlueprintName = "TAELMacAgent"
+            ReferencedContainer = "container:TAELMacAgent.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
       <Testables>
          <TestableReference
-            skipped = "NO">
+            skipped = "NO"
+            parallelizable = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "7A00000000000000000000C1"
+               BlueprintIdentifier = "7BBF771A19B870A8BDB655E7"
                BuildableName = "TAELMacAgentTests.xctest"
                BlueprintName = "TAELMacAgentTests"
                ReferencedContainer = "container:TAELMacAgent.xcodeproj">
             </BuildableReference>
          </TestableReference>
       </Testables>
+      <CommandLineArguments>
+      </CommandLineArguments>
    </TestAction>
    <LaunchAction
       buildConfiguration = "Debug"
@@ -68,12 +82,14 @@
          runnableDebuggingMode = "0">
          <BuildableReference
             BuildableIdentifier = "primary"
-            BlueprintIdentifier = "7A00000000000000000000A1"
+            BlueprintIdentifier = "19B5206FF51EAAA5D9DD33BD"
             BuildableName = "TAELMacAgent.app"
             BlueprintName = "TAELMacAgent"
             ReferencedContainer = "container:TAELMacAgent.xcodeproj">
          </BuildableReference>
       </BuildableProductRunnable>
+      <CommandLineArguments>
+      </CommandLineArguments>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"
@@ -85,12 +101,14 @@
          runnableDebuggingMode = "0">
          <BuildableReference
             BuildableIdentifier = "primary"
-            BlueprintIdentifier = "7A00000000000000000000A1"
+            BlueprintIdentifier = "19B5206FF51EAAA5D9DD33BD"
             BuildableName = "TAELMacAgent.app"
             BlueprintName = "TAELMacAgent"
             ReferencedContainer = "container:TAELMacAgent.xcodeproj">
          </BuildableReference>
       </BuildableProductRunnable>
+      <CommandLineArguments>
+      </CommandLineArguments>
    </ProfileAction>
    <AnalyzeAction
       buildConfiguration = "Debug">

--- a/TAELMacAgent/TAELMacAgent/App/AppDelegate.swift
+++ b/TAELMacAgent/TAELMacAgent/App/AppDelegate.swift
@@ -5,8 +5,6 @@
 
 import AppKit
 import Foundation
-import os.log
-import SwiftUI
 
 @MainActor
 final class AppDelegate: NSObject, NSApplicationDelegate {
@@ -16,7 +14,6 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     private var permissionsGate: PermissionsGate?
     private var screenCaptureService: DisplayScreenshotCapturing?
     private var logService: LocalLogService?
-    private let log = Logger(subsystem: "ai.tael.macagent", category: "AppDelegate")
 
     func applicationDidFinishLaunching(_ notification: Notification) {
         // Belt and braces: even though `LSUIElement = YES`, force
@@ -52,9 +49,19 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         // Hotkey closure: gate → capture → HUD + log. Runs on the main
         // actor (the `@MainActor` class isolation already covers it).
         hotkeyManager.onTrigger = { [weak self] in
-            guard let self else { return }
+            guard let self,
+                  let permissionsGate = self.permissionsGate,
+                  let screenCaptureService = self.screenCaptureService,
+                  let hudController = self.hudController,
+                  let logService = self.logService else { return }
+            let handler = HotkeyInvocationHandler(
+                permissionsGate: permissionsGate,
+                screenCaptureService: screenCaptureService,
+                presentScreenshot: { shot in hudController.present(screenshot: shot) },
+                logService: logService
+            )
             Task { @MainActor in
-                await self.handleHotkeyInvocation()
+                await handler.run()
             }
         }
         hotkeyManager.installBinding()
@@ -63,57 +70,5 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     func applicationWillTerminate(_ notification: Notification) {
         hotkeyManager?.tearDown()
         hudController?.tearDown()
-    }
-
-    /// One invocation of the Week 1 heartbeat. Captures latency,
-    /// outcome, and target metadata into a LocalLogService row.
-    private func handleHotkeyInvocation() async {
-        guard let permissionsGate, let screenCaptureService, let hudController, let logService else {
-            log.fault("Hotkey fired before AppDelegate finished launch wiring; ignoring.")
-            return
-        }
-
-        let started = Date()
-        let gateStart = started
-
-        do {
-            let screenshot = try await permissionsGate.withPermission(.screenRecording) { grant in
-                let gateEnd = Date()
-                let captureStart = gateEnd
-                let result = try await screenCaptureService.captureDisplayScreenshot(grant, target: .week1Default)
-                let captureEnd = Date()
-
-                await logService.record(InvocationLog(
-                    hotkeyTimestamp: started,
-                    gateOutcome: .granted,
-                    gateLatencyMs: gateEnd.timeIntervalSince(gateStart) * 1000,
-                    captureLatencyMs: captureEnd.timeIntervalSince(captureStart) * 1000,
-                    targetDescription: "\(result.target) \(result.width)x\(result.height)"
-                ))
-
-                return result
-            }
-            hudController.present(screenshot: screenshot)
-        } catch let error as PermissionError {
-            // PermissionsGate already invoked permissionUI.showGate.
-            // Log the outcome and stop.
-            let outcome: InvocationLog.GateOutcome
-            switch error {
-            case .missing: outcome = .denied
-            case .notImplemented: outcome = .restricted
-            }
-            await logService.record(InvocationLog(
-                hotkeyTimestamp: started,
-                gateOutcome: outcome,
-                errorDescription: error.localizedDescription
-            ))
-        } catch {
-            await logService.record(InvocationLog(
-                hotkeyTimestamp: started,
-                gateOutcome: .errored,
-                errorDescription: error.localizedDescription
-            ))
-            log.error("Hotkey invocation failed: \(error.localizedDescription, privacy: .public)")
-        }
     }
 }

--- a/TAELMacAgent/TAELMacAgent/App/AppDelegate.swift
+++ b/TAELMacAgent/TAELMacAgent/App/AppDelegate.swift
@@ -4,6 +4,8 @@
 //
 
 import AppKit
+import Foundation
+import os.log
 import SwiftUI
 
 @MainActor
@@ -12,8 +14,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     private var hotkeyManager: HotkeyManager?
     private var hudController: HUDPanelController?
     private var permissionsGate: PermissionsGate?
-    private var screenCaptureService: ScreenCaptureService?
+    private var screenCaptureService: DisplayScreenshotCapturing?
     private var logService: LocalLogService?
+    private let log = Logger(subsystem: "ai.tael.macagent", category: "AppDelegate")
 
     func applicationDidFinishLaunching(_ notification: Notification) {
         // Belt and braces: even though `LSUIElement = YES`, force
@@ -46,16 +49,71 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 
         menuBarController.install()
 
-        // PR 1: do NOT register a real global hotkey yet. The hotkey
-        // package + the hotkey → gate → capture wire-up land in PR 2
-        // (Week 1 tickets 6–9). For now, only the placeholder callback
-        // exists, so launching the app does not call any protected
-        // API.
-        hotkeyManager.installPlaceholderBinding()
+        // Hotkey closure: gate → capture → HUD + log. Runs on the main
+        // actor (the `@MainActor` class isolation already covers it).
+        hotkeyManager.onTrigger = { [weak self] in
+            guard let self else { return }
+            Task { @MainActor in
+                await self.handleHotkeyInvocation()
+            }
+        }
+        hotkeyManager.installBinding()
     }
 
     func applicationWillTerminate(_ notification: Notification) {
         hotkeyManager?.tearDown()
         hudController?.tearDown()
+    }
+
+    /// One invocation of the Week 1 heartbeat. Captures latency,
+    /// outcome, and target metadata into a LocalLogService row.
+    private func handleHotkeyInvocation() async {
+        guard let permissionsGate, let screenCaptureService, let hudController, let logService else {
+            log.fault("Hotkey fired before AppDelegate finished launch wiring; ignoring.")
+            return
+        }
+
+        let started = Date()
+        let gateStart = started
+
+        do {
+            let screenshot = try await permissionsGate.withPermission(.screenRecording) { grant in
+                let gateEnd = Date()
+                let captureStart = gateEnd
+                let result = try await screenCaptureService.captureDisplayScreenshot(grant, target: .week1Default)
+                let captureEnd = Date()
+
+                await logService.record(InvocationLog(
+                    hotkeyTimestamp: started,
+                    gateOutcome: .granted,
+                    gateLatencyMs: gateEnd.timeIntervalSince(gateStart) * 1000,
+                    captureLatencyMs: captureEnd.timeIntervalSince(captureStart) * 1000,
+                    targetDescription: "\(result.target) \(result.width)x\(result.height)"
+                ))
+
+                return result
+            }
+            hudController.present(screenshot: screenshot)
+        } catch let error as PermissionError {
+            // PermissionsGate already invoked permissionUI.showGate.
+            // Log the outcome and stop.
+            let outcome: InvocationLog.GateOutcome
+            switch error {
+            case .missing: outcome = .denied
+            case .notImplemented: outcome = .restricted
+            }
+            await logService.record(InvocationLog(
+                hotkeyTimestamp: started,
+                gateOutcome: outcome,
+                errorDescription: error.localizedDescription
+            ))
+        } catch {
+            await logService.record(InvocationLog(
+                hotkeyTimestamp: started,
+                gateOutcome: .errored,
+                errorDescription: error.localizedDescription
+            ))
+            log.error("Hotkey invocation failed: \(error.localizedDescription, privacy: .public)")
+        }
     }
 }

--- a/TAELMacAgent/TAELMacAgent/App/HotkeyInvocationHandler.swift
+++ b/TAELMacAgent/TAELMacAgent/App/HotkeyInvocationHandler.swift
@@ -2,9 +2,8 @@
 //  HotkeyInvocationHandler.swift
 //  TAELMacAgent
 //
-//  Single invocation of the Week 1 heartbeat: gate → capture → HUD +
-//  log. Extracted from AppDelegate so the wire-up is unit-testable
-//  without spinning up a real menubar or NSPanel.
+//  Single invocation of the gate → capture → HUD pipeline.
+//  Lives outside `AppDelegate` so it can be unit-tested without a menubar or NSPanel.
 //
 
 import Foundation

--- a/TAELMacAgent/TAELMacAgent/App/HotkeyInvocationHandler.swift
+++ b/TAELMacAgent/TAELMacAgent/App/HotkeyInvocationHandler.swift
@@ -1,0 +1,82 @@
+//
+//  HotkeyInvocationHandler.swift
+//  TAELMacAgent
+//
+//  Single invocation of the Week 1 heartbeat: gate → capture → HUD +
+//  log. Extracted from AppDelegate so the wire-up is unit-testable
+//  without spinning up a real menubar or NSPanel.
+//
+
+import Foundation
+import os.log
+
+@MainActor
+struct HotkeyInvocationHandler {
+    let permissionsGate: PermissionsGate
+    let screenCaptureService: any DisplayScreenshotCapturing
+    let presentScreenshot: (CapturedScreenshot) -> Void
+    let logService: LocalLogService
+    let now: () -> Date
+
+    init(
+        permissionsGate: PermissionsGate,
+        screenCaptureService: any DisplayScreenshotCapturing,
+        presentScreenshot: @escaping (CapturedScreenshot) -> Void,
+        logService: LocalLogService,
+        now: @escaping () -> Date = Date.init
+    ) {
+        self.permissionsGate = permissionsGate
+        self.screenCaptureService = screenCaptureService
+        self.presentScreenshot = presentScreenshot
+        self.logService = logService
+        self.now = now
+    }
+
+    private static let log = Logger(subsystem: "ai.tael.macagent", category: "HotkeyInvocationHandler")
+
+    func run() async {
+        let started = now()
+        let gateStart = started
+
+        do {
+            let screenshot = try await permissionsGate.withPermission(.screenRecording) { grant in
+                let gateEnd = self.now()
+                let captureStart = gateEnd
+                let result = try await screenCaptureService.captureDisplayScreenshot(grant, target: .week1Default)
+                let captureEnd = self.now()
+
+                await logService.record(InvocationLog(
+                    hotkeyTimestamp: started,
+                    gateOutcome: .granted,
+                    gateLatencyMs: gateEnd.timeIntervalSince(gateStart) * 1000,
+                    captureLatencyMs: captureEnd.timeIntervalSince(captureStart) * 1000,
+                    targetDescription: "\(result.target) \(result.width)x\(result.height)"
+                ))
+
+                return result
+            }
+            presentScreenshot(screenshot)
+        } catch let error as PermissionError {
+            let outcome: InvocationLog.GateOutcome
+            switch error {
+            case .missing: outcome = .denied
+            case .notImplemented: outcome = .restricted
+            }
+            await logService.record(InvocationLog(
+                hotkeyTimestamp: started,
+                gateOutcome: outcome,
+                errorDescription: error.localizedDescription
+            ))
+        } catch {
+            // Use case-form so debug-mode log inspection sees
+            // `captureFailed("…")` rather than the generic NSError-bridged
+            // string that Swift errors get without LocalizedError.
+            await logService.record(InvocationLog(
+                hotkeyTimestamp: started,
+                gateOutcome: .errored,
+                errorDescription: String(describing: error)
+            ))
+            Self.log.error("Hotkey invocation failed: \(error.localizedDescription, privacy: .public)")
+        }
+    }
+}

--- a/TAELMacAgent/TAELMacAgent/App/HotkeyInvocationHandler.swift
+++ b/TAELMacAgent/TAELMacAgent/App/HotkeyInvocationHandler.swift
@@ -36,10 +36,12 @@ struct HotkeyInvocationHandler {
     func run() async {
         let started = now()
         let gateStart = started
+        var gateLatencyMs: Double?
 
         do {
             let screenshot = try await permissionsGate.withPermission(.screenRecording) { grant in
                 let gateEnd = self.now()
+                gateLatencyMs = gateEnd.timeIntervalSince(gateStart) * 1000
                 let captureStart = gateEnd
                 let result = try await screenCaptureService.captureDisplayScreenshot(grant, target: .week1Default)
                 let captureEnd = self.now()
@@ -47,7 +49,7 @@ struct HotkeyInvocationHandler {
                 await logService.record(InvocationLog(
                     hotkeyTimestamp: started,
                     gateOutcome: .granted,
-                    gateLatencyMs: gateEnd.timeIntervalSince(gateStart) * 1000,
+                    gateLatencyMs: gateLatencyMs,
                     captureLatencyMs: captureEnd.timeIntervalSince(captureStart) * 1000,
                     targetDescription: "\(result.target) \(result.width)x\(result.height)"
                 ))
@@ -67,12 +69,10 @@ struct HotkeyInvocationHandler {
                 errorDescription: error.localizedDescription
             ))
         } catch {
-            // Use case-form so debug-mode log inspection sees
-            // `captureFailed("…")` rather than the generic NSError-bridged
-            // string that Swift errors get without LocalizedError.
             await logService.record(InvocationLog(
                 hotkeyTimestamp: started,
                 gateOutcome: .errored,
+                gateLatencyMs: gateLatencyMs,
                 errorDescription: String(describing: error)
             ))
             Self.log.error("Hotkey invocation failed: \(error.localizedDescription, privacy: .public)")

--- a/TAELMacAgent/TAELMacAgent/Capture/ScreenCaptureService.swift
+++ b/TAELMacAgent/TAELMacAgent/Capture/ScreenCaptureService.swift
@@ -33,7 +33,23 @@ public enum ScreenCaptureError: Error, Equatable {
     case captureFailed(String)
 }
 
-public final class ScreenCaptureService {
+/// Minimal protocol the hotkey/wiring layer depends on. Lets tests
+/// inject a mock that returns a synthetic `CapturedScreenshot` without
+/// pulling in ScreenCaptureKit or requiring a real TCC grant.
+public protocol DisplayScreenshotCapturing: Sendable {
+    func captureDisplayScreenshot(
+        _ grant: PermissionGrant,
+        target: ScreenshotTarget
+    ) async throws -> CapturedScreenshot
+}
+
+public extension DisplayScreenshotCapturing {
+    func captureDisplayScreenshot(_ grant: PermissionGrant) async throws -> CapturedScreenshot {
+        try await captureDisplayScreenshot(grant, target: .week1Default)
+    }
+}
+
+public final class ScreenCaptureService: DisplayScreenshotCapturing {
     public init() {}
 
     /// Capture a screenshot of `target`, falling back to `.mainDisplay`
@@ -43,7 +59,7 @@ public final class ScreenCaptureService {
     /// is the contract that PR 2 will fill in.
     public func captureDisplayScreenshot(
         _ grant: PermissionGrant,
-        target: ScreenshotTarget = .week1Default
+        target: ScreenshotTarget
     ) async throws -> CapturedScreenshot {
         precondition(
             grant.kind == .screenRecording,

--- a/TAELMacAgent/TAELMacAgent/Capture/ScreenCaptureService.swift
+++ b/TAELMacAgent/TAELMacAgent/Capture/ScreenCaptureService.swift
@@ -116,8 +116,8 @@ public final class ScreenCaptureService: DisplayScreenshotCapturing {
         let scale = NSScreen.screens
             .first { ($0.deviceDescription[NSDeviceDescriptionKey("NSScreenNumber")] as? CGDirectDisplayID) == display.displayID }?
             .backingScaleFactor ?? 2.0
-        cfg.width = display.width * Int(scale)
-        cfg.height = display.height * Int(scale)
+        cfg.width = Int((CGFloat(display.width) * scale).rounded())
+        cfg.height = Int((CGFloat(display.height) * scale).rounded())
         cfg.showsCursor = true
         cfg.queueDepth = 1
 

--- a/TAELMacAgent/TAELMacAgent/Capture/ScreenCaptureService.swift
+++ b/TAELMacAgent/TAELMacAgent/Capture/ScreenCaptureService.swift
@@ -5,13 +5,11 @@
 //  Protected service. Only callable with a `PermissionGrant` minted by
 //  `PermissionsGate.withPermission(.screenRecording)`.
 //
-//  PR 1: this is a typed stub. The real ScreenCaptureKit path lands in
-//  PR 2 (Week 1 ticket 8) using:
-//
-//      SCShareableContent
-//      SCContentFilter
-//      SCStreamConfiguration
-//      SCScreenshotManager.captureImage(contentFilter:configuration:)
+//  Real ScreenCaptureKit capture: SCShareableContent → SCContentFilter
+//  → SCStreamConfiguration → SCScreenshotManager.captureImage. Cursor
+//  display first, mainDisplay fallback (v0.3 §23.2). Width/height are
+//  multiplied by the NSScreen backingScaleFactor — explicit per
+//  v0.3 §23.10 (the cfg defaults give the wrong dimensions).
 //
 //  Do NOT use `SCScreenshotManager.captureImage(in:)` — that overload
 //  is macOS 15.2+, and our deployment target is macOS 14.0+
@@ -22,10 +20,14 @@ import Foundation
 #if canImport(CoreGraphics)
 import CoreGraphics
 #endif
+#if canImport(ScreenCaptureKit)
+import ScreenCaptureKit
+#endif
+#if canImport(AppKit)
+import AppKit
+#endif
 
 public enum ScreenCaptureError: Error, Equatable {
-    /// PR 1 placeholder. Removed when ScreenCaptureKit lands in PR 2.
-    case notImplemented
     /// `SCShareableContent` returned no displays.
     case noDisplaysAvailable
     /// Underlying ScreenCaptureKit error. Wrapped to keep call sites
@@ -49,14 +51,44 @@ public extension DisplayScreenshotCapturing {
     }
 }
 
+/// Resolves the target display per v0.3 §23.2: cursor display first,
+/// fallback to main display, fallback to the first available display.
+/// Returns the resolved `(SCDisplay, ScreenshotTarget)` so the caller
+/// knows whether it got the cursor display or fell back.
+@available(macOS 14.0, *)
+private func resolveTargetDisplay(
+    in content: SCShareableContent,
+    requested: ScreenshotTarget
+) -> (display: SCDisplay, resolved: ScreenshotTarget)? {
+    guard !content.displays.isEmpty else { return nil }
+
+    let mainDisplayID = CGMainDisplayID()
+
+    if requested == .displayContainingCursor {
+        let cursorPoint = NSEvent.mouseLocation
+        if let nsScreen = NSScreen.screens.first(where: { $0.frame.contains(cursorPoint) }),
+           let screenNumber = nsScreen.deviceDescription[NSDeviceDescriptionKey("NSScreenNumber")] as? CGDirectDisplayID,
+           let display = content.displays.first(where: { $0.displayID == screenNumber })
+        {
+            return (display, .displayContainingCursor)
+        }
+    }
+
+    // Fallback path: main display, then first available.
+    if let main = content.displays.first(where: { $0.displayID == mainDisplayID }) {
+        return (main, .mainDisplay)
+    }
+    if let first = content.displays.first {
+        return (first, .mainDisplay)
+    }
+    return nil
+}
+
 public final class ScreenCaptureService: DisplayScreenshotCapturing {
     public init() {}
 
     /// Capture a screenshot of `target`, falling back to `.mainDisplay`
     /// if `displayContainingCursor` cannot be resolved.
-    ///
-    /// PR 1 throws `ScreenCaptureError.notImplemented`. The signature
-    /// is the contract that PR 2 will fill in.
     public func captureDisplayScreenshot(
         _ grant: PermissionGrant,
         target: ScreenshotTarget
@@ -66,20 +98,39 @@ public final class ScreenCaptureService: DisplayScreenshotCapturing {
             "ScreenCaptureService requires a .screenRecording grant"
         )
 
-        // PR 2 implementation outline (do not enable in PR 1):
-        //
-        //   let content = try await SCShareableContent.current
-        //   let display = resolveTargetDisplay(content, target: target)
-        //   let filter = SCContentFilter(display: display, excludingWindows: [])
-        //   let cfg = SCStreamConfiguration()
-        //   cfg.width  = display.width  * Int(display.backingScaleFactor)
-        //   cfg.height = display.height * Int(display.backingScaleFactor)
-        //   cfg.showsCursor = true
-        //   let cgImage = try await SCScreenshotManager.captureImage(
-        //       contentFilter: filter, configuration: cfg
-        //   )
-        //   return CapturedScreenshot(image: cgImage, target: resolvedTarget)
+        let content: SCShareableContent
+        do {
+            content = try await SCShareableContent.current
+        } catch {
+            throw ScreenCaptureError.captureFailed("SCShareableContent.current failed: \(error.localizedDescription)")
+        }
 
-        throw ScreenCaptureError.notImplemented
+        guard let resolved = resolveTargetDisplay(in: content, requested: target) else {
+            throw ScreenCaptureError.noDisplaysAvailable
+        }
+
+        let display = resolved.display
+        let filter = SCContentFilter(display: display, excludingWindows: [])
+
+        let cfg = SCStreamConfiguration()
+        let scale = NSScreen.screens
+            .first { ($0.deviceDescription[NSDeviceDescriptionKey("NSScreenNumber")] as? CGDirectDisplayID) == display.displayID }?
+            .backingScaleFactor ?? 2.0
+        cfg.width = display.width * Int(scale)
+        cfg.height = display.height * Int(scale)
+        cfg.showsCursor = true
+        cfg.queueDepth = 1
+
+        let cgImage: CGImage
+        do {
+            cgImage = try await SCScreenshotManager.captureImage(
+                contentFilter: filter,
+                configuration: cfg
+            )
+        } catch {
+            throw ScreenCaptureError.captureFailed("SCScreenshotManager.captureImage failed: \(error.localizedDescription)")
+        }
+
+        return CapturedScreenshot(image: cgImage, target: resolved.resolved)
     }
 }

--- a/TAELMacAgent/TAELMacAgent/HUD/HUDPanelController.swift
+++ b/TAELMacAgent/TAELMacAgent/HUD/HUDPanelController.swift
@@ -28,9 +28,7 @@ final class HUDPanelController: NSObject, PermissionGatePresenting {
     }
 
     func present(screenshot: CapturedScreenshot) {
-        // Task 7 fills this in. Stub so Task 6's AppDelegate wiring
-        // compiles in its own commit.
-        showPlaceholder()
+        presentNew(content: HUDScreenshotView(screenshot: screenshot))
     }
 
     /// `PermissionGatePresenting` implementation: show a sheet-like HUD that

--- a/TAELMacAgent/TAELMacAgent/HUD/HUDPanelController.swift
+++ b/TAELMacAgent/TAELMacAgent/HUD/HUDPanelController.swift
@@ -27,6 +27,12 @@ final class HUDPanelController: NSObject, PermissionGatePresenting {
         presentNew(content: HUDView())
     }
 
+    func present(screenshot: CapturedScreenshot) {
+        // Task 7 fills this in. Stub so Task 6's AppDelegate wiring
+        // compiles in its own commit.
+        showPlaceholder()
+    }
+
     /// `PermissionGatePresenting` implementation: show a sheet-like HUD that
     /// explains the missing permission and links to System Settings.
     /// `nonisolated` so it satisfies the non-isolated protocol

--- a/TAELMacAgent/TAELMacAgent/HUD/HUDScreenshotView.swift
+++ b/TAELMacAgent/TAELMacAgent/HUD/HUDScreenshotView.swift
@@ -2,9 +2,7 @@
 //  HUDScreenshotView.swift
 //  TAELMacAgent
 //
-//  Displays a CapturedScreenshot inside the HUD. PR 2: the shot is
-//  shown at a fixed maximum size so a full 5K display still fits in a
-//  reasonable HUD. Aspect ratio preserved.
+//  Caps screenshots at 720x480 so a full 5K display still fits in the HUD.
 //
 
 import SwiftUI

--- a/TAELMacAgent/TAELMacAgent/HUD/HUDScreenshotView.swift
+++ b/TAELMacAgent/TAELMacAgent/HUD/HUDScreenshotView.swift
@@ -1,0 +1,42 @@
+//
+//  HUDScreenshotView.swift
+//  TAELMacAgent
+//
+//  Displays a CapturedScreenshot inside the HUD. PR 2: the shot is
+//  shown at a fixed maximum size so a full 5K display still fits in a
+//  reasonable HUD. Aspect ratio preserved.
+//
+
+import SwiftUI
+import AppKit
+
+struct HUDScreenshotView: View {
+    let screenshot: CapturedScreenshot
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text("Captured \(screenshot.width)×\(screenshot.height) — \(targetLabel)")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+
+            Image(decorative: screenshot.image, scale: 1.0, orientation: .up)
+                .resizable()
+                .aspectRatio(contentMode: .fit)
+                .frame(maxWidth: 720, maxHeight: 480)
+                .background(Color.black.opacity(0.3))
+                .cornerRadius(6)
+
+            Text(screenshot.capturedAt.formatted(date: .omitted, time: .standard))
+                .font(.caption2)
+                .foregroundStyle(.tertiary)
+        }
+        .padding(16)
+    }
+
+    private var targetLabel: String {
+        switch screenshot.target {
+        case .displayContainingCursor: return "cursor display"
+        case .mainDisplay: return "main display (fallback)"
+        }
+    }
+}

--- a/TAELMacAgent/TAELMacAgent/Hotkey/HotkeyManager.swift
+++ b/TAELMacAgent/TAELMacAgent/Hotkey/HotkeyManager.swift
@@ -24,14 +24,6 @@ final class HotkeyManager {
         }
     }
 
-    /// Backwards-compatible alias for the PR 1 call site. Removed in
-    /// the same commit that updates `AppDelegate` to call
-    /// `installBinding()` directly (Task 6).
-    @available(*, deprecated, renamed: "installBinding")
-    func installPlaceholderBinding() {
-        installBinding()
-    }
-
     func tearDown() {
         KeyboardShortcuts.disable(.toggleTAEL)
         onTrigger = nil

--- a/TAELMacAgent/TAELMacAgent/Hotkey/HotkeyManager.swift
+++ b/TAELMacAgent/TAELMacAgent/Hotkey/HotkeyManager.swift
@@ -2,36 +2,38 @@
 //  HotkeyManager.swift
 //  TAELMacAgent
 //
-//  Global hotkey owner. PR 1 contains only a placeholder binding hook
-//  (no real registration), so the app can launch without pulling in a
-//  third-party package and without calling any protected API.
-//
-//  PR 2 (Week 1 ticket 6) adds the `KeyboardShortcuts` SPM package and
-//  registers a real shortcut that calls `onTrigger`.
+//  Owns the global hotkey registration via the KeyboardShortcuts
+//  package. The actual work (gate → capture → HUD) is the closure
+//  assigned to `onTrigger` by `AppDelegate`.
 //
 
 import Foundation
+import KeyboardShortcuts
 
 @MainActor
 final class HotkeyManager {
-    /// Set by the wiring code in `AppDelegate` once the gate, capture
-    /// service, and HUD exist. PR 1 leaves this nil-by-default; PR 2
-    /// will assign a closure that runs:
-    ///
-    ///     try await permissionsGate.withPermission(.screenRecording) { grant in
-    ///         let shot = try await screenCaptureService
-    ///             .captureDisplayScreenshot(grant)
-    ///         hudController.present(shot)
-    ///     }
+    /// Set by `AppDelegate` to the gate→capture→HUD closure.
+    /// Read inside the KeyboardShortcuts callback.
     var onTrigger: (() -> Void)?
 
-    /// PR 1 no-op binding. Exists so the call site in `AppDelegate`
-    /// can be wired now and the PR 2 change is purely additive.
+    /// Registers the real global hotkey with KeyboardShortcuts.
+    /// Call once during `applicationDidFinishLaunching`.
+    func installBinding() {
+        KeyboardShortcuts.onKeyDown(for: .toggleTAEL) { [weak self] in
+            self?.onTrigger?()
+        }
+    }
+
+    /// Backwards-compatible alias for the PR 1 call site. Removed in
+    /// the same commit that updates `AppDelegate` to call
+    /// `installBinding()` directly (Task 6).
+    @available(*, deprecated, renamed: "installBinding")
     func installPlaceholderBinding() {
-        // Intentionally empty.
+        installBinding()
     }
 
     func tearDown() {
+        KeyboardShortcuts.disable(.toggleTAEL)
         onTrigger = nil
     }
 }

--- a/TAELMacAgent/TAELMacAgent/Hotkey/HotkeyName.swift
+++ b/TAELMacAgent/TAELMacAgent/Hotkey/HotkeyName.swift
@@ -3,15 +3,13 @@
 //  TAELMacAgent
 //
 //  Declares the global hotkey name used by KeyboardShortcuts.
-//  Default chord: ⌘⇧T ("T" for TAEL). User can rebind via Settings
-//  later (post-PR 2).
+//  Default chord: ⌘⇧T ("T" for TAEL). User-rebindable when Settings ships.
 //
 
 import KeyboardShortcuts
 
 extension KeyboardShortcuts.Name {
-    /// Primary "summon TAEL" hotkey. v0.3 §1: this triggers the full
-    /// hotkey → gate → capture → HUD pipeline.
+    /// Primary "summon TAEL" hotkey (v0.3 §1).
     static let toggleTAEL = Self(
         "toggleTAEL",
         default: .init(.t, modifiers: [.command, .shift])

--- a/TAELMacAgent/TAELMacAgent/Hotkey/HotkeyName.swift
+++ b/TAELMacAgent/TAELMacAgent/Hotkey/HotkeyName.swift
@@ -1,0 +1,19 @@
+//
+//  HotkeyName.swift
+//  TAELMacAgent
+//
+//  Declares the global hotkey name used by KeyboardShortcuts.
+//  Default chord: ⌘⇧T ("T" for TAEL). User can rebind via Settings
+//  later (post-PR 2).
+//
+
+import KeyboardShortcuts
+
+extension KeyboardShortcuts.Name {
+    /// Primary "summon TAEL" hotkey. v0.3 §1: this triggers the full
+    /// hotkey → gate → capture → HUD pipeline.
+    static let toggleTAEL = Self(
+        "toggleTAEL",
+        default: .init(.t, modifiers: [.command, .shift])
+    )
+}

--- a/TAELMacAgent/TAELMacAgentTests/HotkeyHandlerTests.swift
+++ b/TAELMacAgent/TAELMacAgentTests/HotkeyHandlerTests.swift
@@ -1,0 +1,145 @@
+//
+//  HotkeyHandlerTests.swift
+//  TAELMacAgentTests
+//
+
+import XCTest
+@testable import TAELMacAgent
+import CoreGraphics
+
+@MainActor
+final class HotkeyHandlerTests: XCTestCase {
+
+    // MARK: - Test doubles
+
+    private actor StubChecker: PermissionChecking {
+        private let status: PermissionStatus
+        init(_ status: PermissionStatus) { self.status = status }
+        func status(for kind: PermissionKind) async -> PermissionStatus { status }
+    }
+
+    private actor SpyUI: PermissionGatePresenting {
+        private(set) var shownKinds: [PermissionKind] = []
+        func showGate(for kind: PermissionKind) async { shownKinds.append(kind) }
+    }
+
+    private actor SpyCapture: DisplayScreenshotCapturing {
+        var thrownError: Error?
+        var capturedTargets: [ScreenshotTarget] = []
+        var stubScreenshot: CapturedScreenshot
+
+        init(stub: CapturedScreenshot) { self.stubScreenshot = stub }
+
+        func setError(_ error: Error?) { self.thrownError = error }
+        func observedTargets() -> [ScreenshotTarget] { capturedTargets }
+
+        func captureDisplayScreenshot(
+            _ grant: PermissionGrant,
+            target: ScreenshotTarget
+        ) async throws -> CapturedScreenshot {
+            precondition(grant.kind == .screenRecording)
+            capturedTargets.append(target)
+            if let thrownError { throw thrownError }
+            return stubScreenshot
+        }
+    }
+
+    /// Builds a 1x1 transparent CGImage for tests; no real capture.
+    private func makeStubScreenshot() -> CapturedScreenshot {
+        let cs = CGColorSpaceCreateDeviceRGB()
+        let ctx = CGContext(data: nil, width: 1, height: 1, bitsPerComponent: 8, bytesPerRow: 4, space: cs, bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue)!
+        let image = ctx.makeImage()!
+        return CapturedScreenshot(image: image, target: .displayContainingCursor)
+    }
+
+    // MARK: - Granted path
+
+    func test_run_whenGranted_callsCaptureAndPresentsAndLogsGranted() async {
+        let checker = StubChecker(.granted)
+        let ui = SpyUI()
+        let gate = PermissionsGate(checker: checker, permissionUI: ui)
+        let capture = SpyCapture(stub: makeStubScreenshot())
+        let logService = LocalLogService(capacity: 16)
+
+        var presented: [CapturedScreenshot] = []
+        let handler = HotkeyInvocationHandler(
+            permissionsGate: gate,
+            screenCaptureService: capture,
+            presentScreenshot: { presented.append($0) },
+            logService: logService
+        )
+
+        await handler.run()
+
+        let targets = await capture.observedTargets()
+        XCTAssertEqual(targets, [.week1Default])
+        XCTAssertEqual(presented.count, 1)
+
+        let logs = await logService.recent(10)
+        XCTAssertEqual(logs.count, 1)
+        XCTAssertEqual(logs.first?.gateOutcome, .granted)
+        XCTAssertNotNil(logs.first?.gateLatencyMs)
+        XCTAssertNotNil(logs.first?.captureLatencyMs)
+    }
+
+    // MARK: - Denied path
+
+    func test_run_whenDenied_doesNotCapture_doesNotPresent_logsDenied() async {
+        let checker = StubChecker(.denied)
+        let ui = SpyUI()
+        let gate = PermissionsGate(checker: checker, permissionUI: ui)
+        let capture = SpyCapture(stub: makeStubScreenshot())
+        let logService = LocalLogService(capacity: 16)
+
+        var presented: [CapturedScreenshot] = []
+        let handler = HotkeyInvocationHandler(
+            permissionsGate: gate,
+            screenCaptureService: capture,
+            presentScreenshot: { presented.append($0) },
+            logService: logService
+        )
+
+        await handler.run()
+
+        let targets = await capture.observedTargets()
+        XCTAssertTrue(targets.isEmpty)
+        XCTAssertTrue(presented.isEmpty)
+
+        let logs = await logService.recent(10)
+        XCTAssertEqual(logs.count, 1)
+        XCTAssertEqual(logs.first?.gateOutcome, .denied)
+        XCTAssertNotNil(logs.first?.errorDescription)
+
+        // The gate still surfaces the UI on missing permission.
+        let shown = await ui.shownKinds
+        XCTAssertEqual(shown, [.screenRecording])
+    }
+
+    // MARK: - Capture failure path
+
+    func test_run_whenCaptureFails_logsErroredOutcome() async {
+        let checker = StubChecker(.granted)
+        let ui = SpyUI()
+        let gate = PermissionsGate(checker: checker, permissionUI: ui)
+        let capture = SpyCapture(stub: makeStubScreenshot())
+        await capture.setError(ScreenCaptureError.captureFailed("simulated"))
+
+        let logService = LocalLogService(capacity: 16)
+
+        var presented: [CapturedScreenshot] = []
+        let handler = HotkeyInvocationHandler(
+            permissionsGate: gate,
+            screenCaptureService: capture,
+            presentScreenshot: { presented.append($0) },
+            logService: logService
+        )
+
+        await handler.run()
+
+        XCTAssertTrue(presented.isEmpty)
+        let logs = await logService.recent(10)
+        XCTAssertEqual(logs.count, 1)
+        XCTAssertEqual(logs.first?.gateOutcome, .errored)
+        XCTAssertEqual(logs.first?.errorDescription, "captureFailed(\"simulated\")")
+    }
+}

--- a/TAELMacAgent/TAELMacAgentTests/HotkeyHandlerTests.swift
+++ b/TAELMacAgent/TAELMacAgentTests/HotkeyHandlerTests.swift
@@ -108,6 +108,7 @@ final class HotkeyHandlerTests: XCTestCase {
         let logs = await logService.recent(10)
         XCTAssertEqual(logs.count, 1)
         XCTAssertEqual(logs.first?.gateOutcome, .denied)
+        XCTAssertNil(logs.first?.gateLatencyMs)
         XCTAssertNotNil(logs.first?.errorDescription)
 
         // The gate still surfaces the UI on missing permission.
@@ -140,6 +141,7 @@ final class HotkeyHandlerTests: XCTestCase {
         let logs = await logService.recent(10)
         XCTAssertEqual(logs.count, 1)
         XCTAssertEqual(logs.first?.gateOutcome, .errored)
+        XCTAssertNotNil(logs.first?.gateLatencyMs)
         XCTAssertEqual(logs.first?.errorDescription, "captureFailed(\"simulated\")")
     }
 }

--- a/TAELMacAgent/project.yml
+++ b/TAELMacAgent/project.yml
@@ -38,10 +38,6 @@ targets:
           - "Resources/TAELMacAgent.entitlements"
     resources:
       - path: TAELMacAgent/Resources/Assets.xcassets
-    info:
-      path: TAELMacAgent/Resources/Info.plist
-    entitlements:
-      path: TAELMacAgent/Resources/TAELMacAgent.entitlements
     settings:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: ai.tael.macagent

--- a/TAELMacAgent/project.yml
+++ b/TAELMacAgent/project.yml
@@ -8,6 +8,11 @@ options:
   generateEmptyDirectories: false
   defaultConfig: Debug
 
+packages:
+  KeyboardShortcuts:
+    url: https://github.com/sindresorhus/KeyboardShortcuts
+    from: "2.0.0"
+
 settings:
   base:
     # Swift language *mode* (not toolchain version). Xcode's
@@ -31,6 +36,8 @@ targets:
     type: application
     platform: macOS
     deploymentTarget: "14.0"
+    dependencies:
+      - package: KeyboardShortcuts
     sources:
       - path: TAELMacAgent
         excludes:

--- a/TAEL_AI_mac_agent_build_plan_v0_2.md
+++ b/TAEL_AI_mac_agent_build_plan_v0_2.md
@@ -38,7 +38,6 @@ global hotkey -> PermissionsGate -> SCScreenshotManager -> NSPanel HUD with scre
 
 If the app cannot prove hotkey-to-screenshot by day 5, stop and diagnose before adding more scope.
 
-
 ### 1.1 v0.2 implementation freeze amendments
 
 These amendments are locked before repo creation:
@@ -53,7 +52,6 @@ These amendments are locked before repo creation:
 - Represent executable actions as structured executable + argv arrays, not raw shell strings.
 - Track context size, token estimates, and latency from the first planner integration.
 - Keep product naming unresolved until after the technical heartbeat works.
-
 
 ---
 
@@ -2417,7 +2415,6 @@ Mitigation:
 - no consumer productivity sprawl.
 
 ---
-
 
 ## 23. v0.2 implementation amendments before coding
 

--- a/TAEL_AI_mac_agent_build_plan_v0_3.md
+++ b/TAEL_AI_mac_agent_build_plan_v0_3.md
@@ -38,7 +38,6 @@ global hotkey -> PermissionsGate -> SCScreenshotManager -> NSPanel HUD with scre
 
 If the app cannot prove hotkey-to-screenshot by day 5, stop and diagnose before adding more scope.
 
-
 ### 1.1 v0.3 implementation freeze amendments
 
 These amendments are locked before repo creation:
@@ -58,7 +57,6 @@ These amendments are locked before repo creation:
 - Week 1 `PermissionsChecker` implements Screen Recording only. Accessibility and Microphone may exist as enum placeholders, but they are not real checks until their milestones.
 - `PermissionsGate` uses a tokenized closure boundary: protected services accept a `PermissionGrant`, not casual public calls.
 - First commit is only the native macOS menubar scaffold plus policy docs. Screenshot capture starts after the scaffold commit.
-
 
 ---
 
@@ -2446,7 +2444,6 @@ Mitigation:
 
 ---
 
-
 ## 23. v0.3 implementation amendments before coding
 
 ### 23.1 Deployment target
@@ -2688,7 +2685,6 @@ Use `dev.git.commit_preview` for Skill 3. The user thinks “commit this.” The
 
 ---
 
-
 ### 23.10 ScreenCaptureKit implementation notes for Week 1
 
 For macOS 14.0+, the Week 1 screenshot service uses:
@@ -2871,7 +2867,6 @@ tael-mac-agent
 ```
 
 Do not use `tael-ai` for the prototype repo. `tael-ai` is reserved for possible umbrella website, docs, backend, and brand assets later.
-
 
 ## 24. Final build checklist
 

--- a/TODO_FOR_OZZY.md
+++ b/TODO_FOR_OZZY.md
@@ -80,3 +80,48 @@ These are *not* PR 1 problems but Ozzy-side decisions that will land soon:
   vs hand-rolled. PR 2 will need to add it via SPM.
 - [ ] Decide on a HUD design language. PR 1 ships an intentionally
   ugly placeholder.
+
+## PR-3 follow-up items from PR #18 review
+
+The 5-agent review of PR #18 surfaced these gaps. They were
+deliberately not bundled into PR 2 because each one either
+exceeds Week 1 scope, touches behavior the v0.3 §23.4 acceptance
+test does not require, or is a test-quality improvement that
+adds value without blocking the heartbeat. Pick them up in PR 3
+or as small follow-ups — none of them are urgent in isolation.
+
+- [ ] **User-facing error HUD on capture failure.**
+  Today `HotkeyInvocationHandler.run()` writes an `InvocationLog`
+  row and `os.log` line on capture failure, then returns silently.
+  v0.3 §23.4 only requires "does not crash," but the UX intent of
+  the heartbeat is feedback. Add an `HUDErrorView(message:)` and a
+  `presentError: (String) -> Void` closure on the handler, parallel
+  to `presentScreenshot`. Wire it from `AppDelegate`. Source: `silent-failure-hunter` review of PR #18.
+- [ ] **Hotkey closure teardown race.**
+  In `AppDelegate.swift:51-66` the hotkey closure early-returns
+  silently if any of `permissionsGate`, `screenCaptureService`,
+  `hudController`, `logService` is nil — only happens during
+  `applicationWillTerminate` race. Add at minimum
+  `Self.log.error("Hotkey fired but app state unavailable")` in the
+  guard's `else`. Source: `silent-failure-hunter` review of PR #18.
+- [ ] **Concurrent invocation guard.**
+  Two rapid hotkey presses spawn two concurrent `Task { await
+  handler.run() }` blocks. The slower one wins the HUD. If
+  invocation #1 succeeds late and #2 fails fast, the user sees
+  invocation #1's screenshot with no signal that the most recent
+  press failed. Add an in-flight token on the handler (or
+  `HotkeyManager` debounce). Source: `silent-failure-hunter` IMPORTANT
+  4 + `pr-test-analyzer` #7 from PR #18 review.
+- [ ] **Test: deterministic-clock latency assertions.**
+  `HotkeyHandlerTests` currently asserts `XCTAssertNotNil` on
+  `gateLatencyMs` / `captureLatencyMs`. Inject a deterministic
+  `now: () -> Date` (the handler already accepts one) and assert
+  exact ms values, ordering (`gateLatencyMs >= 0`,
+  `gateLatencyMs + captureLatencyMs <= elapsed`), and units
+  (regression-proof against a missing `* 1000`). Source:
+  `pr-test-analyzer` #2.
+- [ ] **Test: `.notImplemented` → `.restricted` mapping.**
+  `HotkeyInvocationHandler.swift` maps `PermissionError.notImplemented`
+  to `gateOutcome = .restricted`. No test exercises this branch.
+  Add a stub gate that throws `.notImplemented` and assert the
+  outcome is `.restricted`. Source: `pr-test-analyzer` #1.

--- a/TODO_FOR_OZZY.md
+++ b/TODO_FOR_OZZY.md
@@ -53,6 +53,7 @@ the pain if these are not resolved.
   the project was not compiled here. Source files follow the v0.3 layout
   and the `PermissionsGate` tokenized pattern, but a real Xcode build
   on macOS 14.0+ is the only ground truth. To verify:
+
   ```bash
   xcodebuild -project TAELMacAgent/TAELMacAgent.xcodeproj \
              -scheme TAELMacAgent \
@@ -64,6 +65,7 @@ the pain if these are not resolved.
              -destination 'platform=macOS' \
              test
   ```
+
   Expected: clean build, all `TAELMacAgentTests` pass, app launches as a
   menubar utility, Quit menu works.
 

--- a/docs/Architecture.md
+++ b/docs/Architecture.md
@@ -7,7 +7,7 @@ sections 8 and 13.
 
 ## What exists today
 
-```
+```text
 TAELMacAgent (menubar app, native macOS)
 ├── App
 │   ├── TAELMacAgentApp.swift     SwiftUI App entry
@@ -73,7 +73,7 @@ boundary**, not a polite convention.
 
 ## Week 1 heartbeat (target, not yet wired)
 
-```
+```text
 global hotkey                                                (HotkeyManager)
   → PermissionsGate.withPermission(.screenRecording) { grant in
       → SCScreenshotManager.captureImage(contentFilter:configuration:)

--- a/docs/ManualTestChecklist.md
+++ b/docs/ManualTestChecklist.md
@@ -41,43 +41,51 @@ when PR 2 lands.
 
 ## PR 2 — Week 1 heartbeat manual cases
 
-PR-2.1 First-launch Screen Recording prompt
+### PR-2.1 First-launch Screen Recording prompt
+
 - Quit TAEL if running.
 - `make tcc-reset` to clear ai.tael.macagent's TCC entries.
 - `make run`.
 - Press ⌘⇧T while Terminal is focused.
 - Expected: PermissionGateView appears with "TAEL needs Screen Recording permission" and "Open System Settings" / "Cancel" buttons.
 
-PR-2.2 Cancel button dismisses the gate
+### PR-2.2 Cancel button dismisses the gate
+
 - From PR-2.1's gate, click "Cancel".
 - Expected: panel disappears within ~100ms, no crash.
 
-PR-2.3 Granted path captures and renders
+### PR-2.3 Granted path captures and renders
+
 - Click "Open System Settings" in the gate, grant Screen Recording for TAELMacAgent, quit/relaunch TAEL.
 - Press ⌘⇧T.
 - Expected: HUD appears within ~500ms showing the cursor display's screenshot at max 720x480 with caption "Captured WIDTHxHEIGHT — cursor display".
 - Expected: HUD does not steal focus from Terminal/VS Code/Cursor.
 
-PR-2.4 Multi-monitor — cursor display selection
+### PR-2.4 Multi-monitor — cursor display selection
+
 - With two displays, move the cursor to the secondary display.
 - Press ⌘⇧T.
 - Expected: HUD shows the secondary display's content, caption says "cursor display".
 
-PR-2.5 Multi-monitor — main display fallback
+### PR-2.5 Multi-monitor — main display fallback
+
 - Disconnect or disable the secondary display while the cursor was on it (edge case; requires a hotplug or display-arrangement change).
 - Press ⌘⇧T.
 - Expected: HUD shows the main display, caption says "main display (fallback)".
 
-PR-2.6 Full-screen app
+### PR-2.6 Full-screen app
+
 - Make a Terminal or VS Code window full-screen.
 - Press ⌘⇧T.
 - Expected: HUD appears as an overlay; full-screen app stays focused; HUD shows the captured screenshot.
 
-PR-2.7 No screenshot persistence
+### PR-2.7 No screenshot persistence
+
 - After PR-2.3, check `~/Library/Application Support/TAELMacAgent/` and the project root.
 - Expected: no PNG/JPEG files created. Screenshots are in-memory only.
 
-PR-2.8 Invocation log fields
+### PR-2.8 Invocation log fields
+
 - After several invocations, attach a debugger to TAELMacAgent and inspect `LocalLogService.recent()`.
 - Expected: each row has hotkeyTimestamp, gateOutcome, gateLatencyMs, captureLatencyMs, targetDescription. Granted-path rows have all four numeric fields populated.
 

--- a/docs/ManualTestChecklist.md
+++ b/docs/ManualTestChecklist.md
@@ -44,8 +44,8 @@ when PR 2 lands.
 ### PR-2.1 First-launch Screen Recording prompt
 
 - Quit TAEL if running.
-- `make tcc-reset` to clear ai.tael.macagent's TCC entries.
-- `make run`.
+- `scripts/reset-tcc-dev.sh` to clear ai.tael.macagent's TCC entries.
+- Open `TAELMacAgent/TAELMacAgent.xcodeproj` in Xcode and Run, or `xcodebuild -project TAELMacAgent/TAELMacAgent.xcodeproj -scheme TAELMacAgent -configuration Debug -destination 'platform=macOS' CODE_SIGNING_ALLOWED=NO build` then launch the built `.app`.
 - Press ⌘⇧T while Terminal is focused.
 - Expected: PermissionGateView appears with "TAEL needs Screen Recording permission" and "Open System Settings" / "Cancel" buttons.
 

--- a/docs/ManualTestChecklist.md
+++ b/docs/ManualTestChecklist.md
@@ -39,6 +39,48 @@ when PR 2 lands.
 | W1.11 | Press hotkey with cursor on a Cursor / VS Code window | Screenshot includes that window |
 | W1.12 | Inspect `LocalLogService` after several invocations | Each invocation has a row with hotkey ts, gate result, capture timing, target display metadata |
 
+## PR 2 — Week 1 heartbeat manual cases
+
+PR-2.1 First-launch Screen Recording prompt
+- Quit TAEL if running.
+- `make tcc-reset` to clear ai.tael.macagent's TCC entries.
+- `make run`.
+- Press ⌘⇧T while Terminal is focused.
+- Expected: PermissionGateView appears with "TAEL needs Screen Recording permission" and "Open System Settings" / "Cancel" buttons.
+
+PR-2.2 Cancel button dismisses the gate
+- From PR-2.1's gate, click "Cancel".
+- Expected: panel disappears within ~100ms, no crash.
+
+PR-2.3 Granted path captures and renders
+- Click "Open System Settings" in the gate, grant Screen Recording for TAELMacAgent, quit/relaunch TAEL.
+- Press ⌘⇧T.
+- Expected: HUD appears within ~500ms showing the cursor display's screenshot at max 720x480 with caption "Captured WIDTHxHEIGHT — cursor display".
+- Expected: HUD does not steal focus from Terminal/VS Code/Cursor.
+
+PR-2.4 Multi-monitor — cursor display selection
+- With two displays, move the cursor to the secondary display.
+- Press ⌘⇧T.
+- Expected: HUD shows the secondary display's content, caption says "cursor display".
+
+PR-2.5 Multi-monitor — main display fallback
+- Disconnect or disable the secondary display while the cursor was on it (edge case; requires a hotplug or display-arrangement change).
+- Press ⌘⇧T.
+- Expected: HUD shows the main display, caption says "main display (fallback)".
+
+PR-2.6 Full-screen app
+- Make a Terminal or VS Code window full-screen.
+- Press ⌘⇧T.
+- Expected: HUD appears as an overlay; full-screen app stays focused; HUD shows the captured screenshot.
+
+PR-2.7 No screenshot persistence
+- After PR-2.3, check `~/Library/Application Support/TAELMacAgent/` and the project root.
+- Expected: no PNG/JPEG files created. Screenshots are in-memory only.
+
+PR-2.8 Invocation log fields
+- After several invocations, attach a debugger to TAELMacAgent and inspect `LocalLogService.recent()`.
+- Expected: each row has hotkeyTimestamp, gateOutcome, gateLatencyMs, captureLatencyMs, targetDescription. Granted-path rows have all four numeric fields populated.
+
 ## TCC reset for clean re-test
 
 ```bash

--- a/docs/Week1Heartbeat.md
+++ b/docs/Week1Heartbeat.md
@@ -4,7 +4,7 @@
 
 The Week 1 heartbeat is the **only thing** Week 1 has to prove.
 
-```
+```text
 global hotkey
   → PermissionsGate
   → SCScreenshotManager.captureImage(contentFilter:configuration:)
@@ -102,7 +102,7 @@ AX work and starts in Week 2.
 
 The capture path **must** use:
 
-```
+```swift
 SCScreenshotManager.captureImage(contentFilter:configuration:)
 ```
 
@@ -111,7 +111,7 @@ overload is macOS 15.2+, and our deployment target is macOS 14.0+.
 
 ## What Week 1 explicitly excludes
 
-```
+```text
 No AI planner.
 No speech capture.
 No WhisperKit.

--- a/docs/Week1Heartbeat.md
+++ b/docs/Week1Heartbeat.md
@@ -1,5 +1,7 @@
 # Week 1 heartbeat
 
+> **Status (2026-04-26): heartbeat shipped in PR 2.** Hotkey ⌘⇧T → PermissionsGate.withPermission(.screenRecording) → SCScreenshotManager.captureImage → non-activating NSPanel HUD with the captured CGImage. See `docs/ManualTestChecklist.md` PR-2.* cases for verification.
+
 The Week 1 heartbeat is the **only thing** Week 1 has to prove.
 
 ```

--- a/docs/superpowers/plans/2026-04-25-pr1-cleanup.md
+++ b/docs/superpowers/plans/2026-04-25-pr1-cleanup.md
@@ -23,10 +23,12 @@
 - [ ] **Step 1: Verify the merge happened**
 
 Run:
+
 ```bash
 git fetch origin
 git log origin/develop --oneline | head -5
 ```
+
 Expected: the most recent commit on `origin/develop` is the merge commit from PR #14 (`Merge pull request #14 from ...`) sitting on top of the `0cc890b` review-addendum commit.
 
 - [ ] **Step 2: If not merged, stop and ask Ozzy to merge**
@@ -44,26 +46,32 @@ PR #14 must merge to `develop` before this cleanup PR makes sense — the cleanu
 - [ ] **Step 1: Switch to develop and pull**
 
 Run:
+
 ```bash
 git checkout develop
 git pull origin develop
 ```
+
 Expected: working tree clean, branch up to date.
 
 - [ ] **Step 2: Create the cleanup branch**
 
 Run:
+
 ```bash
 git checkout -b feature/pr1-cleanup
 ```
+
 Expected: `Switched to a new branch 'feature/pr1-cleanup'`.
 
 - [ ] **Step 3: Push the branch to set upstream**
 
 Run:
+
 ```bash
 git push -u origin feature/pr1-cleanup
 ```
+
 Expected: branch tracks `origin/feature/pr1-cleanup`.
 
 ---
@@ -73,6 +81,7 @@ Expected: branch tracks `origin/feature/pr1-cleanup`.
 ### Task 2: Rename `PermissionsCheckerProtocol` → `PermissionChecking`
 
 **Files:**
+
 - Modify: `TAELMacAgent/TAELMacAgent/Permissions/PermissionsChecker.swift`
 - Modify: `TAELMacAgent/TAELMacAgent/Permissions/PermissionsGate.swift`
 - Modify: `TAELMacAgent/TAELMacAgentTests/PermissionsGateTests.swift`
@@ -85,6 +94,7 @@ Expected: branch tracks `origin/feature/pr1-cleanup`.
 In `TAELMacAgent/TAELMacAgent/Permissions/PermissionsChecker.swift`:
 
 Replace:
+
 ```swift
 public protocol PermissionsCheckerProtocol: Sendable {
     func status(for kind: PermissionKind) async -> PermissionStatus
@@ -94,6 +104,7 @@ public final class PermissionsChecker: PermissionsCheckerProtocol {
 ```
 
 With:
+
 ```swift
 public protocol PermissionChecking: Sendable {
     func status(for kind: PermissionKind) async -> PermissionStatus
@@ -107,6 +118,7 @@ public final class PermissionsChecker: PermissionChecking {
 In `TAELMacAgent/TAELMacAgent/Permissions/PermissionsGate.swift`:
 
 Replace:
+
 ```swift
     private let checker: PermissionsCheckerProtocol
     private let permissionUI: PermissionGateUI
@@ -116,6 +128,7 @@ Replace:
 ```
 
 With:
+
 ```swift
     private let checker: PermissionChecking
     private let permissionUI: PermissionGateUI
@@ -129,11 +142,13 @@ With:
 In `TAELMacAgent/TAELMacAgentTests/PermissionsGateTests.swift`:
 
 Replace:
+
 ```swift
     private actor StubChecker: PermissionsCheckerProtocol {
 ```
 
 With:
+
 ```swift
     private actor StubChecker: PermissionChecking {
 ```
@@ -141,19 +156,23 @@ With:
 - [ ] **Step 4: Search for any straggling references**
 
 Run:
+
 ```bash
 grep -rn "PermissionsCheckerProtocol" TAELMacAgent/ docs/
 ```
+
 Expected: zero matches.
 
 - [ ] **Step 5: Build and test**
 
 Run:
+
 ```bash
 xcodebuild -project TAELMacAgent/TAELMacAgent.xcodeproj \
   -scheme TAELMacAgent -configuration Debug \
   -destination 'platform=macOS' CODE_SIGNING_ALLOWED=NO test
 ```
+
 Expected: BUILD SUCCEEDED, all 4 PermissionsGateTests pass.
 
 - [ ] **Step 6: Commit**
@@ -171,6 +190,7 @@ Ported from PR #15 dev-codex; mechanical refactor, no behavior change."
 ### Task 3: Rename `PermissionGateUI` → `PermissionGatePresenting` and `NoopPermissionGateUI` → `NoopPermissionGatePresenter`
 
 **Files:**
+
 - Modify: `TAELMacAgent/TAELMacAgent/Permissions/PermissionsGate.swift`
 - Modify: `TAELMacAgent/TAELMacAgent/HUD/HUDPanelController.swift`
 - Modify: `TAELMacAgent/TAELMacAgentTests/PermissionsGateTests.swift`
@@ -182,6 +202,7 @@ Ported from PR #15 dev-codex; mechanical refactor, no behavior change."
 In `TAELMacAgent/TAELMacAgent/Permissions/PermissionsGate.swift`:
 
 Replace:
+
 ```swift
 public protocol PermissionGateUI: Sendable {
     func showGate(for kind: PermissionKind) async
@@ -195,6 +216,7 @@ public struct NoopPermissionGateUI: PermissionGateUI {
 ```
 
 With:
+
 ```swift
 public protocol PermissionGatePresenting: Sendable {
     func showGate(for kind: PermissionKind) async
@@ -208,6 +230,7 @@ public struct NoopPermissionGatePresenter: PermissionGatePresenting {
 ```
 
 Then in the same file, replace:
+
 ```swift
     private let permissionUI: PermissionGateUI
 
@@ -218,6 +241,7 @@ Then in the same file, replace:
 ```
 
 With:
+
 ```swift
     private let permissionUI: PermissionGatePresenting
 
@@ -232,11 +256,13 @@ With:
 In `TAELMacAgent/TAELMacAgent/HUD/HUDPanelController.swift`:
 
 Replace:
+
 ```swift
 final class HUDPanelController: NSObject, PermissionGateUI {
 ```
 
 With:
+
 ```swift
 final class HUDPanelController: NSObject, PermissionGatePresenting {
 ```
@@ -244,6 +270,7 @@ final class HUDPanelController: NSObject, PermissionGatePresenting {
 Also update the doc comment header on the same file:
 
 Replace:
+
 ```swift
 //  Owns the non-activating NSPanel that hosts the HUD. Implements
 //  `PermissionGateUI` so `PermissionsGate` can route missing-permission
@@ -251,6 +278,7 @@ Replace:
 ```
 
 With:
+
 ```swift
 //  Owns the non-activating NSPanel that hosts the HUD. Implements
 //  `PermissionGatePresenting` so `PermissionsGate` can route missing-
@@ -262,11 +290,13 @@ With:
 In `TAELMacAgent/TAELMacAgentTests/PermissionsGateTests.swift`:
 
 Replace:
+
 ```swift
     private actor SpyUI: PermissionGateUI {
 ```
 
 With:
+
 ```swift
     private actor SpyUI: PermissionGatePresenting {
 ```
@@ -274,9 +304,11 @@ With:
 - [ ] **Step 4: Search for stragglers**
 
 Run:
+
 ```bash
 grep -rn "PermissionGateUI\|NoopPermissionGateUI" TAELMacAgent/ docs/
 ```
+
 Expected: zero matches.
 
 - [ ] **Step 5: Build and test**
@@ -286,6 +318,7 @@ xcodebuild -project TAELMacAgent/TAELMacAgent.xcodeproj \
   -scheme TAELMacAgent -configuration Debug \
   -destination 'platform=macOS' CODE_SIGNING_ALLOWED=NO test
 ```
+
 Expected: BUILD SUCCEEDED, all 4 PermissionsGateTests pass.
 
 - [ ] **Step 6: Commit**
@@ -306,6 +339,7 @@ naming symmetry. Ported from PR #15 dev-codex."
 ### Task 4: `PermissionsChecker` returns `.notDetermined` instead of `.denied` when preflight is false
 
 **Files:**
+
 - Modify: `TAELMacAgent/TAELMacAgent/Permissions/PermissionsChecker.swift`
 - Modify: `TAELMacAgent/TAELMacAgentTests/PermissionsGateTests.swift` (only if test names imply `.denied` semantics)
 
@@ -316,6 +350,7 @@ naming symmetry. Ported from PR #15 dev-codex."
 In `TAELMacAgent/TAELMacAgent/Permissions/PermissionsChecker.swift`:
 
 Replace:
+
 ```swift
     private func screenRecordingStatus() -> PermissionStatus {
         #if os(macOS)
@@ -339,6 +374,7 @@ Replace:
 ```
 
 With:
+
 ```swift
     private func screenRecordingStatus() -> PermissionStatus {
         #if os(macOS)
@@ -369,6 +405,7 @@ xcodebuild -project TAELMacAgent/TAELMacAgent.xcodeproj \
   -scheme TAELMacAgent -configuration Debug \
   -destination 'platform=macOS' CODE_SIGNING_ALLOWED=NO test
 ```
+
 Expected: BUILD SUCCEEDED, all 4 PermissionsGateTests pass. The `whenNotDetermined` test still exercises the new return value's gate path; the `whenDenied` test still uses an explicit `.denied` injection from the stub, so it continues to test the gate's `guard status == .granted` correctly.
 
 - [ ] **Step 3: Commit**
@@ -390,6 +427,7 @@ PR #15 dev-codex (semantic fix only, naming stays this PR's)."
 ### Task 5: Drop `PermissionGrant: Hashable` → `Equatable`
 
 **Files:**
+
 - Modify: `TAELMacAgent/TAELMacAgent/Permissions/PermissionsGate.swift`
 
 **Why:** Type-design-analyzer flagged: `Hashable` invites a `Set<PermissionGrant>` caching anti-pattern that the policy doc explicitly bans (don't "remember" grants). `Equatable` is enough for tests and error comparisons.
@@ -399,6 +437,7 @@ PR #15 dev-codex (semantic fix only, naming stays this PR's)."
 In `TAELMacAgent/TAELMacAgent/Permissions/PermissionsGate.swift`:
 
 Replace:
+
 ```swift
 public struct PermissionGrant: Sendable, Hashable {
     public let kind: PermissionKind
@@ -410,6 +449,7 @@ public struct PermissionGrant: Sendable, Hashable {
 ```
 
 With:
+
 ```swift
 public struct PermissionGrant: Sendable, Equatable {
     public let kind: PermissionKind
@@ -427,6 +467,7 @@ xcodebuild -project TAELMacAgent/TAELMacAgent.xcodeproj \
   -scheme TAELMacAgent -configuration Debug \
   -destination 'platform=macOS' CODE_SIGNING_ALLOWED=NO test
 ```
+
 Expected: BUILD SUCCEEDED, all tests pass. If a consumer relied on `Hashable`, the build will fail and the offending consumer should be reviewed (likely an unintentional `Set<PermissionGrant>`).
 
 - [ ] **Step 3: Commit**
@@ -447,6 +488,7 @@ sufficient for tests and PermissionError equality."
 ### Task 6: Throw `PermissionError.notImplemented(kind)` for unimplemented kinds (TDD)
 
 **Files:**
+
 - Modify: `TAELMacAgent/TAELMacAgent/Permissions/PermissionsGate.swift`
 - Modify: `TAELMacAgent/TAELMacAgentTests/PermissionsGateTests.swift`
 
@@ -487,6 +529,7 @@ In `TAELMacAgent/TAELMacAgentTests/PermissionsGateTests.swift`, add a new test m
 - [ ] **Step 2: Run the test and confirm it fails**
 
 Run:
+
 ```bash
 xcodebuild test \
   -project TAELMacAgent/TAELMacAgent.xcodeproj \
@@ -495,6 +538,7 @@ xcodebuild test \
   CODE_SIGNING_ALLOWED=NO \
   -only-testing:TAELMacAgentTests/PermissionsGateTests/test_withPermission_whenKindNotImplemented_throwsNotImplemented_andDoesNotShowGate
 ```
+
 Expected: FAIL — current code throws `.missing(.microphone)` and shows the gate UI, not `.notImplemented`.
 
 - [ ] **Step 3: Update `withPermission` to short-circuit unimplemented kinds**
@@ -502,6 +546,7 @@ Expected: FAIL — current code throws `.missing(.microphone)` and shows the gat
 In `TAELMacAgent/TAELMacAgent/Permissions/PermissionsGate.swift`:
 
 Replace:
+
 ```swift
     @discardableResult
     public func withPermission<T>(
@@ -520,6 +565,7 @@ Replace:
 ```
 
 With:
+
 ```swift
     @discardableResult
     public func withPermission<T>(
@@ -557,6 +603,7 @@ xcodebuild -project TAELMacAgent/TAELMacAgent.xcodeproj \
   -scheme TAELMacAgent -configuration Debug \
   -destination 'platform=macOS' CODE_SIGNING_ALLOWED=NO test
 ```
+
 Expected: BUILD SUCCEEDED, 5 PermissionsGateTests pass (4 existing + 1 new).
 
 - [ ] **Step 6: Commit**
@@ -579,6 +626,7 @@ case already existed in PermissionError but was unreachable."
 ### Task 7: Wire `PermissionGateView` Cancel button to `HUDPanelController.tearDown()`
 
 **Files:**
+
 - Modify: `TAELMacAgent/TAELMacAgent/HUD/PermissionGateView.swift`
 - Modify: `TAELMacAgent/TAELMacAgent/HUD/HUDPanelController.swift`
 
@@ -589,6 +637,7 @@ case already existed in PermissionError but was unreachable."
 In `TAELMacAgent/TAELMacAgent/HUD/PermissionGateView.swift`:
 
 Replace:
+
 ```swift
 struct PermissionGateView: View {
     let kind: PermissionKind
@@ -597,6 +646,7 @@ struct PermissionGateView: View {
 ```
 
 With:
+
 ```swift
 struct PermissionGateView: View {
     let kind: PermissionKind
@@ -606,6 +656,7 @@ struct PermissionGateView: View {
 ```
 
 Then replace:
+
 ```swift
                 Button("Cancel") {
                     NSApp.keyWindow?.close()
@@ -613,6 +664,7 @@ Then replace:
 ```
 
 With:
+
 ```swift
                 Button("Cancel") {
                     onCancel()
@@ -624,6 +676,7 @@ With:
 In `TAELMacAgent/TAELMacAgent/HUD/HUDPanelController.swift`:
 
 Replace:
+
 ```swift
     nonisolated func showGate(for kind: PermissionKind) async {
         await MainActor.run {
@@ -633,6 +686,7 @@ Replace:
 ```
 
 With:
+
 ```swift
     nonisolated func showGate(for kind: PermissionKind) async {
         await MainActor.run {
@@ -650,6 +704,7 @@ xcodebuild -project TAELMacAgent/TAELMacAgent.xcodeproj \
   -scheme TAELMacAgent -configuration Debug \
   -destination 'platform=macOS' CODE_SIGNING_ALLOWED=NO build
 ```
+
 Expected: BUILD SUCCEEDED.
 
 The "Show HUD (placeholder)" menu calls `showPlaceholder()` which uses `HUDView()`, not `PermissionGateView`, so no other call sites need updating.
@@ -661,6 +716,7 @@ xcodebuild -project TAELMacAgent/TAELMacAgent.xcodeproj \
   -scheme TAELMacAgent -configuration Debug \
   -destination 'platform=macOS' CODE_SIGNING_ALLOWED=NO test
 ```
+
 Expected: BUILD SUCCEEDED, all tests pass (no test for the SwiftUI button itself; manual verification follows in PR review).
 
 - [ ] **Step 5: Commit**
@@ -681,6 +737,7 @@ path through the controller's lifecycle."
 ### Task 8: Panel style mask back to v0.3 §23.11 spec
 
 **Files:**
+
 - Modify: `TAELMacAgent/TAELMacAgent/HUD/HUDPanelController.swift`
 
 **Why:** Comment-analyzer flagged: code uses `[.titled, .closable, .nonactivatingPanel, .utilityWindow, .hudWindow]` but v0.3 §23.11 mandates `[.nonactivatingPanel, .borderless]` plus explicit `isReleasedWhenClosed = false` and `collectionBehavior = [.canJoinAllSpaces, .fullScreenAuxiliary, .transient]`. Bring back to spec; the existing `.titled, .closable` was added presumably for the (now-broken) Cancel-button-via-titlebar path that Task 7 already fixed properly.
@@ -690,6 +747,7 @@ path through the controller's lifecycle."
 In `TAELMacAgent/TAELMacAgent/HUD/HUDPanelController.swift`:
 
 Replace:
+
 ```swift
     private func makePanel<Content: View>(content: Content) -> NSPanel {
         let host = NSHostingController(rootView: AnyView(content))
@@ -713,6 +771,7 @@ Replace:
 ```
 
 With:
+
 ```swift
     private func makePanel<Content: View>(content: Content) -> NSPanel {
         let host = NSHostingController(rootView: AnyView(content))
@@ -747,6 +806,7 @@ xcodebuild -project TAELMacAgent/TAELMacAgent.xcodeproj \
   -scheme TAELMacAgent -configuration Debug \
   -destination 'platform=macOS' CODE_SIGNING_ALLOWED=NO build
 ```
+
 Expected: BUILD SUCCEEDED. (No `.title` setter line because borderless panels don't render a titlebar.)
 
 - [ ] **Step 3: Run tests**
@@ -756,6 +816,7 @@ xcodebuild -project TAELMacAgent/TAELMacAgent.xcodeproj \
   -scheme TAELMacAgent -configuration Debug \
   -destination 'platform=macOS' CODE_SIGNING_ALLOWED=NO test
 ```
+
 Expected: all tests pass.
 
 - [ ] **Step 4: Commit**
@@ -778,6 +839,7 @@ the broken titlebar-Cancel path that Task 7 fixed properly."
 ### Task 9: `LocalLogService` overflow signal (TDD)
 
 **Files:**
+
 - Modify: `TAELMacAgent/TAELMacAgent/Logging/LocalLogService.swift`
 - Create: `TAELMacAgent/TAELMacAgentTests/LocalLogServiceTests.swift`
 
@@ -858,6 +920,7 @@ xcodebuild test \
   CODE_SIGNING_ALLOWED=NO \
   -only-testing:TAELMacAgentTests/LocalLogServiceTests
 ```
+
 Expected: FAIL — `droppedCount` doesn't exist on `LocalLogService`.
 
 - [ ] **Step 3: Update `LocalLogService` with `droppedCount` and `os_log` signal**
@@ -933,6 +996,7 @@ xcodebuild -project TAELMacAgent/TAELMacAgent.xcodeproj \
   -scheme TAELMacAgent -configuration Debug \
   -destination 'platform=macOS' CODE_SIGNING_ALLOWED=NO test
 ```
+
 Expected: BUILD SUCCEEDED, all tests pass (existing 5 + new 3 = 8 total).
 
 - [ ] **Step 6: Commit**
@@ -956,6 +1020,7 @@ clear() does NOT reset droppedCount; it's a session metric."
 ### Task 10: Fix `reset-tcc-dev.sh` `set -e` interaction with command substitution
 
 **Files:**
+
 - Modify: `scripts/reset-tcc-dev.sh`
 
 **Why:** Code-reviewer + silent-failure-hunter both flagged: with `set -euo pipefail`, the script aborts on the FIRST `tccutil` non-zero exit because `output=$("${cmd[@]}" 2>&1)` triggers `set -e`. Lines 73-87 (the benign-vs-real distinguishing logic) are dead code; the `Done.` on line 97 never prints either.
@@ -965,6 +1030,7 @@ clear() does NOT reset droppedCount; it's a session metric."
 In `scripts/reset-tcc-dev.sh`, find the loop body (around lines 67-87):
 
 Replace:
+
 ```bash
   echo "running:   ${cmd[*]}"
   # We capture combined output and the exit code so we can distinguish
@@ -990,6 +1056,7 @@ Replace:
 ```
 
 With:
+
 ```bash
   echo "running:   ${cmd[*]}"
   # We capture combined output and the exit code so we can distinguish
@@ -1020,17 +1087,21 @@ With:
 - [ ] **Step 2: Verify the script syntax**
 
 Run:
+
 ```bash
 bash -n scripts/reset-tcc-dev.sh && echo OK
 ```
+
 Expected: `OK` (no syntax errors).
 
 - [ ] **Step 3: Dry-run to confirm the loop iterates all services**
 
 Run:
+
 ```bash
 ./scripts/reset-tcc-dev.sh --dry-run
 ```
+
 Expected: prints "would run: ..." for all 5 services, no early exit.
 
 - [ ] **Step 4: Commit**
@@ -1055,6 +1126,7 @@ Found by pr-review-toolkit code-reviewer pass on PR #14."
 ### Task 11: Sync `ProtectedAPICallPolicy.md` and `Week1Heartbeat.md` snippets to current closure shape
 
 **Files:**
+
 - Modify: `docs/ProtectedAPICallPolicy.md`
 - Modify: `docs/Week1Heartbeat.md`
 
@@ -1063,9 +1135,11 @@ Found by pr-review-toolkit code-reviewer pass on PR #14."
 - [ ] **Step 1: Read both docs to find the stale snippets**
 
 Run:
+
 ```bash
 grep -n "@escaping\|CGImage" docs/ProtectedAPICallPolicy.md docs/Week1Heartbeat.md
 ```
+
 Expected: a handful of matches in each file.
 
 - [ ] **Step 2: Update `docs/ProtectedAPICallPolicy.md`**
@@ -1088,6 +1162,7 @@ Same pattern as Step 2: walk every code block and bring it in sync with the curr
 grep -n "@escaping\|CGImage\|PermissionsCheckerProtocol\|PermissionGateUI\|NoopPermissionGateUI" \
   docs/ProtectedAPICallPolicy.md docs/Week1Heartbeat.md docs/Architecture.md docs/PermissionNotes.md
 ```
+
 Expected: zero matches.
 
 - [ ] **Step 5: Commit**
@@ -1120,6 +1195,7 @@ xcodebuild -project TAELMacAgent/TAELMacAgent.xcodeproj \
   -scheme TAELMacAgent -configuration Debug \
   -destination 'platform=macOS' CODE_SIGNING_ALLOWED=NO clean test
 ```
+
 Expected: BUILD SUCCEEDED, all 8 tests pass (5 PermissionsGateTests + 3 LocalLogServiceTests).
 
 - [ ] **Step 2: Confirm the branch is ahead of develop with one commit per task**
@@ -1127,6 +1203,7 @@ Expected: BUILD SUCCEEDED, all 8 tests pass (5 PermissionsGateTests + 3 LocalLog
 ```bash
 git log origin/develop..HEAD --oneline
 ```
+
 Expected: 10 commits (Tasks 2–11), in order, conventional-commit format.
 
 - [ ] **Step 3: Push the branch**
@@ -1178,6 +1255,7 @@ Applies the 11 items from the pr-review-toolkit pass on PR #14 (see \`docs/PR1_r
 EOF
 )"
 ```
+
 Expected: PR URL printed.
 
 - [ ] **Step 5: Notify Ozzy in chat**

--- a/docs/superpowers/plans/2026-04-26-pr2-week1-heartbeat.md
+++ b/docs/superpowers/plans/2026-04-26-pr2-week1-heartbeat.md
@@ -25,6 +25,7 @@ git checkout develop && git pull origin develop && \
   git checkout -b feature/pr2-week1-heartbeat && \
   git push -u origin feature/pr2-week1-heartbeat
 ```
+
 Expected: `Switched to a new branch 'feature/pr2-week1-heartbeat'`, branch tracks origin.
 
 ---
@@ -34,6 +35,7 @@ Expected: `Switched to a new branch 'feature/pr2-week1-heartbeat'`, branch track
 ### Task 1: Add `KeyboardShortcuts` SPM dependency via XcodeGen
 
 **Files:**
+
 - Modify: `TAELMacAgent/project.yml`
 - Modify (regenerated): `TAELMacAgent/TAELMacAgent.xcodeproj/project.pbxproj`
 - Modify (created by Xcode/SPM resolve): `TAELMacAgent/TAELMacAgent.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved`
@@ -72,6 +74,7 @@ Then in the `targets.TAELMacAgent` block, add a `dependencies` key:
 ```bash
 command -v xcodegen >/dev/null && echo OK || brew install xcodegen
 ```
+
 Expected: `OK`, or `xcodegen` installed via Homebrew.
 
 - [ ] **Step 3: Regenerate `.xcodeproj`**
@@ -79,6 +82,7 @@ Expected: `OK`, or `xcodegen` installed via Homebrew.
 ```bash
 make xcodeproj
 ```
+
 Expected: XcodeGen prints `Created project at ...TAELMacAgent.xcodeproj`. The pbxproj will now include the package reference, product dependency, and Frameworks build phase entry.
 
 - [ ] **Step 4: Resolve SPM dependencies**
@@ -86,6 +90,7 @@ Expected: XcodeGen prints `Created project at ...TAELMacAgent.xcodeproj`. The pb
 ```bash
 xcodebuild -project TAELMacAgent/TAELMacAgent.xcodeproj -resolvePackageDependencies
 ```
+
 Expected: `Resolved source packages`. Creates/updates `Package.resolved`.
 
 - [ ] **Step 5: Build to confirm KeyboardShortcuts links cleanly**
@@ -95,6 +100,7 @@ xcodebuild -project TAELMacAgent/TAELMacAgent.xcodeproj \
   -scheme TAELMacAgent -configuration Debug \
   -destination 'platform=macOS' CODE_SIGNING_ALLOWED=NO build
 ```
+
 Expected: BUILD SUCCEEDED. No source code uses `KeyboardShortcuts` yet, but the link should succeed.
 
 - [ ] **Step 6: Commit**
@@ -119,6 +125,7 @@ Regenerated pbxproj via 'make xcodeproj' (XcodeGen)."
 ### Task 2: Define `DisplayScreenshotCapturing` protocol and conform `ScreenCaptureService`
 
 **Files:**
+
 - Modify: `TAELMacAgent/TAELMacAgent/Capture/ScreenCaptureService.swift`
 
 **Why:** the hotkey wire-up in Task 6 needs to be unit-testable, but the real `ScreenCaptureService` requires TCC Screen Recording grant. A thin protocol lets Task 7's tests inject a mock without touching ScreenCaptureKit. **Do NOT pull the type into a separate file** — keep it co-located with the service per the same file-locality principle that protects `PermissionGrant` from forgery (the protocol+default is the public surface; the implementation stays one read away).
@@ -180,6 +187,7 @@ xcodebuild -project TAELMacAgent/TAELMacAgent.xcodeproj \
   -scheme TAELMacAgent -configuration Debug \
   -destination 'platform=macOS' CODE_SIGNING_ALLOWED=NO test
 ```
+
 Expected: BUILD SUCCEEDED, all 8 existing tests still pass. The protocol extraction is a refactor — behavior is unchanged.
 
 - [ ] **Step 4: Commit**
@@ -201,6 +209,7 @@ Type stays co-located with the service per file-locality discipline."
 ### Task 3: Replace `notImplemented` stub with real `SCScreenshotManager` capture
 
 **Files:**
+
 - Modify: `TAELMacAgent/TAELMacAgent/Capture/ScreenCaptureService.swift`
 
 **Why:** ticket 8. Replace the stub body. The PR 2 outline comment in the file already describes the shape; this task fills it in.
@@ -349,6 +358,7 @@ xcodebuild -project TAELMacAgent/TAELMacAgent.xcodeproj \
   -scheme TAELMacAgent -configuration Debug \
   -destination 'platform=macOS' CODE_SIGNING_ALLOWED=NO test
 ```
+
 Expected: BUILD SUCCEEDED, all 8 existing tests still pass. The body change is not exercised by any current test (it's the production capture path).
 
 - [ ] **Step 6: Commit**
@@ -376,6 +386,7 @@ Manual verification via 'make run' after Task 6 wires the hotkey."
 ### Task 4: Add `KeyboardShortcuts.Name` extension
 
 **Files:**
+
 - Create: `TAELMacAgent/TAELMacAgent/Hotkey/HotkeyName.swift`
 
 **Why:** the KeyboardShortcuts API requires shortcut names declared as `KeyboardShortcuts.Name` static properties. Co-locate the name in its own small file under `Hotkey/` so it's findable.
@@ -423,6 +434,7 @@ xcodebuild -project TAELMacAgent/TAELMacAgent.xcodeproj \
   -scheme TAELMacAgent -configuration Debug \
   -destination 'platform=macOS' CODE_SIGNING_ALLOWED=NO build
 ```
+
 Expected: BUILD SUCCEEDED.
 
 - [ ] **Step 4: Commit**
@@ -441,6 +453,7 @@ via KeyboardShortcuts.onKeyDown."
 ### Task 5: Replace `HotkeyManager` placeholder with real registration
 
 **Files:**
+
 - Modify: `TAELMacAgent/TAELMacAgent/Hotkey/HotkeyManager.swift`
 
 **Why:** ticket 6. Currently `installPlaceholderBinding()` is a no-op; PR 2 wires it through `KeyboardShortcuts.onKeyDown(for:)`.
@@ -490,6 +503,7 @@ xcodebuild -project TAELMacAgent/TAELMacAgent.xcodeproj \
   -scheme TAELMacAgent -configuration Debug \
   -destination 'platform=macOS' CODE_SIGNING_ALLOWED=NO build
 ```
+
 Expected: BUILD SUCCEEDED. There's still a call site in `AppDelegate` to `installPlaceholderBinding()` that no longer exists — Task 6 fixes it. If you want a passing build between tasks, temporarily rename the call site too; otherwise commit Task 5 + Task 6 together.
 
 **Decision:** for cleaner per-task commits, keep `installPlaceholderBinding` as a deprecated alias that just calls `installBinding`. Replace Step 1's file with this version instead:
@@ -545,6 +559,7 @@ xcodebuild -project TAELMacAgent/TAELMacAgent.xcodeproj \
   -scheme TAELMacAgent -configuration Debug \
   -destination 'platform=macOS' CODE_SIGNING_ALLOWED=NO test
 ```
+
 Expected: 8 tests pass.
 
 - [ ] **Step 4: Commit**
@@ -568,6 +583,7 @@ commit's build green; removed when AppDelegate updates in Task 6."
 ### Task 6: Wire `AppDelegate` — hotkey → gate → capture → HUD + log
 
 **Files:**
+
 - Modify: `TAELMacAgent/TAELMacAgent/App/AppDelegate.swift`
 
 **Why:** ticket 9. This is the heartbeat itself. The closure assigned to `hotkeyManager.onTrigger` runs the gate, captures, presents to HUD, records a log row.
@@ -705,6 +721,7 @@ xcodebuild -project TAELMacAgent/TAELMacAgent.xcodeproj \
   -scheme TAELMacAgent -configuration Debug \
   -destination 'platform=macOS' CODE_SIGNING_ALLOWED=NO build
 ```
+
 Expected: BUILD SUCCEEDED, no deprecation warning. The change references `installBinding()` (Task 5) and a new `hudController.present(screenshot:)` method (added in Task 7).
 
 **Will fail at this point** — `HUDPanelController.present(screenshot:)` doesn't exist yet. That's expected; the next task adds it. **Do not commit Task 6 alone.** Commit Task 6 + Task 7 together OR add a stub `present(screenshot:)` to HUDPanelController in this commit and flesh it out in Task 7.
@@ -730,6 +747,7 @@ xcodebuild -project TAELMacAgent/TAELMacAgent.xcodeproj \
   -scheme TAELMacAgent -configuration Debug \
   -destination 'platform=macOS' CODE_SIGNING_ALLOWED=NO test
 ```
+
 Expected: 8 tests pass.
 
 - [ ] **Step 4: Commit**
@@ -759,6 +777,7 @@ as a stub; Task 7 fleshes out the real screenshot rendering."
 ### Task 7: HUD screenshot rendering
 
 **Files:**
+
 - Create: `TAELMacAgent/TAELMacAgent/HUD/HUDScreenshotView.swift`
 - Modify: `TAELMacAgent/TAELMacAgent/HUD/HUDPanelController.swift`
 
@@ -830,6 +849,7 @@ xcodebuild -project TAELMacAgent/TAELMacAgent.xcodeproj \
   -scheme TAELMacAgent -configuration Debug \
   -destination 'platform=macOS' CODE_SIGNING_ALLOWED=NO build
 ```
+
 Expected: BUILD SUCCEEDED.
 
 - [ ] **Step 4: Run tests**
@@ -839,6 +859,7 @@ xcodebuild -project TAELMacAgent/TAELMacAgent.xcodeproj \
   -scheme TAELMacAgent -configuration Debug \
   -destination 'platform=macOS' CODE_SIGNING_ALLOWED=NO test
 ```
+
 Expected: 8 tests pass.
 
 - [ ] **Step 5: Commit**
@@ -863,11 +884,13 @@ HUDPanelController.present(screenshot:) replaces the Task 6 stub."
 ### Task 8: Wire-up tests via `DisplayScreenshotCapturing` mock (TDD)
 
 **Files:**
+
 - Create: `TAELMacAgent/TAELMacAgentTests/HotkeyHandlerTests.swift`
 
 **Why:** the hotkey path orchestrates four collaborators (gate, capture service, HUD, log). Without tests, regressions in the wire-up only surface in manual testing. The `DisplayScreenshotCapturing` protocol from Task 2 makes this mockable. Tests live in their own file because they exercise a different surface than `PermissionsGateTests`.
 
 **Caveat:** `AppDelegate.handleHotkeyInvocation` is `private`. Two options:
+
 1. Make it `internal` and `@testable import` — simpler but expands the API.
 2. Extract the body into a free function or a small `HotkeyInvocationHandler` type that AppDelegate composes — testable in isolation, no privacy widening.
 
@@ -1148,6 +1171,7 @@ xcodebuild test \
   CODE_SIGNING_ALLOWED=NO \
   -only-testing:TAELMacAgentTests/HotkeyHandlerTests
 ```
+
 Expected: 3 tests pass.
 
 - [ ] **Step 5: Run the full suite**
@@ -1157,6 +1181,7 @@ xcodebuild -project TAELMacAgent/TAELMacAgent.xcodeproj \
   -scheme TAELMacAgent -configuration Debug \
   -destination 'platform=macOS' CODE_SIGNING_ALLOWED=NO test
 ```
+
 Expected: 11 tests pass (5 PermissionsGate + 3 LocalLogService + 3 HotkeyHandler).
 
 - [ ] **Step 6: Commit**
@@ -1185,6 +1210,7 @@ capture-failure (no present, log errored)."
 ### Task 9: Remove the `installPlaceholderBinding` deprecated alias
 
 **Files:**
+
 - Modify: `TAELMacAgent/TAELMacAgent/Hotkey/HotkeyManager.swift`
 
 **Why:** Task 5's deprecated alias was scaffolding for clean per-task commits. Now that `AppDelegate` calls `installBinding()` directly (Task 6), the alias is dead.
@@ -1205,6 +1231,7 @@ In `TAELMacAgent/TAELMacAgent/Hotkey/HotkeyManager.swift`, delete:
 ```bash
 grep -rn "installPlaceholderBinding" TAELMacAgent/
 ```
+
 Expected: zero matches.
 
 - [ ] **Step 3: Build and test**
@@ -1214,6 +1241,7 @@ xcodebuild -project TAELMacAgent/TAELMacAgent.xcodeproj \
   -scheme TAELMacAgent -configuration Debug \
   -destination 'platform=macOS' CODE_SIGNING_ALLOWED=NO test
 ```
+
 Expected: 11 tests pass, no warnings.
 
 - [ ] **Step 4: Commit**
@@ -1233,6 +1261,7 @@ Task 6 updated the AppDelegate call site. Both tasks have landed."
 ### Task 10: Update `ManualTestChecklist.md` and `Week1Heartbeat.md`
 
 **Files:**
+
 - Modify: `docs/ManualTestChecklist.md`
 - Modify: `docs/Week1Heartbeat.md`
 
@@ -1324,6 +1353,7 @@ xcodebuild -project TAELMacAgent/TAELMacAgent.xcodeproj \
   -scheme TAELMacAgent -configuration Debug \
   -destination 'platform=macOS' CODE_SIGNING_ALLOWED=NO clean test
 ```
+
 Expected: 11 tests pass.
 
 - [ ] **Step 2: Confirm the branch is ahead of develop**
@@ -1331,6 +1361,7 @@ Expected: 11 tests pass.
 ```bash
 git log origin/develop..HEAD --oneline
 ```
+
 Expected: 10 commits (Task 1 + Tasks 2–10), one per task, conventional-commit format.
 
 - [ ] **Step 3: Push**
@@ -1386,6 +1417,7 @@ Plan: \`docs/superpowers/plans/2026-04-26-pr2-week1-heartbeat.md\`. Codex-driven
 EOF
 )"
 ```
+
 Expected: PR URL printed. Notify Ozzy.
 
 ---
@@ -1395,12 +1427,14 @@ Expected: PR URL printed. Notify Ozzy.
 After writing the plan and before handing off:
 
 **1. Spec coverage:**
+
 - v0.3 §12.2 Week 1 deliverables: menubar app ✓ (PR 1), KeyboardShortcuts (Task 1), global hotkey works (Tasks 4–6), PermissionsChecker (PR 1), PermissionsGate (PR 1), Screen Recording gate (PR 1 + Task 6 wire-up), Week 1 screenshot target (Task 3 cursor + fallback), SCScreenshotManager.captureImage (Task 3), explicit width/height (Task 3 backingScaleFactor), NSPanel HUD displays image (Task 7). All covered.
 - v0.3 §23.5 first-13 tickets: 6 (KeyboardShortcuts) → Tasks 1, 4, 5; 8 (ScreenCaptureService real) → Task 3; 9 (wire-up) → Task 6; 10 (HUD render) → Task 7; 11 (InvocationLog) → Task 6 wire + records via logService. All covered.
 
 **2. Placeholder scan:** No "TBD", "implement later", "add appropriate error handling" patterns. Each step has concrete code or commands.
 
 **3. Type consistency:**
+
 - `DisplayScreenshotCapturing` is the protocol name in Tasks 2, 3, 6, 8. ✓
 - `KeyboardShortcuts.Name.toggleTAEL` declared in Task 4, used in Task 5. ✓
 - `HotkeyInvocationHandler` introduced in Task 8 (extraction); `AppDelegate.handleHotkeyInvocation` from Task 6 is replaced by the handler — Task 8 explicitly removes it. ✓


### PR DESCRIPTION
## Summary

Ships the Week 1 heartbeat per v0.3 §1: `global hotkey → PermissionsGate → SCScreenshotManager → non-activating NSPanel HUD with screenshot PNG`.

Plan: `docs/superpowers/plans/2026-04-26-pr2-week1-heartbeat.md`. Codex-driven where the sandbox allowed; maestro-driven for SPM dep resolution and PR creation.

## What's in

- **KeyboardShortcuts SPM package** registered via XcodeGen (`project.yml`)
- **Real `SCScreenshotManager.captureImage(contentFilter:configuration:)`** capture with cursor-display resolution + main-display fallback (v0.3 §23.2)
- **`DisplayScreenshotCapturing` protocol** so the wire-up is unit-testable without TCC
- **`HotkeyInvocationHandler`** extracted from AppDelegate (testable struct)
- **`HUDScreenshotView`** rendering CGImage at max 720×480, aspect ratio preserved, caption with dimensions + target + timestamp
- **`InvocationLog`** rows recorded per invocation: gate outcome, gate latency, capture latency, target description, error description on failure
- **3 new tests** (`HotkeyHandlerTests`) covering granted / denied / capture-failure paths
- **8 new manual test cases** in `docs/ManualTestChecklist.md` (PR-2.1 through PR-2.8)
- **xcodegen idempotency fix** (extra commit `fd9283d`): the `info:` / `entitlements:` blocks in `project.yml` were destructive — `make xcodeproj` clobbered the curated Info.plist (`LSUIElement`, `NSScreenCaptureUsageDescription`) and the sandbox-off entitlement. `settings.base` already wires `INFOPLIST_FILE` and `CODE_SIGN_ENTITLEMENTS`, so the blocks were redundant. Dropped them; xcodegen no longer touches those files.

## Known Swift-6 warning

`HotkeyInvocationHandler.swift:42` — sending non-Sendable closure into `PermissionsGate.withPermission`. Informational under current Swift 5 language mode. Adding `@Sendable` to the gate's signature would break `PermissionsGateTests` (the existing tests mutate `var` counters from inside the closure). Defer the `@Sendable` + test refactor to the Swift 6 migration PR.

## Test plan

- [x] `xcodebuild ... clean test` — 11 tests, 0 failures (5 PermissionsGate + 3 LocalLogService + 3 HotkeyHandler)
- [ ] Manual PR-2.1 (first-launch Screen Recording prompt)
- [ ] Manual PR-2.2 (Cancel dismisses gate)
- [ ] Manual PR-2.3 (granted path captures and renders)
- [ ] Manual PR-2.4 (multi-monitor cursor display)
- [ ] Manual PR-2.5 (multi-monitor main fallback)
- [ ] Manual PR-2.6 (full-screen app)
- [ ] Manual PR-2.7 (no screenshot persistence)
- [ ] Manual PR-2.8 (InvocationLog fields populated)

## Out of scope

- AX tree (Week 2)
- Voice capture / WhisperKit (Week 3)
- Planner adapter (Week 4)
- Safe executor (Week 5)
- Skill matcher / hardcoded skills (Weeks 6–7)
- User-rebindable hotkey (post-PR 2)
- Disk-persisted invocation log (after executor lands)

🤖 Generated with [Claude Code](https://claude.com/claude-code)