### PR TITLE
feat: stabilize alpha context and packaging

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -8,12 +8,12 @@
 
 - [ ] Inside the v0.3 milestone scope (no scope creep)
 - [ ] No protected macOS API call bypasses `PermissionsGate`
-- [ ] Week 1 only: Screen Recording is the only real permission check
 - [ ] Screenshot path uses `SCScreenshotManager.captureImage(contentFilter:configuration:)`
       (not `captureImage(in:)`) when applicable
 - [ ] No screenshot, audio, or transcript persisted to disk unless the
       milestone explicitly added it
 - [ ] No new third-party package without an entry in `docs/Architecture.md`
+- [ ] Claude review checkpoint completed before merge to `develop`
 
 ## Permissions impact
 
@@ -29,6 +29,7 @@
 - [ ] `xcodebuild ... test` passes
 - [ ] App launches as menubar utility and quits cleanly from menu
 - [ ] Manual checks from `docs/ManualTestChecklist.md` relevant to this PR
+- [ ] For release changes: `docs/AlphaReleaseChecklist.md` is updated or confirmed unchanged
 
 ## Out of scope / follow-ups
 
@@ -36,14 +37,12 @@
 
 ## Risk
 
-- [ ] Low — purely additive, behind a feature
-- [ ] Medium — touches PermissionsGate / capture path
-- [ ] High — touches signing, entitlements, or executor
+- [ ] Low: purely additive, behind a feature
+- [ ] Medium: touches PermissionsGate, capture path, or AX metadata
+- [ ] High: touches signing, entitlements, release packaging, or executor
 
 ## Screenshots / recordings
 
 <!-- Optional. Drag in a HUD screenshot or short clip for UI changes. -->
 
 ---
-
-🤖 Generated with [Claude Code](https://claude.com/claude-code)

--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,7 @@ help:
 	@echo "  make run             Build and launch the app"
 	@echo "  make clean           Clean build artifacts"
 	@echo "  make xcodeproj       Regenerate .xcodeproj from project.yml (requires xcodegen)"
+	@echo "  make package-alpha   Build, notarize, and staple internal alpha DMG"
 	@echo "  make tcc-reset       Reset TCC entries for ai.tael.macagent (dev only)"
 	@echo ""
 	@echo "Requirements: macOS 14.0+, Xcode 15.3+. See TODO_FOR_OZZY.md."
@@ -47,6 +48,10 @@ xcodeproj:
 	    exit 1; \
 	}
 	cd TAELMacAgent && xcodegen generate
+
+.PHONY: package-alpha
+package-alpha:
+	./scripts/package-alpha-dmg.sh
 
 .PHONY: tcc-reset
 tcc-reset:

--- a/README.md
+++ b/README.md
@@ -10,30 +10,30 @@ freeze in [`TAEL_AI_mac_agent_build_plan_v0_3.md`](TAEL_AI_mac_agent_build_plan_
 
 ## Status
 
-PR 1 scope: native macOS menubar scaffold + Week 1 policy/docs.
-
-What works today:
+Current internal alpha track:
 
 - App launches as a native macOS menubar utility.
 - Stable bundle ID `ai.tael.macagent`, deployment target macOS 14.0+.
-- Quit cleanly from menubar.
-- Permissions boundary types (`PermissionKind`, `PermissionStatus`,
-  `PermissionError`, `PermissionGrant`) are in place.
+- Global hotkey `Command-Shift-T` runs the heartbeat.
 - `PermissionsGate` enforces a tokenized closure boundary for protected APIs.
-- `PermissionsChecker` v0 reports Screen Recording status only.
-- `HUDPanelController` placeholder (non-activating `NSPanel`).
-- `ScreenCaptureService` exists as a typed stub that requires a
-  `PermissionGrant`; the real `SCScreenshotManager` call lands in PR 2.
+- Screen Recording and Accessibility permission checks are active.
+- `ScreenCaptureService` captures the display containing the cursor with
+  `SCScreenshotManager.captureImage(contentFilter:configuration:)`.
+- HUD renders the captured screenshot and, when Accessibility is granted,
+  focused-window metadata.
+- `LocalLogService` keeps an in-memory invocation log only.
+- Internal alpha DMG packaging is scripted in `scripts/package-alpha-dmg.sh`,
+  but Developer ID certificate and notary credentials are local prerequisites.
 
-What is intentionally NOT in PR 1:
+Still intentionally deferred:
 
 - AI planner, speech capture, WhisperKit
-- AX tree, focused-window metadata
-- YAML skills, executor, clipboard / shell / AppleScript / CGEvent actions
+- AX tree dump beyond focused-window metadata
+- YAML skills, executor, clipboard, shell, AppleScript, CGEvent actions
 - Settings UI, polished onboarding
-- DMG packaging, Sparkle, analytics, token tracking
-- Screenshot persistence
-- Product naming / landing page
+- Sparkle updates, analytics, token tracking
+- Screenshot or AX context persistence
+- Public launch operations
 
 See [`docs/Week1Heartbeat.md`](docs/Week1Heartbeat.md) for the Week 1
 heartbeat and the Week 1 implementation ticket order.
@@ -80,21 +80,37 @@ tael-ai/
 ## Building
 
 ```bash
-open TAELMacAgent/TAELMacAgent.xcodeproj
+make xcodeproj
+make build
+make test
 ```
 
-In Xcode, select the `TAELMacAgent` scheme and press Run.
+For Xcode, open `TAELMacAgent/TAELMacAgent.xcodeproj`, select the
+`TAELMacAgent` scheme, and press Run.
 
 > Ad-hoc signing is **not** the intended dev path. TCC permissions are keyed
 > to bundle identity and signing requirements; unstable signing makes
 > permission debugging noisy. The real Team ID must be set before any
-> Screen Recording / TCC work — see TODO.
+> Screen Recording / TCC work. See TODO.
+
+## Alpha packaging
+
+Internal alpha packaging is manual DMG only:
+
+```bash
+DEVELOPER_ID_APPLICATION="Developer ID Application: OMER FARUK AKBEN (...)" \
+NOTARYTOOL_PROFILE="tael-notary" \
+VERSION="0.1.0-alpha.1" \
+./scripts/package-alpha-dmg.sh
+```
+
+See [`docs/AlphaReleaseChecklist.md`](docs/AlphaReleaseChecklist.md).
 
 ## Branches
 
-- `main` — frozen plan + scaffold
-- `dev-claude` — Maestro Claude development branch (this branch)
-- `dev-codex` — Codex development branch
+- `main` is the production/release branch.
+- `develop` is the integration branch.
+- `feature/*` and `codex/*` branches PR into `develop`.
 
 ## License
 

--- a/TAELMacAgent/TAELMacAgent.xcodeproj/project.pbxproj
+++ b/TAELMacAgent/TAELMacAgent.xcodeproj/project.pbxproj
@@ -7,28 +7,33 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		02E5172BAA7A3A56E9952C59 /* HUDContextBundleView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A7BCC0DD380BCA035E3BE982 /* HUDContextBundleView.swift */; };
 		0330637AAF26CC3C25DCD10F /* CapturedScreenshot.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6DEC30773055C5F4AE735610 /* CapturedScreenshot.swift */; };
 		033A279961698D88188A33AD /* MenuBarController.swift in Sources */ = {isa = PBXBuildFile; fileRef = EBD624AFDCE20EF4B613B9A4 /* MenuBarController.swift */; };
 		06ADDF6182CAEDB9CC8191F9 /* HotkeyHandlerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 600507D8811CFB057BB49AA4 /* HotkeyHandlerTests.swift */; };
-		354AC58980118264F0FF7B67 /* HotkeyManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11BA73F54C69186834610D30 /* HotkeyManagerTests.swift */; };
-		925C4AADEDDDF4182FB89AF8 /* PermissionsCheckerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3391ED18AB6186A614671A75 /* PermissionsCheckerTests.swift */; };
 		0B0660E9860988CD91DA599E /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB704571A9597F9AF9313D65 /* AppDelegate.swift */; };
 		1EFB0EA699153ADC53EA4286 /* LocalLogServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C654DA20715C3C6F29B9E6F4 /* LocalLogServiceTests.swift */; };
+		2677B0F4DC46B483FCF1080D /* AXService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6117FF021320036888C63298 /* AXService.swift */; };
 		2BAF280AA3FB18E55785FAD8 /* KeyboardShortcuts in Frameworks */ = {isa = PBXBuildFile; productRef = 271157EB2BA4172C872A7408 /* KeyboardShortcuts */; };
 		34F3D8094B35A969BEFEFE4A /* LocalLogService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F5C315999DFCC84BE675BE2 /* LocalLogService.swift */; };
 		3F34E0D14D96EB8D52BE71A0 /* TAELMacAgentApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 69DDCCAE89FD5A160E17AE49 /* TAELMacAgentApp.swift */; };
+		554AB7D253B393D4F08AB225 /* ContextBundleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 995C4E3E4317B367CAFEBBC2 /* ContextBundleTests.swift */; };
+		5825405C894EAB8C49D44D00 /* ContextBundle.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB6EB3B92EA975E182EE38D0 /* ContextBundle.swift */; };
 		5AD70596B8B5BEBD936F2F60 /* PermissionsGateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14306A2EBDA587DA5C4E6182 /* PermissionsGateTests.swift */; };
 		6AB4701304241B41166818BB /* HotkeyManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 917682B8FDBFE7C755263E19 /* HotkeyManager.swift */; };
 		6BA0CBE1B80E6592A9C6983A /* PermissionGateView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 422D881643EB42E6E96F6073 /* PermissionGateView.swift */; };
 		7A08515211A39DD11A6E370B /* PermissionsGate.swift in Sources */ = {isa = PBXBuildFile; fileRef = F46F76B62679E79E964F4EAE /* PermissionsGate.swift */; };
+		849C242625ED0EA22FB38890 /* HotkeyManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61EC8235844217BF59E50B3F /* HotkeyManagerTests.swift */; };
+		8791A773E3A54879EF035D27 /* FocusedWindowMetadata.swift in Sources */ = {isa = PBXBuildFile; fileRef = E68A1DD137DD5E5D8291D4FB /* FocusedWindowMetadata.swift */; };
 		8AC8665020F765D063A96609 /* HUDPanelController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9363E4D91044162835D20FAA /* HUDPanelController.swift */; };
 		9565442421E66D83C0B03CDF /* HotkeyName.swift in Sources */ = {isa = PBXBuildFile; fileRef = C96D7E9A9156DA07866B2574 /* HotkeyName.swift */; };
 		C3C9015E4F181F2FC2A056BB /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 3900941745D06B0194400E8E /* Assets.xcassets */; };
 		CACD72769410271CF6577CC0 /* InvocationLog.swift in Sources */ = {isa = PBXBuildFile; fileRef = A74AE945B8920595491B2B29 /* InvocationLog.swift */; };
 		CF17A6BDF21FD1B3F8690D13 /* PermissionError.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED47D03840F40871272ED13C /* PermissionError.swift */; };
+		CFA7CDEDCA4642C836A4892A /* HUDErrorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 15EBB8FD7CC491B54EAD7C32 /* HUDErrorView.swift */; };
 		D4D7892F3C39042079C92DEC /* PermissionsChecker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D36CFA939327054CE038538 /* PermissionsChecker.swift */; };
+		DB297417A946D0AEA311F7BE /* PermissionsCheckerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 42F84AD2F6F1FE9B0EA2B5B0 /* PermissionsCheckerTests.swift */; };
 		DF3BAB13D3897B30011FF8B2 /* HUDScreenshotView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 659ECE5A728C28C51E500F35 /* HUDScreenshotView.swift */; };
-		C6D0EFACE6A32A5B1339F60E /* HUDErrorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A366B091A2CF78B079314AE1 /* HUDErrorView.swift */; };
 		E22538B7BAFDD6DE67CD39A6 /* PermissionKind.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E3601A9D97DFCC20CB1B190 /* PermissionKind.swift */; };
 		EE4E5F822C40DF6233CBDD2A /* ScreenshotTarget.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6C80394C10DB95ACE8B23410 /* ScreenshotTarget.swift */; };
 		F213518191A0D0FBED62E67B /* ScreenCaptureService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 198A12FCDFC021700C887DC3 /* ScreenCaptureService.swift */; };
@@ -51,16 +56,17 @@
 		09182C33476D9D80D775700D /* TAELMacAgent.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = TAELMacAgent.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		14306A2EBDA587DA5C4E6182 /* PermissionsGateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PermissionsGateTests.swift; sourceTree = "<group>"; };
 		1469160F2705F009163C15E0 /* HUDView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HUDView.swift; sourceTree = "<group>"; };
+		15EBB8FD7CC491B54EAD7C32 /* HUDErrorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HUDErrorView.swift; sourceTree = "<group>"; };
 		198A12FCDFC021700C887DC3 /* ScreenCaptureService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScreenCaptureService.swift; sourceTree = "<group>"; };
 		1D36CFA939327054CE038538 /* PermissionsChecker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PermissionsChecker.swift; sourceTree = "<group>"; };
 		3900941745D06B0194400E8E /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		422D881643EB42E6E96F6073 /* PermissionGateView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PermissionGateView.swift; sourceTree = "<group>"; };
+		42F84AD2F6F1FE9B0EA2B5B0 /* PermissionsCheckerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PermissionsCheckerTests.swift; sourceTree = "<group>"; };
 		600507D8811CFB057BB49AA4 /* HotkeyHandlerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HotkeyHandlerTests.swift; sourceTree = "<group>"; };
-		11BA73F54C69186834610D30 /* HotkeyManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HotkeyManagerTests.swift; sourceTree = "<group>"; };
-		3391ED18AB6186A614671A75 /* PermissionsCheckerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PermissionsCheckerTests.swift; sourceTree = "<group>"; };
+		6117FF021320036888C63298 /* AXService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AXService.swift; sourceTree = "<group>"; };
+		61EC8235844217BF59E50B3F /* HotkeyManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HotkeyManagerTests.swift; sourceTree = "<group>"; };
 		639F88F50828EB01F823718B /* PermissionStatus.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PermissionStatus.swift; sourceTree = "<group>"; };
 		659ECE5A728C28C51E500F35 /* HUDScreenshotView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HUDScreenshotView.swift; sourceTree = "<group>"; };
-		A366B091A2CF78B079314AE1 /* HUDErrorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HUDErrorView.swift; sourceTree = "<group>"; };
 		69DDCCAE89FD5A160E17AE49 /* TAELMacAgentApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TAELMacAgentApp.swift; sourceTree = "<group>"; };
 		6C80394C10DB95ACE8B23410 /* ScreenshotTarget.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScreenshotTarget.swift; sourceTree = "<group>"; };
 		6DEC30773055C5F4AE735610 /* CapturedScreenshot.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CapturedScreenshot.swift; sourceTree = "<group>"; };
@@ -68,15 +74,19 @@
 		6F5C315999DFCC84BE675BE2 /* LocalLogService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalLogService.swift; sourceTree = "<group>"; };
 		917682B8FDBFE7C755263E19 /* HotkeyManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HotkeyManager.swift; sourceTree = "<group>"; };
 		9363E4D91044162835D20FAA /* HUDPanelController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HUDPanelController.swift; sourceTree = "<group>"; };
+		995C4E3E4317B367CAFEBBC2 /* ContextBundleTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContextBundleTests.swift; sourceTree = "<group>"; };
 		9A76044EF0F9B7BE7C3F5C00 /* TAELMacAgentTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = TAELMacAgentTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		A74AE945B8920595491B2B29 /* InvocationLog.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InvocationLog.swift; sourceTree = "<group>"; };
+		A7BCC0DD380BCA035E3BE982 /* HUDContextBundleView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HUDContextBundleView.swift; sourceTree = "<group>"; };
 		AB704571A9597F9AF9313D65 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		C654DA20715C3C6F29B9E6F4 /* LocalLogServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalLogServiceTests.swift; sourceTree = "<group>"; };
 		C778F76C2BA992BFF35FF455 /* HotkeyInvocationHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HotkeyInvocationHandler.swift; sourceTree = "<group>"; };
 		C96D7E9A9156DA07866B2574 /* HotkeyName.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HotkeyName.swift; sourceTree = "<group>"; };
+		E68A1DD137DD5E5D8291D4FB /* FocusedWindowMetadata.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FocusedWindowMetadata.swift; sourceTree = "<group>"; };
 		EBD624AFDCE20EF4B613B9A4 /* MenuBarController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MenuBarController.swift; sourceTree = "<group>"; };
 		ED47D03840F40871272ED13C /* PermissionError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PermissionError.swift; sourceTree = "<group>"; };
 		F46F76B62679E79E964F4EAE /* PermissionsGate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PermissionsGate.swift; sourceTree = "<group>"; };
+		FB6EB3B92EA975E182EE38D0 /* ContextBundle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContextBundle.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -94,10 +104,11 @@
 		1D955BDFBFFB1E992ABC4E95 /* TAELMacAgentTests */ = {
 			isa = PBXGroup;
 			children = (
+				995C4E3E4317B367CAFEBBC2 /* ContextBundleTests.swift */,
 				600507D8811CFB057BB49AA4 /* HotkeyHandlerTests.swift */,
-				11BA73F54C69186834610D30 /* HotkeyManagerTests.swift */,
+				61EC8235844217BF59E50B3F /* HotkeyManagerTests.swift */,
 				C654DA20715C3C6F29B9E6F4 /* LocalLogServiceTests.swift */,
-				3391ED18AB6186A614671A75 /* PermissionsCheckerTests.swift */,
+				42F84AD2F6F1FE9B0EA2B5B0 /* PermissionsCheckerTests.swift */,
 				14306A2EBDA587DA5C4E6182 /* PermissionsGateTests.swift */,
 			);
 			path = TAELMacAgentTests;
@@ -106,7 +117,8 @@
 		25F2B0347D98A8AADDF902E0 /* HUD */ = {
 			isa = PBXGroup;
 			children = (
-				A366B091A2CF78B079314AE1 /* HUDErrorView.swift */,
+				A7BCC0DD380BCA035E3BE982 /* HUDContextBundleView.swift */,
+				15EBB8FD7CC491B54EAD7C32 /* HUDErrorView.swift */,
 				9363E4D91044162835D20FAA /* HUDPanelController.swift */,
 				659ECE5A728C28C51E500F35 /* HUDScreenshotView.swift */,
 				1469160F2705F009163C15E0 /* HUDView.swift */,
@@ -152,7 +164,10 @@
 		99C93CFB96CF8F9301DF4757 /* Capture */ = {
 			isa = PBXGroup;
 			children = (
+				6117FF021320036888C63298 /* AXService.swift */,
 				6DEC30773055C5F4AE735610 /* CapturedScreenshot.swift */,
+				FB6EB3B92EA975E182EE38D0 /* ContextBundle.swift */,
+				E68A1DD137DD5E5D8291D4FB /* FocusedWindowMetadata.swift */,
 				198A12FCDFC021700C887DC3 /* ScreenCaptureService.swift */,
 				6C80394C10DB95ACE8B23410 /* ScreenshotTarget.swift */,
 			);
@@ -257,10 +272,12 @@
 				LastUpgradeCheck = 1430;
 				TargetAttributes = {
 					19B5206FF51EAAA5D9DD33BD = {
+						DevelopmentTeam = 4X8U3NCLQ8;
 						ProvisioningStyle = Automatic;
 					};
 					7BBF771A19B870A8BDB655E7 = {
-						DevelopmentTeam = "";
+						DevelopmentTeam = 4X8U3NCLQ8;
+						ProvisioningStyle = Automatic;
 					};
 				};
 			};
@@ -303,10 +320,14 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				2677B0F4DC46B483FCF1080D /* AXService.swift in Sources */,
 				0B0660E9860988CD91DA599E /* AppDelegate.swift in Sources */,
 				0330637AAF26CC3C25DCD10F /* CapturedScreenshot.swift in Sources */,
+				5825405C894EAB8C49D44D00 /* ContextBundle.swift in Sources */,
+				8791A773E3A54879EF035D27 /* FocusedWindowMetadata.swift in Sources */,
+				02E5172BAA7A3A56E9952C59 /* HUDContextBundleView.swift in Sources */,
+				CFA7CDEDCA4642C836A4892A /* HUDErrorView.swift in Sources */,
 				8AC8665020F765D063A96609 /* HUDPanelController.swift in Sources */,
-				C6D0EFACE6A32A5B1339F60E /* HUDErrorView.swift in Sources */,
 				DF3BAB13D3897B30011FF8B2 /* HUDScreenshotView.swift in Sources */,
 				F8A8B61233E0F29CD0725388 /* HUDView.swift in Sources */,
 				F6E2AD25AAD3F1AE6D0CA2A6 /* HotkeyInvocationHandler.swift in Sources */,
@@ -331,10 +352,11 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				554AB7D253B393D4F08AB225 /* ContextBundleTests.swift in Sources */,
 				06ADDF6182CAEDB9CC8191F9 /* HotkeyHandlerTests.swift in Sources */,
-				354AC58980118264F0FF7B67 /* HotkeyManagerTests.swift in Sources */,
+				849C242625ED0EA22FB38890 /* HotkeyManagerTests.swift in Sources */,
 				1EFB0EA699153ADC53EA4286 /* LocalLogServiceTests.swift in Sources */,
-				925C4AADEDDDF4182FB89AF8 /* PermissionsCheckerTests.swift in Sources */,
+				DB297417A946D0AEA311F7BE /* PermissionsCheckerTests.swift in Sources */,
 				5AD70596B8B5BEBD936F2F60 /* PermissionsGateTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -358,14 +380,10 @@
 				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
-				DEVELOPMENT_TEAM = 4X8U3NCLQ8;
 				ENABLE_USER_SCRIPT_SANDBOXING = YES;
 				GENERATE_INFOPLIST_FILE = NO;
 				INFOPLIST_FILE = TAELMacAgent/Resources/Info.plist;
-				LD_RUNPATH_SEARCH_PATHS = (
-					"$(inherited)",
-					"@executable_path/../Frameworks",
-				);
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 14.0;
 				PRODUCT_BUNDLE_IDENTIFIER = ai.tael.macagent;
 				PRODUCT_NAME = TAELMacAgent;
@@ -408,7 +426,7 @@
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				COPY_PHASE_STRIP = NO;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
-				DEVELOPMENT_TEAM = "";
+				DEVELOPMENT_TEAM = 4X8U3NCLQ8;
 				ENABLE_HARDENED_RUNTIME = YES;
 				ENABLE_NS_ASSERTIONS = NO;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
@@ -436,6 +454,8 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
+				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Apple Development";
+				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -486,7 +506,7 @@
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				COPY_PHASE_STRIP = NO;
 				DEBUG_INFORMATION_FORMAT = dwarf;
-				DEVELOPMENT_TEAM = "";
+				DEVELOPMENT_TEAM = 4X8U3NCLQ8;
 				ENABLE_HARDENED_RUNTIME = YES;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				ENABLE_TESTABILITY = YES;
@@ -525,14 +545,10 @@
 				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
-				DEVELOPMENT_TEAM = 4X8U3NCLQ8;
 				ENABLE_USER_SCRIPT_SANDBOXING = YES;
 				GENERATE_INFOPLIST_FILE = NO;
 				INFOPLIST_FILE = TAELMacAgent/Resources/Info.plist;
-				LD_RUNPATH_SEARCH_PATHS = (
-					"$(inherited)",
-					"@executable_path/../Frameworks",
-				);
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 14.0;
 				PRODUCT_BUNDLE_IDENTIFIER = ai.tael.macagent;
 				PRODUCT_NAME = TAELMacAgent;
@@ -544,6 +560,8 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
+				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Apple Development";
+				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				LD_RUNPATH_SEARCH_PATHS = (

--- a/TAELMacAgent/TAELMacAgent/App/AppDelegate.swift
+++ b/TAELMacAgent/TAELMacAgent/App/AppDelegate.swift
@@ -16,6 +16,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     private var hudController: HUDPanelController?
     private var permissionsGate: PermissionsGate?
     private var screenCaptureService: DisplayScreenshotCapturing?
+    private var focusedWindowReader: FocusedWindowReading?
     private var logService: LocalLogService?
 
     func applicationDidFinishLaunching(_ notification: Notification) {
@@ -30,6 +31,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             permissionUI: hudController
         )
         let screenCaptureService = ScreenCaptureService()
+        let focusedWindowReader = AXService()
         let hotkeyManager = HotkeyManager()
         let menuBarController = MenuBarController(
             onShowHUD: { [weak hudController] in
@@ -44,6 +46,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         self.hudController = hudController
         self.permissionsGate = permissionsGate
         self.screenCaptureService = screenCaptureService
+        self.focusedWindowReader = focusedWindowReader
         self.hotkeyManager = hotkeyManager
         self.menuBarController = menuBarController
 
@@ -55,6 +58,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             guard let self,
                   let permissionsGate = self.permissionsGate,
                   let screenCaptureService = self.screenCaptureService,
+                  let focusedWindowReader = self.focusedWindowReader,
                   let hudController = self.hudController,
                   let logService = self.logService else {
                 AppDelegate.log.error("Hotkey fired but app state unavailable; ignoring")
@@ -63,7 +67,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             let handler = HotkeyInvocationHandler(
                 permissionsGate: permissionsGate,
                 screenCaptureService: screenCaptureService,
+                focusedWindowReader: focusedWindowReader,
                 presentScreenshot: { shot in hudController.present(screenshot: shot) },
+                presentContext: { bundle in hudController.present(context: bundle) },
                 presentError: { msg in hudController.present(error: msg) },
                 logService: logService
             )

--- a/TAELMacAgent/TAELMacAgent/App/HotkeyInvocationHandler.swift
+++ b/TAELMacAgent/TAELMacAgent/App/HotkeyInvocationHandler.swift
@@ -13,7 +13,9 @@ import os.log
 struct HotkeyInvocationHandler {
     let permissionsGate: PermissionsGate
     let screenCaptureService: any DisplayScreenshotCapturing
+    let focusedWindowReader: (any FocusedWindowReading)?
     let presentScreenshot: (CapturedScreenshot) -> Void
+    let presentContext: ((ContextBundle) -> Void)?
     let presentError: (String) -> Void
     let logService: LocalLogService
     let now: () -> Date
@@ -22,7 +24,9 @@ struct HotkeyInvocationHandler {
     init(
         permissionsGate: PermissionsGate,
         screenCaptureService: any DisplayScreenshotCapturing,
+        focusedWindowReader: (any FocusedWindowReading)? = nil,
         presentScreenshot: @escaping (CapturedScreenshot) -> Void,
+        presentContext: ((ContextBundle) -> Void)? = nil,
         presentError: @escaping (String) -> Void = { _ in },
         logService: LocalLogService,
         now: @escaping () -> Date = Date.init,
@@ -30,7 +34,9 @@ struct HotkeyInvocationHandler {
     ) {
         self.permissionsGate = permissionsGate
         self.screenCaptureService = screenCaptureService
+        self.focusedWindowReader = focusedWindowReader
         self.presentScreenshot = presentScreenshot
+        self.presentContext = presentContext
         self.presentError = presentError
         self.logService = logService
         self.now = now
@@ -43,6 +49,7 @@ struct HotkeyInvocationHandler {
         let started = now()
         let gateStart = started
         var gateLatencyMs: Double?
+        var captureLatencyMs: Double?
 
         do {
             let screenshot = try await permissionsGate.withPermission(kind) { grant in
@@ -51,18 +58,26 @@ struct HotkeyInvocationHandler {
                 let captureStart = gateEnd
                 let result = try await screenCaptureService.captureDisplayScreenshot(grant, target: .week1Default)
                 let captureEnd = self.now()
-
-                await logService.record(InvocationLog(
-                    hotkeyTimestamp: started,
-                    gateOutcome: .granted,
-                    gateLatencyMs: gateLatencyMs,
-                    captureLatencyMs: captureEnd.timeIntervalSince(captureStart) * 1000,
-                    targetDescription: "\(result.target) \(result.width)x\(result.height)"
-                ))
+                captureLatencyMs = captureEnd.timeIntervalSince(captureStart) * 1000
 
                 return result
             }
-            presentScreenshot(screenshot)
+
+            let focusedWindow = await captureFocusedWindowIfAvailable()
+            let bundle = ContextBundle(screenshot: screenshot, focusedWindow: focusedWindow)
+            await logService.record(InvocationLog(
+                hotkeyTimestamp: started,
+                gateOutcome: .granted,
+                gateLatencyMs: gateLatencyMs,
+                captureLatencyMs: captureLatencyMs,
+                targetDescription: bundle.logTargetDescription
+            ))
+
+            if let presentContext {
+                presentContext(bundle)
+            } else {
+                presentScreenshot(screenshot)
+            }
         } catch let error as PermissionError {
             let outcome: InvocationLog.GateOutcome
             switch error {
@@ -83,6 +98,22 @@ struct HotkeyInvocationHandler {
             ))
             presentError("Screen capture failed: \(error.localizedDescription)")
             Self.log.error("Hotkey invocation failed: \(error.localizedDescription, privacy: .public)")
+        }
+    }
+
+    private func captureFocusedWindowIfAvailable() async -> FocusedWindowMetadata? {
+        guard let focusedWindowReader else { return nil }
+
+        do {
+            return try await permissionsGate.withPermission(.accessibility, showMissingUI: false) { grant in
+                try await focusedWindowReader.captureFocusedWindowMetadata(grant)
+            }
+        } catch let error as PermissionError {
+            Self.log.info("Focused-window metadata skipped: \(error.localizedDescription, privacy: .public)")
+            return nil
+        } catch {
+            Self.log.error("Focused-window metadata failed: \(error.localizedDescription, privacy: .public)")
+            return nil
         }
     }
 }

--- a/TAELMacAgent/TAELMacAgent/Capture/AXService.swift
+++ b/TAELMacAgent/TAELMacAgent/Capture/AXService.swift
@@ -60,6 +60,15 @@ public final class AXService: FocusedWindowReading {
             )
         }
 
+        guard CFGetTypeID(focusedWindowRef) == AXUIElementGetTypeID() else {
+            return FocusedWindowMetadata(
+                bundleIdentifier: bundleIdentifier,
+                applicationName: applicationName,
+                windowTitle: nil,
+                windowRole: nil,
+                capturedAt: capturedAt
+            )
+        }
         let focusedWindow = focusedWindowRef as! AXUIElement
         return FocusedWindowMetadata(
             bundleIdentifier: bundleIdentifier,

--- a/TAELMacAgent/TAELMacAgent/Capture/AXService.swift
+++ b/TAELMacAgent/TAELMacAgent/Capture/AXService.swift
@@ -1,0 +1,79 @@
+//
+//  AXService.swift
+//  TAELMacAgent
+//
+//  Reads frontmost/focused-window metadata through Accessibility APIs.
+//  The service is read-only and requires a .accessibility PermissionGrant.
+//
+
+import AppKit
+import Foundation
+#if canImport(ApplicationServices)
+import ApplicationServices
+#endif
+
+public protocol FocusedWindowReading: Sendable {
+    @MainActor
+    func captureFocusedWindowMetadata(_ grant: PermissionGrant) async throws -> FocusedWindowMetadata
+}
+
+@MainActor
+public final class AXService: FocusedWindowReading {
+    public init() {}
+
+    public func captureFocusedWindowMetadata(_ grant: PermissionGrant) async throws -> FocusedWindowMetadata {
+        precondition(
+            grant.kind == .accessibility,
+            "AXService requires a .accessibility grant"
+        )
+
+        let app = NSWorkspace.shared.frontmostApplication
+        let bundleIdentifier = app?.bundleIdentifier
+        let applicationName = app?.localizedName
+        let capturedAt = Date()
+
+        guard let app, app.processIdentifier > 0 else {
+            return FocusedWindowMetadata(
+                bundleIdentifier: bundleIdentifier,
+                applicationName: applicationName,
+                windowTitle: nil,
+                windowRole: nil,
+                capturedAt: capturedAt
+            )
+        }
+
+        let appElement = AXUIElementCreateApplication(app.processIdentifier)
+        var focusedWindowRef: CFTypeRef?
+        let err = AXUIElementCopyAttributeValue(
+            appElement,
+            kAXFocusedWindowAttribute as CFString,
+            &focusedWindowRef
+        )
+
+        guard err == .success, let focusedWindowRef else {
+            return FocusedWindowMetadata(
+                bundleIdentifier: bundleIdentifier,
+                applicationName: applicationName,
+                windowTitle: nil,
+                windowRole: nil,
+                capturedAt: capturedAt
+            )
+        }
+
+        let focusedWindow = focusedWindowRef as! AXUIElement
+        return FocusedWindowMetadata(
+            bundleIdentifier: bundleIdentifier,
+            applicationName: applicationName,
+            windowTitle: copyStringAttribute(focusedWindow, kAXTitleAttribute as CFString),
+            windowRole: copyStringAttribute(focusedWindow, kAXRoleAttribute as CFString),
+            capturedAt: capturedAt
+        )
+    }
+
+    private func copyStringAttribute(_ element: AXUIElement, _ attribute: CFString) -> String? {
+        var value: CFTypeRef?
+        let err = AXUIElementCopyAttributeValue(element, attribute, &value)
+        guard err == .success else { return nil }
+        return value as? String
+    }
+}

--- a/TAELMacAgent/TAELMacAgent/Capture/ContextBundle.swift
+++ b/TAELMacAgent/TAELMacAgent/Capture/ContextBundle.swift
@@ -1,0 +1,42 @@
+//
+//  ContextBundle.swift
+//  TAELMacAgent
+//
+//  One invocation's visible context. Screenshot is the Week 1 heartbeat;
+//  focused-window metadata is Week 2 context and must degrade gracefully.
+//
+
+import Foundation
+
+public struct ContextBundle: Sendable {
+    public let screenshot: CapturedScreenshot?
+    public let focusedWindow: FocusedWindowMetadata?
+    public let capturedAt: Date
+
+    public init(
+        screenshot: CapturedScreenshot?,
+        focusedWindow: FocusedWindowMetadata?,
+        capturedAt: Date = Date()
+    ) {
+        self.screenshot = screenshot
+        self.focusedWindow = focusedWindow
+        self.capturedAt = capturedAt
+    }
+
+    public var hasFocusedWindowData: Bool {
+        focusedWindow?.hasAnyData == true
+    }
+
+    public var logTargetDescription: String? {
+        var parts: [String] = []
+        if let screenshot {
+            parts.append("\(screenshot.target) \(screenshot.width)x\(screenshot.height)")
+        }
+        if let focusedWindow, focusedWindow.hasAnyData {
+            let app = focusedWindow.applicationName ?? focusedWindow.bundleIdentifier ?? "unknown app"
+            let title = focusedWindow.windowTitle ?? "untitled window"
+            parts.append("\(app): \(title)")
+        }
+        return parts.isEmpty ? nil : parts.joined(separator: " | ")
+    }
+}

--- a/TAELMacAgent/TAELMacAgent/Capture/FocusedWindowMetadata.swift
+++ b/TAELMacAgent/TAELMacAgent/Capture/FocusedWindowMetadata.swift
@@ -1,0 +1,39 @@
+//
+//  FocusedWindowMetadata.swift
+//  TAELMacAgent
+//
+//  Snapshot of the frontmost app's focused window taken alongside
+//  the screenshot during a hotkey invocation. All fields are optional
+//  because AX availability varies by app, sandbox, and visibility.
+//
+
+import Foundation
+
+public struct FocusedWindowMetadata: Equatable, Sendable {
+    public let bundleIdentifier: String?
+    public let applicationName: String?
+    public let windowTitle: String?
+    public let windowRole: String?
+    public let capturedAt: Date
+
+    public init(
+        bundleIdentifier: String?,
+        applicationName: String?,
+        windowTitle: String?,
+        windowRole: String?,
+        capturedAt: Date = Date()
+    ) {
+        self.bundleIdentifier = bundleIdentifier
+        self.applicationName = applicationName
+        self.windowTitle = windowTitle
+        self.windowRole = windowRole
+        self.capturedAt = capturedAt
+    }
+
+    public var hasAnyData: Bool {
+        bundleIdentifier != nil ||
+            applicationName != nil ||
+            windowTitle != nil ||
+            windowRole != nil
+    }
+}

--- a/TAELMacAgent/TAELMacAgent/HUD/HUDContextBundleView.swift
+++ b/TAELMacAgent/TAELMacAgent/HUD/HUDContextBundleView.swift
@@ -5,7 +5,6 @@
 //  Renders the Week 1 screenshot plus Week 2 focused-window metadata.
 //
 
-import AppKit
 import SwiftUI
 
 struct HUDContextBundleView: View {

--- a/TAELMacAgent/TAELMacAgent/HUD/HUDContextBundleView.swift
+++ b/TAELMacAgent/TAELMacAgent/HUD/HUDContextBundleView.swift
@@ -1,0 +1,89 @@
+//
+//  HUDContextBundleView.swift
+//  TAELMacAgent
+//
+//  Renders the Week 1 screenshot plus Week 2 focused-window metadata.
+//
+
+import AppKit
+import SwiftUI
+
+struct HUDContextBundleView: View {
+    let context: ContextBundle
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            header
+
+            if let screenshot = context.screenshot {
+                Image(decorative: screenshot.image, scale: 1.0, orientation: .up)
+                    .resizable()
+                    .aspectRatio(contentMode: .fit)
+                    .frame(maxWidth: 720, maxHeight: 440)
+                    .background(Color.black.opacity(0.3))
+                    .cornerRadius(6)
+            }
+
+            Divider()
+
+            VStack(alignment: .leading, spacing: 4) {
+                Text("Focused window")
+                    .font(.caption.weight(.semibold))
+                    .foregroundStyle(.secondary)
+
+                if let focusedWindow = context.focusedWindow, focusedWindow.hasAnyData {
+                    Text(focusedWindow.applicationName ?? focusedWindow.bundleIdentifier ?? "Unknown app")
+                        .font(.subheadline.weight(.semibold))
+                        .lineLimit(1)
+
+                    Text(focusedWindow.windowTitle ?? "No focused window title")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                        .lineLimit(2)
+
+                    if let role = focusedWindow.windowRole {
+                        Text(role)
+                            .font(.caption2)
+                            .foregroundStyle(.tertiary)
+                    }
+                } else {
+                    Text("Accessibility metadata unavailable")
+                        .font(.caption)
+                        .foregroundStyle(.tertiary)
+                }
+            }
+        }
+        .padding(16)
+    }
+
+    private var header: some View {
+        HStack(alignment: .firstTextBaseline) {
+            if let screenshot = context.screenshot {
+                Text("Captured \(screenshot.width)x\(screenshot.height)")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+
+                Text(targetLabel(for: screenshot))
+                    .font(.caption2)
+                    .foregroundStyle(.tertiary)
+            } else {
+                Text("No screenshot captured")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+
+            Spacer()
+
+            Text(context.capturedAt.formatted(date: .omitted, time: .standard))
+                .font(.caption2)
+                .foregroundStyle(.tertiary)
+        }
+    }
+
+    private func targetLabel(for screenshot: CapturedScreenshot) -> String {
+        switch screenshot.target {
+        case .displayContainingCursor: return "cursor display"
+        case .mainDisplay: return "main display fallback"
+        }
+    }
+}

--- a/TAELMacAgent/TAELMacAgent/HUD/HUDPanelController.swift
+++ b/TAELMacAgent/TAELMacAgent/HUD/HUDPanelController.swift
@@ -6,8 +6,7 @@
 //  `PermissionGatePresenting` so `PermissionsGate` can route missing-
 //  permission states through the same surface as the placeholder content.
 //
-//  PR 1 ships an intentionally ugly placeholder. Real screenshot
-//  rendering lands in PR 2 (Week 1 ticket 10).
+//  Hosts placeholder, screenshot, context bundle, permission, and error HUDs.
 //
 
 import AppKit
@@ -28,7 +27,11 @@ final class HUDPanelController: NSObject, PermissionGatePresenting {
     }
 
     func present(screenshot: CapturedScreenshot) {
-        presentNew(content: HUDScreenshotView(screenshot: screenshot))
+        presentNew(content: HUDScreenshotView(screenshot: screenshot), size: NSSize(width: 760, height: 560))
+    }
+
+    func present(context: ContextBundle) {
+        presentNew(content: HUDContextBundleView(context: context), size: NSSize(width: 760, height: 620))
     }
 
     func present(error message: String) {
@@ -58,17 +61,20 @@ final class HUDPanelController: NSObject, PermissionGatePresenting {
     /// `content`. Avoids both the multi-panel leak and the "stale rootView"
     /// bug from reusing a panel that was created for a different surface
     /// (gate vs placeholder).
-    private func presentNew<Content: View>(content: Content) {
+    private func presentNew<Content: View>(
+        content: Content,
+        size: NSSize = NSSize(width: 480, height: 280)
+    ) {
         panel?.orderOut(nil)
         panel = nil
-        let next = makePanel(content: content)
+        let next = makePanel(content: content, size: size)
         panel = next
         present(next)
     }
 
-    private func makePanel<Content: View>(content: Content) -> NSPanel {
+    private func makePanel<Content: View>(content: Content, size: NSSize) -> NSPanel {
         let host = NSHostingController(rootView: AnyView(content))
-        host.view.frame = NSRect(x: 0, y: 0, width: 480, height: 280)
+        host.view.frame = NSRect(origin: .zero, size: size)
 
         // v0.3 §23.11 defaults. Borderless + non-activating gives the
         // overlay-on-top-of-the-user's-app feel; transient prevents

--- a/TAELMacAgent/TAELMacAgent/HUD/HUDScreenshotView.swift
+++ b/TAELMacAgent/TAELMacAgent/HUD/HUDScreenshotView.swift
@@ -13,7 +13,7 @@ struct HUDScreenshotView: View {
 
     var body: some View {
         VStack(alignment: .leading, spacing: 8) {
-            Text("Captured \(screenshot.width)×\(screenshot.height) — \(targetLabel)")
+            Text("Captured \(screenshot.width)x\(screenshot.height) - \(targetLabel)")
                 .font(.caption)
                 .foregroundStyle(.secondary)
 

--- a/TAELMacAgent/TAELMacAgent/HUD/PermissionGateView.swift
+++ b/TAELMacAgent/TAELMacAgent/HUD/PermissionGateView.swift
@@ -51,7 +51,7 @@ struct PermissionGateView: View {
         case .screenRecording:
             return "Used to capture the display containing the cursor when you invoke TAEL. Screenshots are not saved to disk."
         case .accessibility:
-            return "Used to read the focused window's UI tree (title, role, content text) so TAEL can scope context to what you're looking at. Read-only — TAEL does not synthesize keyboard or mouse events."
+            return "Used to read the focused window's UI tree (title, role, content text) so TAEL can scope context to what you're looking at. Read-only: TAEL does not synthesize keyboard or mouse events."
         case .microphone:
             return "Used to capture your voice for the active invocation. Not yet implemented."
         case .appleEvents:

--- a/TAELMacAgent/TAELMacAgent/Permissions/PermissionsGate.swift
+++ b/TAELMacAgent/TAELMacAgent/Permissions/PermissionsGate.swift
@@ -79,6 +79,7 @@ public final class PermissionsGate: Sendable {
     @discardableResult
     public func withPermission<T>(
         _ kind: PermissionKind,
+        showMissingUI: Bool = true,
         operation: (PermissionGrant) async throws -> T
     ) async throws -> T {
         // Unimplemented kinds short-circuit before the checker. Showing
@@ -92,7 +93,9 @@ public final class PermissionsGate: Sendable {
         let status = await checker.status(for: kind)
 
         guard status == .granted else {
-            await permissionUI.showGate(for: kind)
+            if showMissingUI {
+                await permissionUI.showGate(for: kind)
+            }
             throw PermissionError.missing(kind)
         }
 

--- a/TAELMacAgent/TAELMacAgentTests/ContextBundleTests.swift
+++ b/TAELMacAgent/TAELMacAgentTests/ContextBundleTests.swift
@@ -1,0 +1,59 @@
+//
+//  ContextBundleTests.swift
+//  TAELMacAgentTests
+//
+
+import CoreGraphics
+import XCTest
+@testable import TAELMacAgent
+
+final class ContextBundleTests: XCTestCase {
+    func test_focusedWindowMetadata_hasAnyDataReflectsOptionalFields() {
+        let empty = FocusedWindowMetadata(
+            bundleIdentifier: nil,
+            applicationName: nil,
+            windowTitle: nil,
+            windowRole: nil
+        )
+        XCTAssertFalse(empty.hasAnyData)
+
+        let populated = FocusedWindowMetadata(
+            bundleIdentifier: "com.example.App",
+            applicationName: nil,
+            windowTitle: nil,
+            windowRole: nil
+        )
+        XCTAssertTrue(populated.hasAnyData)
+    }
+
+    func test_contextBundle_logTargetDescriptionCombinesScreenshotAndFocusedWindow() throws {
+        let screenshot = makeStubScreenshot()
+        let window = FocusedWindowMetadata(
+            bundleIdentifier: "com.example.Terminal",
+            applicationName: "Terminal",
+            windowTitle: "tael-ai",
+            windowRole: "AXWindow"
+        )
+
+        let bundle = ContextBundle(screenshot: screenshot, focusedWindow: window)
+
+        let description = try XCTUnwrap(bundle.logTargetDescription)
+        XCTAssertTrue(description.contains("displayContainingCursor 1x1"))
+        XCTAssertTrue(description.contains("Terminal: tael-ai"))
+    }
+
+    private func makeStubScreenshot() -> CapturedScreenshot {
+        let cs = CGColorSpaceCreateDeviceRGB()
+        let ctx = CGContext(
+            data: nil,
+            width: 1,
+            height: 1,
+            bitsPerComponent: 8,
+            bytesPerRow: 4,
+            space: cs,
+            bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue
+        )!
+        let image = ctx.makeImage()!
+        return CapturedScreenshot(image: image, target: .displayContainingCursor)
+    }
+}

--- a/TAELMacAgent/TAELMacAgentTests/HotkeyHandlerTests.swift
+++ b/TAELMacAgent/TAELMacAgentTests/HotkeyHandlerTests.swift
@@ -44,12 +44,43 @@ final class HotkeyHandlerTests: XCTestCase {
         }
     }
 
+    @MainActor
+    private final class SpyFocusedWindowReader: FocusedWindowReading {
+        var thrownError: Error?
+        var callCount = 0
+        var stubMetadata: FocusedWindowMetadata
+
+        init(stub: FocusedWindowMetadata) {
+            self.stubMetadata = stub
+        }
+
+        func setError(_ error: Error?) { self.thrownError = error }
+        func observedCallCount() -> Int { callCount }
+
+        func captureFocusedWindowMetadata(_ grant: PermissionGrant) async throws -> FocusedWindowMetadata {
+            precondition(grant.kind == .accessibility)
+            callCount += 1
+            if let thrownError { throw thrownError }
+            return stubMetadata
+        }
+    }
+
     /// Builds a 1x1 transparent CGImage for tests; no real capture.
     private func makeStubScreenshot() -> CapturedScreenshot {
         let cs = CGColorSpaceCreateDeviceRGB()
         let ctx = CGContext(data: nil, width: 1, height: 1, bitsPerComponent: 8, bytesPerRow: 4, space: cs, bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue)!
         let image = ctx.makeImage()!
         return CapturedScreenshot(image: image, target: .displayContainingCursor)
+    }
+
+    private func makeStubFocusedWindow() -> FocusedWindowMetadata {
+        FocusedWindowMetadata(
+            bundleIdentifier: "com.example.Terminal",
+            applicationName: "Terminal",
+            windowTitle: "tael-ai",
+            windowRole: "AXWindow",
+            capturedAt: Date(timeIntervalSince1970: 10)
+        )
     }
 
     /// Pops dates from a fixed sequence each time it's read. The handler
@@ -110,6 +141,77 @@ final class HotkeyHandlerTests: XCTestCase {
             "gate took 100ms (0 → 0.1 second), value must be ms not seconds")
         XCTAssertEqual(row.captureLatencyMs ?? -1, 200, accuracy: 0.001,
             "capture took 200ms (0.1 → 0.3 second)")
+    }
+
+    func test_run_whenGrantedAndAccessibilityGranted_presentsContextBundle() async throws {
+        let checker = StubChecker(.granted)
+        let ui = SpyUI()
+        let gate = PermissionsGate(checker: checker, permissionUI: ui)
+        let capture = SpyCapture(stub: makeStubScreenshot())
+        let focusedWindowReader = SpyFocusedWindowReader(stub: makeStubFocusedWindow())
+        let logService = LocalLogService(capacity: 16)
+        let clock = StubClock([
+            Date(timeIntervalSince1970: 0),
+            Date(timeIntervalSince1970: 0.1),
+            Date(timeIntervalSince1970: 0.3),
+        ])
+
+        var presentedScreenshots: [CapturedScreenshot] = []
+        var presentedContexts: [ContextBundle] = []
+        let handler = HotkeyInvocationHandler(
+            permissionsGate: gate,
+            screenCaptureService: capture,
+            focusedWindowReader: focusedWindowReader,
+            presentScreenshot: { presentedScreenshots.append($0) },
+            presentContext: { presentedContexts.append($0) },
+            logService: logService,
+            now: { clock.next() }
+        )
+
+        await handler.run()
+
+        XCTAssertTrue(presentedScreenshots.isEmpty)
+        XCTAssertEqual(presentedContexts.count, 1)
+        let bundle = try XCTUnwrap(presentedContexts.first)
+        XCTAssertNotNil(bundle.screenshot)
+        XCTAssertEqual(bundle.focusedWindow?.applicationName, "Terminal")
+        XCTAssertEqual(bundle.focusedWindow?.windowTitle, "tael-ai")
+
+        let logs = await logService.recent(10)
+        let row = try XCTUnwrap(logs.first)
+        XCTAssertEqual(row.gateOutcome, .granted)
+        XCTAssertTrue(row.targetDescription?.contains("Terminal: tael-ai") == true)
+    }
+
+    func test_run_whenAccessibilityMissing_stillPresentsScreenshotContextWithoutShowingAXGate() async throws {
+        let ui = SpyUI()
+        let capture = SpyCapture(stub: makeStubScreenshot())
+        let focusedWindowReader = SpyFocusedWindowReader(stub: makeStubFocusedWindow())
+        let logService = LocalLogService(capacity: 16)
+
+        var presentedContexts: [ContextBundle] = []
+        let handler = HotkeyInvocationHandler(
+            permissionsGate: PermissionsGate(
+                checker: SplitChecker(screenRecording: .granted, accessibility: .notDetermined),
+                permissionUI: ui
+            ),
+            screenCaptureService: capture,
+            focusedWindowReader: focusedWindowReader,
+            presentScreenshot: { _ in },
+            presentContext: { presentedContexts.append($0) },
+            logService: logService
+        )
+
+        await handler.run()
+
+        XCTAssertEqual(presentedContexts.count, 1)
+        XCTAssertNotNil(presentedContexts.first?.screenshot)
+        XCTAssertNil(presentedContexts.first?.focusedWindow)
+        let focusedWindowCallCount = focusedWindowReader.observedCallCount()
+        XCTAssertEqual(focusedWindowCallCount, 0)
+
+        let shown = await ui.shownKinds
+        XCTAssertTrue(shown.isEmpty, "Optional AX metadata must not show the permission gate")
     }
 
     // MARK: - Denied path
@@ -229,5 +331,26 @@ final class HotkeyHandlerTests: XCTestCase {
         // PermissionsGateTests contract: not-implemented is silent).
         let shown = await ui.shownKinds
         XCTAssertTrue(shown.isEmpty)
+    }
+}
+
+private actor SplitChecker: PermissionChecking {
+    private let screenRecording: PermissionStatus
+    private let accessibility: PermissionStatus
+
+    init(screenRecording: PermissionStatus, accessibility: PermissionStatus) {
+        self.screenRecording = screenRecording
+        self.accessibility = accessibility
+    }
+
+    func status(for kind: PermissionKind) async -> PermissionStatus {
+        switch kind {
+        case .screenRecording:
+            return screenRecording
+        case .accessibility:
+            return accessibility
+        case .microphone, .appleEvents, .inputMonitoring:
+            return .notDetermined
+        }
     }
 }

--- a/TAELMacAgent/TAELMacAgentTests/PermissionsGateTests.swift
+++ b/TAELMacAgent/TAELMacAgentTests/PermissionsGateTests.swift
@@ -11,7 +11,7 @@
 //       `.granted`, and the closure receives a `PermissionGrant`
 //       whose `kind` matches the requested kind.
 //    3. The grant's `kind` cannot be forged from outside
-//       `PermissionsGate.swift` — `PermissionGrant` is declared in
+//       `PermissionsGate.swift`; `PermissionGrant` is declared in
 //       that same file with a `fileprivate init`, so even
 //       `@testable import` cannot reach the initializer from this
 //       test file. Verified at compile time: this test file does not
@@ -168,6 +168,6 @@ final class PermissionsGateTests: XCTestCase {
 
         XCTAssertFalse(operationRan, "Operation must not run for unimplemented kinds.")
         let shown = await ui.shownKinds
-        XCTAssertTrue(shown.isEmpty, "Gate UI must not appear for unimplemented kinds — there is nothing the user can grant.")
+        XCTAssertTrue(shown.isEmpty, "Gate UI must not appear for unimplemented kinds; there is nothing the user can grant.")
     }
 }

--- a/TAELMacAgent/TAELMacAgentTests/PermissionsGateTests.swift
+++ b/TAELMacAgent/TAELMacAgentTests/PermissionsGateTests.swift
@@ -99,6 +99,30 @@ final class PermissionsGateTests: XCTestCase {
         XCTAssertEqual(shown, [.screenRecording])
     }
 
+    func test_withPermission_whenMissingAndShowMissingUIFalse_throwsWithoutShowingGate() async {
+        let checker = StubChecker([.accessibility: .denied])
+        let ui = SpyUI()
+        let gate = PermissionsGate(checker: checker, permissionUI: ui)
+
+        var operationRan = false
+
+        do {
+            _ = try await gate.withPermission(.accessibility, showMissingUI: false) { _ in
+                operationRan = true
+                return ()
+            }
+            XCTFail("Expected PermissionError.missing to be thrown.")
+        } catch let error as PermissionError {
+            XCTAssertEqual(error, .missing(.accessibility))
+        } catch {
+            XCTFail("Unexpected error: \(error)")
+        }
+
+        XCTAssertFalse(operationRan)
+        let shown = await ui.shownKinds
+        XCTAssertTrue(shown.isEmpty, "Gate UI must not appear when showMissingUI is false.")
+    }
+
     // MARK: - Granted path
 
     func test_withPermission_whenGranted_runsOperationOnceWithMatchingGrantKind() async throws {

--- a/TAELMacAgent/project.yml
+++ b/TAELMacAgent/project.yml
@@ -21,8 +21,7 @@ settings:
     # compiler is documented separately in README.md.
     SWIFT_VERSION: "5.0"
     MACOSX_DEPLOYMENT_TARGET: "14.0"
-    # DEVELOPMENT_TEAM is intentionally blank. See TODO_FOR_OZZY.md.
-    DEVELOPMENT_TEAM: ""
+    DEVELOPMENT_TEAM: 4X8U3NCLQ8
     ALWAYS_SEARCH_USER_PATHS: NO
     ENABLE_HARDENED_RUNTIME: YES
     SWIFT_STRICT_CONCURRENCY: complete
@@ -52,6 +51,7 @@ targets:
         INFOPLIST_FILE: TAELMacAgent/Resources/Info.plist
         CODE_SIGN_ENTITLEMENTS: TAELMacAgent/Resources/TAELMacAgent.entitlements
         CODE_SIGN_STYLE: Automatic
+        "CODE_SIGN_IDENTITY[sdk=macosx*]": Apple Development
         ASSETCATALOG_COMPILER_APPICON_NAME: AppIcon
         ENABLE_USER_SCRIPT_SANDBOXING: YES
         GENERATE_INFOPLIST_FILE: NO
@@ -71,6 +71,9 @@ targets:
         PRODUCT_NAME: TAELMacAgentTests
         BUNDLE_LOADER: $(TEST_HOST)
         TEST_HOST: $(BUILT_PRODUCTS_DIR)/TAELMacAgent.app/Contents/MacOS/TAELMacAgent
+        CODE_SIGN_STYLE: Automatic
+        "CODE_SIGN_IDENTITY[sdk=macosx*]": Apple Development
+        GENERATE_INFOPLIST_FILE: YES
 
 schemes:
   TAELMacAgent:

--- a/TODO_FOR_OZZY.md
+++ b/TODO_FOR_OZZY.md
@@ -1,8 +1,6 @@
 # TODO for Ozzy
 
-Items that require owner input before this repo is truly buildable
-on a real Mac. Nothing here blocks PR 1, but PR 2 will start to feel
-the pain if these are not resolved.
+Owner-side decisions and credentials that affect the internal alpha track.
 
 ## Signing and identity
 
@@ -14,29 +12,29 @@ the pain if these are not resolved.
   Developer Program (Individual). Signing Certificate: Development.
 - [x] **Confirm bundle ID `ai.tael.macagent` is acceptable long-term.**
   Confirmed 2026-04-26. Used as the stable TCC identity.
+- [ ] **Install Developer ID Application certificate.**
+  Required before `scripts/package-alpha-dmg.sh` can produce a notarized
+  internal alpha DMG. Current local keychain inspection showed Apple
+  Development only.
+- [ ] **Create a `notarytool` keychain profile.**
+  Recommended profile name: `tael-notary`.
+  Run `xcrun notarytool store-credentials tael-notary` locally.
 
 ## Repo and naming
 
 - [x] **Confirm repo name `tael-ai` should remain.**
   Confirmed 2026-04-26. Keeping `tael-ai`.
-- [ ] **Confirm GitHub Issues should be created manually or via CLI.**
-  Maestro Claude does not have `gh` access and does not auto-open
-  Issues from this run. Week 1 ticket checklist lives in
-  [`docs/Week1Heartbeat.md`](docs/Week1Heartbeat.md). If you want a
-  one-issue-per-ticket layout, tell Claude/Codex on the next run and
-  it can be created via the GitHub MCP server.
+- [x] **Confirm GitHub Issues should be created manually or via CLI.**
+  Week 1 issues were created via CLI and are reconciled as part of the
+  SDLC stabilization pass.
 
 ## Branches
 
-- [ ] **Confirm branch model.** The plan says:
-  - `main` — frozen plan + scaffold
-  - `dev-claude` — Maestro Claude
-  - `dev-codex` — Codex
-  
-  This run created `dev-claude` from `main` and developed there.
-  PR is opened against `main` as a draft per repo policy.
+- [x] **Confirm branch model.**
+  Active flow: `feature/*` or `codex/*` → `develop` → `main`.
+  Claude remains a review checkpoint; Codex can lead scoped execution.
 
-## Build / test status from PR 1
+## Build / test status
 
 - [x] **Run `xcodebuild` locally.**
   Verified 2026-04-26. Clean build succeeds. All 11 tests pass
@@ -44,18 +42,23 @@ the pain if these are not resolved.
   App launches as menubar utility. Permission gate HUD confirmed
   working. Quit menu works. Required fix: set
   `GENERATE_INFOPLIST_FILE = YES` on TAELMacAgentTests target.
+- [x] **Fix signing source drift for test host.**
+  Verified 2026-04-30. `project.yml` now carries Team `4X8U3NCLQ8`,
+  Apple Development debug signing, and generated test target Info.plist
+  settings so `make xcodeproj` does not reintroduce ad-hoc test signing.
+  `make test` passes with 20 tests.
 
 ## Future, intentionally deferred
 
-These are *not* PR 1 problems but Ozzy-side decisions that will land soon:
+These are not blockers for the current internal alpha stabilization pass:
 
-- [ ] Decide product name. v0.3 is explicit: do this **after** the
-  Week 1 heartbeat works.
-- [ ] Decide release signing model (Developer ID + notarization).
-- [ ] Decide on KeyboardShortcuts package source (sindresorhus/KeyboardShortcuts)
-  vs hand-rolled. PR 2 will need to add it via SPM.
-- [ ] Decide on a HUD design language. PR 1 ships an intentionally
-  ugly placeholder.
+- [ ] Decide product name. Internal alpha remains TAEL / TAELMacAgent.
+- [x] Decide release signing model.
+  Internal alpha uses manual Developer ID DMG plus notarization.
+- [x] Decide on KeyboardShortcuts package source.
+  `sindresorhus/KeyboardShortcuts` is active via SPM.
+- [ ] Decide on a HUD design language. The current HUD is functional
+  but intentionally plain.
 
 ## PR-3 follow-up items from PR #18 review
 
@@ -64,13 +67,13 @@ deliberately not bundled into PR 2 because each one either
 exceeds Week 1 scope, touches behavior the v0.3 §23.4 acceptance
 test does not require, or is a test-quality improvement that
 adds value without blocking the heartbeat. Pick them up in PR 3
-or as small follow-ups — none of them are urgent in isolation.
+or as small follow-ups. None of them are urgent in isolation.
 
 - [x] **User-facing error HUD on capture failure.**
   Shipped 2026-04-26 in PR-3 (Task 6). `HUDErrorView` + a `presentError`
   closure on `HotkeyInvocationHandler`, wired through `HUDPanelController`
   and `AppDelegate`. Permission-error path intentionally does not call
-  `presentError` — `PermissionsGate` already shows the gate UI.
+  `presentError`; `PermissionsGate` already shows the gate UI.
 - [x] **Hotkey closure teardown race.**
   Shipped 2026-04-26 in PR-3 (Task 4). `AppDelegate.log` is now
   `private static let` so the guard's `else` clause can log
@@ -89,7 +92,7 @@ or as small follow-ups — none of them are urgent in isolation.
   failure test asserts 50ms gate latency is retained across the failure.
 - [x] **Test: `.notImplemented` → `.restricted` mapping.**
   Shipped 2026-04-26 in PR-3 (Task 2). `HotkeyInvocationHandler` accepts
-  a `kind: PermissionKind` init parameter (default `.screenRecording` —
-  no production behavior change). New test passes `.accessibility` (whose
-  `isImplemented` returns false in Week 1) and asserts the gate throws
+  a `kind: PermissionKind` init parameter (default `.screenRecording`;
+  no production behavior change). New test passes `.microphone` (which
+  remains unimplemented) and asserts the gate throws
   `.notImplemented`, the handler logs `.restricted`, and no UI is shown.

--- a/docs/AlphaReleaseChecklist.md
+++ b/docs/AlphaReleaseChecklist.md
@@ -1,0 +1,60 @@
+# Alpha release checklist
+
+This checklist is for the internal alpha DMG only. It is not the public
+launch process.
+
+## Prerequisites
+
+- Apple Developer Program account has a Developer ID Application certificate.
+- The certificate is installed in the local login keychain.
+- A notary profile exists:
+
+```bash
+xcrun notarytool store-credentials tael-notary
+```
+
+- `security find-identity -v -p codesigning` shows the Developer ID identity.
+- Screen Recording and Accessibility flows have passed the manual checklist.
+
+## Build and package
+
+```bash
+DEVELOPER_ID_APPLICATION="Developer ID Application: OMER FARUK AKBEN (...)" \
+NOTARYTOOL_PROFILE="tael-notary" \
+VERSION="0.1.0-alpha.1" \
+./scripts/package-alpha-dmg.sh
+```
+
+The script archives the Release app, signs with Developer ID, notarizes and
+staples the app, creates a DMG, notarizes and staples the DMG, and runs
+Gatekeeper checks.
+
+## Required validation
+
+- `git diff --check`
+- `make xcodeproj`
+- `make test`
+- `make build`
+- `codesign --verify --deep --strict --verbose=2 <path>/TAELMacAgent.app`
+- `xcrun stapler validate <path>/TAELMacAgent-<version>.dmg`
+- `spctl -a -vvv <path>/TAELMacAgent.app`
+- `spctl -a -vvv --type open <path>/TAELMacAgent-<version>.dmg`
+
+## Manual install smoke test
+
+- Open the DMG from a clean user account or fresh Mac.
+- Drag `TAELMacAgent.app` to Applications.
+- Launch the app and confirm the menubar item appears.
+- Press `Command-Shift-T` from Terminal or VS Code.
+- Grant Screen Recording, quit and relaunch, then verify screenshot HUD.
+- Grant Accessibility and verify focused-window app/title metadata appears.
+- Revoke Screen Recording and verify TAEL shows the permission gate.
+- Confirm no screenshots or AX context files are written to disk.
+
+## Known alpha constraints
+
+- Manual DMG only. Sparkle auto-update is deferred.
+- App Sandbox remains off for alpha while ScreenCaptureKit, hotkey, and AX
+  behavior are still being proven together.
+- Developer ID certificate and notary credentials are local machine
+  prerequisites and are not committed to the repo.

--- a/docs/Architecture.md
+++ b/docs/Architecture.md
@@ -1,4 +1,4 @@
-# TAEL macOS agent — Architecture (PR 1)
+# TAEL macOS agent architecture
 
 This document tracks the *current* architecture, not the eventual one.
 The eventual architecture is described in
@@ -10,21 +10,22 @@ sections 8 and 13.
 ```text
 TAELMacAgent (menubar app, native macOS)
 ├── App
-│   ├── TAELMacAgentApp.swift     SwiftUI App entry
-│   ├── AppDelegate.swift          Menubar lifecycle, NSStatusItem
+│   ├── TAELMacAgentApp.swift      SwiftUI App entry
+│   ├── AppDelegate.swift          Menubar lifecycle and dependency wiring
+│   ├── HotkeyInvocationHandler.swift
+│   │                              gate → capture → focused-window metadata → HUD + log
 │   └── MenuBarController.swift    Menubar menu (Show HUD, Quit)
 ├── Hotkey
-│   └── HotkeyManager.swift        Stub. Registers a callback. No real
-│                                  global hotkey until KeyboardShortcuts
-│                                  package is added (PR 2, ticket 6).
+│   ├── HotkeyManager.swift        KeyboardShortcuts-backed global hotkey
+│   └── HotkeyName.swift           Command-Shift-T binding name
 ├── Permissions
 │   ├── PermissionKind.swift       Enum: screenRecording, accessibility,
 │   │                              microphone, appleEvents, inputMonitoring
 │   ├── PermissionStatus.swift     Enum: notDetermined, denied, granted,
 │   │                              restricted
 │   ├── PermissionError.swift      Errors thrown by PermissionsGate
-│   ├── PermissionsChecker.swift   Reads current OS permission state.
-│   │                              v0: Screen Recording only.
+│   ├── PermissionsChecker.swift   Reads current OS permission state for
+│   │                              Screen Recording and Accessibility.
 │   └── PermissionsGate.swift      The architectural boundary. Every
 │                                  protected call goes through here.
 │                                  Also defines `PermissionGrant` so
@@ -33,19 +34,22 @@ TAELMacAgent (menubar app, native macOS)
 ├── HUD
 │   ├── HUDPanelController.swift   Non-activating NSPanel host.
 │   ├── HUDView.swift              SwiftUI placeholder content.
-│   └── PermissionGateView.swift   "Open System Settings" sheet for
-│                                  missing permissions.
+│   ├── HUDScreenshotView.swift    Screenshot rendering.
+│   ├── HUDContextBundleView.swift Screenshot plus focused-window metadata.
+│   ├── HUDErrorView.swift         Capture failure surface.
+│   └── PermissionGateView.swift   "Open System Settings" sheet.
 ├── Capture
 │   ├── ScreenshotTarget.swift     displayContainingCursor / mainDisplay
 │   ├── CapturedScreenshot.swift   Screenshot value type + metadata
-│   └── ScreenCaptureService.swift Stub. Real SCScreenshotManager call
-│                                  lands in PR 2, ticket 8. Requires a
-│                                  PermissionGrant of kind .screenRecording.
+│   ├── ScreenCaptureService.swift ScreenCaptureKit screenshot service.
+│   ├── FocusedWindowMetadata.swift
+│   ├── ContextBundle.swift        Per-invocation screenshot + AX metadata.
+│   └── AXService.swift            Focused-window metadata through AX APIs.
 ├── Logging
 │   ├── InvocationLog.swift        Value type: hotkey ts, gate result,
 │   │                              capture timing, target metadata.
 │   └── LocalLogService.swift      Local-only logger. Does not touch disk
-│                                  in PR 1; in-memory ring buffer.
+│                                  in the alpha track; in-memory ring buffer.
 └── Resources
     └── Assets.xcassets            App icon placeholder.
 ```
@@ -71,7 +75,7 @@ accept the grant and assert their expected kind via `precondition`.
 This makes the boundary **a code-review-visible, type-system-visible
 boundary**, not a polite convention.
 
-## Week 1 heartbeat (target, not yet wired)
+## Invocation flow
 
 ```text
 global hotkey                                                (HotkeyManager)
@@ -80,26 +84,36 @@ global hotkey                                                (HotkeyManager)
         (display containing cursor, fallback to main display)
                                                            (ScreenCaptureService)
     }
-  → HUDPanelController shows non-activating NSPanel with PNG     (HUD)
+  → PermissionsGate.withPermission(.accessibility, showMissingUI: false) { grant in
+      → read frontmost app and focused-window title / role       (AXService)
+    }
+  → HUDPanelController shows non-activating NSPanel              (HUD)
   → InvocationLog written locally                               (Logging)
 ```
 
+Accessibility metadata is optional. Missing or revoked Accessibility permission
+must not break the screenshot heartbeat or show a second permission gate during
+the hotkey flow.
+
 ## Folder layout reference
 
-The Week 1 layout in this repo is intentionally a strict subset of the
-section-13 "Recommended initial structure" in v0.3. Folders that have no
-PR 1 implementation (`Voice/`, `Planner/`, `Skills/`, `Executor/`,
-`Settings/`) are not created here. They will be added in their own PRs.
+The current layout is still a subset of the section-13 "Recommended initial
+structure" in v0.3. Folders that have no implementation yet (`Voice/`,
+`Planner/`, `Skills/`, `Executor/`, `Settings/`) are not created here. They
+will be added in their own milestones.
 
 ## Third-party packages
 
-PR 1: none.
-
-Planned (do not add yet):
+Active:
 
 | Package | Purpose | Ticket |
 |---|---|---|
-| `sindresorhus/KeyboardShortcuts` | global hotkey + user-configurable | Week 1 ticket 6 |
+| `sindresorhus/KeyboardShortcuts` | global hotkey | Week 1 ticket 6 |
+
+Planned, not yet added:
+
+| Package | Purpose | Milestone |
+|---|---|---|
 | `argmaxinc/WhisperKit` | local STT, isolated behind `TranscriptionService` | Week 3 |
 
 ## Concurrency model
@@ -112,13 +126,14 @@ Planned (do not add yet):
 
 ## Logging
 
-`LocalLogService` keeps an in-memory ring buffer of `InvocationLog` rows
-in PR 1. PR 1 does **not** persist logs to disk. Disk persistence (with
-size cap and daily rotation) lands when the executor lands.
+`LocalLogService` keeps an in-memory ring buffer of `InvocationLog` rows.
+The app does **not** persist screenshots, AX metadata, audio, transcripts, or
+invocation logs to disk in the current alpha track. Disk persistence with size
+cap and rotation lands only when the executor milestone needs it.
 
 ## Test layout
 
-- `TAELMacAgentTests/PermissionsGateTests.swift` — verifies that
-  `withPermission` short-circuits on denied status, that the operation
-  is invoked exactly once on granted, and that the closure receives a
-  grant of the requested kind.
+- `TAELMacAgentTests/PermissionsGateTests.swift` verifies the tokenized gate.
+- `TAELMacAgentTests/HotkeyHandlerTests.swift` verifies screenshot success,
+  capture failure, missing permissions, and optional AX metadata degradation.
+- `TAELMacAgentTests/ContextBundleTests.swift` verifies context value behavior.

--- a/docs/ManualTestChecklist.md
+++ b/docs/ManualTestChecklist.md
@@ -3,9 +3,9 @@
 PR-by-PR, run the rows that apply. Anything new and risky should add a
 row here.
 
-Legend: ✅ pass · ⚠️ pass with note · ❌ fail · — not applicable to this PR
+Legend: pass, pass with note, fail, not applicable
 
-## PR 1 — scaffold only
+## PR 1 scaffold only
 
 | # | Check | Expected | Result |
 |---|---|---|---|
@@ -19,10 +19,9 @@ Legend: ✅ pass · ⚠️ pass with note · ❌ fail · — not applicable to t
 | 8 | Inspect `Info.plist` | `LSUIElement = YES`, `LSMinimumSystemVersion = 14.0`, `CFBundleIdentifier = ai.tael.macagent` | |
 | 9 | Confirm no Screen Recording prompt appears on launch | We do not call any protected API on launch | |
 
-## Week 1 (lands in PR 2 — `hotkey → screenshot → HUD`)
+## Week 1 heartbeat, shipped in PR 2
 
-These are not expected to pass on PR 1. Listed here so they are ready
-when PR 2 lands.
+These are retained as the baseline heartbeat checks.
 
 | # | Check | Expected |
 |---|---|---|
@@ -39,7 +38,7 @@ when PR 2 lands.
 | W1.11 | Press hotkey with cursor on a Cursor / VS Code window | Screenshot includes that window |
 | W1.12 | Inspect `LocalLogService` after several invocations | Each invocation has a row with hotkey ts, gate result, capture timing, target display metadata |
 
-## PR 2 — Week 1 heartbeat manual cases
+## PR 2 Week 1 heartbeat manual cases
 
 ### PR-2.1 First-launch Screen Recording prompt
 
@@ -58,16 +57,16 @@ when PR 2 lands.
 
 - Click "Open System Settings" in the gate, grant Screen Recording for TAELMacAgent, quit/relaunch TAEL.
 - Press ⌘⇧T.
-- Expected: HUD appears within ~500ms showing the cursor display's screenshot at max 720x480 with caption "Captured WIDTHxHEIGHT — cursor display".
+- Expected: HUD appears within ~500ms showing the cursor display's screenshot at max 720x480 with caption "Captured WIDTHxHEIGHT - cursor display".
 - Expected: HUD does not steal focus from Terminal/VS Code/Cursor.
 
-### PR-2.4 Multi-monitor — cursor display selection
+### PR-2.4 Multi-monitor cursor display selection
 
 - With two displays, move the cursor to the secondary display.
 - Press ⌘⇧T.
 - Expected: HUD shows the secondary display's content, caption says "cursor display".
 
-### PR-2.5 Multi-monitor — main display fallback
+### PR-2.5 Multi-monitor main display fallback
 
 - Disconnect or disable the secondary display while the cursor was on it (edge case; requires a hotplug or display-arrangement change).
 - Press ⌘⇧T.
@@ -90,6 +89,29 @@ when PR 2 lands.
 - Expected: each row has hotkeyTimestamp, gateOutcome, gateLatencyMs, captureLatencyMs, targetDescription. Granted-path rows have all four numeric fields populated.
 
 ## TCC reset for clean re-test
+
+## PR 5 focused-window metadata
+
+| # | Check | Expected |
+|---|---|---|
+| PR-5.1 | Grant Screen Recording, do not grant Accessibility, press `Command-Shift-T` from Terminal | Screenshot HUD appears; focused-window area says metadata is unavailable; no Accessibility gate interrupts the heartbeat |
+| PR-5.2 | Grant Screen Recording and Accessibility, press `Command-Shift-T` from Terminal | HUD shows screenshot plus Terminal app name and focused-window title when available |
+| PR-5.3 | Press `Command-Shift-T` from VS Code or Cursor | HUD shows screenshot plus app name and a best-effort focused-window title |
+| PR-5.4 | Press `Command-Shift-T` from Safari or another sandboxed app | HUD still appears; metadata may be partial but app must not crash |
+| PR-5.5 | Press `Command-Shift-T` from a full-screen app | HUD appears without stealing focus; metadata degrades gracefully |
+| PR-5.6 | Revoke Accessibility while app is running, then press `Command-Shift-T` | Screenshot still appears; focused-window metadata is omitted |
+| PR-5.7 | Inspect project root and `~/Library/Application Support/TAELMacAgent/` | No screenshot or AX context files are created |
+
+## Alpha DMG smoke test
+
+| # | Check | Expected |
+|---|---|---|
+| A.1 | Run `./scripts/package-alpha-dmg.sh` without required env vars | Script exits with a clear prerequisite error |
+| A.2 | Package with Developer ID identity and notary profile | DMG is created, notarized, stapled, and Gatekeeper-checked |
+| A.3 | Install from the DMG on a clean user or fresh Mac | App launches as a menubar utility |
+| A.4 | Grant Screen Recording and invoke the hotkey | Screenshot HUD appears |
+| A.5 | Grant Accessibility and invoke the hotkey | Focused-window metadata appears when available |
+| A.6 | Quit from menubar | App exits cleanly |
 
 ```bash
 ./scripts/reset-tcc-dev.sh

--- a/docs/ManualTestChecklist.md
+++ b/docs/ManualTestChecklist.md
@@ -90,6 +90,14 @@ These are retained as the baseline heartbeat checks.
 
 ## TCC reset for clean re-test
 
+```bash
+./scripts/reset-tcc-dev.sh
+```
+
+After running, **quit the app and relaunch** before re-testing
+W1.3-W1.5. Some macOS 14 builds need a quit+relaunch for the new
+state to take effect.
+
 ## PR 5 focused-window metadata
 
 | # | Check | Expected |
@@ -112,11 +120,3 @@ These are retained as the baseline heartbeat checks.
 | A.4 | Grant Screen Recording and invoke the hotkey | Screenshot HUD appears |
 | A.5 | Grant Accessibility and invoke the hotkey | Focused-window metadata appears when available |
 | A.6 | Quit from menubar | App exits cleanly |
-
-```bash
-./scripts/reset-tcc-dev.sh
-```
-
-After running, **quit the app and relaunch** before re-testing
-W1.3–W1.5. Some macOS 14 builds need a quit+relaunch for the new
-state to take effect.

--- a/docs/PermissionNotes.md
+++ b/docs/PermissionNotes.md
@@ -17,7 +17,7 @@ If you hit a TCC weirdness, write it down here.
   requirement, and ad-hoc identities flap, which causes the OS to
   re-prompt or silently drop grants.
 
-## Week 1 active permission: Screen Recording
+## Active permission: Screen Recording
 
 ### Behavior
 
@@ -37,19 +37,16 @@ If you hit a TCC weirdness, write it down here.
 We use `CGPreflightScreenCaptureAccess()` to read the current
 state without triggering the prompt.
 
-PR 1's `PermissionGateView` does **not** call
-`CGRequestScreenCaptureAccess()`; it only links the user to System
-Settings → Privacy & Security → Screen Recording. The first system
-prompt for Screen Recording is therefore triggered as a side effect of
-the first real ScreenCaptureKit call (which lands in PR 2). If we add
-an explicit "Request access" button in the gate later, it will route
-through `CGRequestScreenCaptureAccess()` — but until then, the gate
-is "Open System Settings" only.
+`PermissionGateView` does **not** call `CGRequestScreenCaptureAccess()`;
+it links the user to System Settings → Privacy & Security → Screen
+Recording. If we add an explicit "Request access" button later, it will
+route through `CGRequestScreenCaptureAccess()`. Until then, the gate is
+"Open System Settings" only.
 
 > Note: in some macOS 14 minor versions, `CGPreflightScreenCaptureAccess`
 > can return `true` even when ScreenCaptureKit later fails. The gate
 > should consider both preflight and an actual `SCShareableContent` probe.
-> This is an open item — see ticket 4 in `Week1Heartbeat.md`.
+> This remains a known macOS edge case to watch during manual QA.
 
 ### Reset for development
 
@@ -62,18 +59,21 @@ script for what it does and how to dry-run it.
 
 ## Active permissions
 
-### Accessibility (PR 4)
+### Accessibility
 
-- Required for AX tree reads (PR 5+) and for `CGEvent` synthesis on
-  Apple Silicon under modern macOS.
+- Required for focused-window metadata and for future AX tree reads.
+- `AXService` consumes a `.accessibility` grant to read frontmost app,
+  focused-window title, and focused-window role.
 - `PermissionsChecker.accessibilityStatus()` calls `AXIsProcessTrusted()`
-  — the no-prompt variant. The prompting variant
+  - the no-prompt variant. The prompting variant
   (`AXIsProcessTrustedWithOptions([kAXTrustedCheckOptionPrompt: true])`)
   is intentionally not used; `PermissionGateView` owns the prompt path
   so the user lands in the same flow as Screen Recording.
 - Quit-and-relaunch behavior: similar to Screen Recording. After
   granting AX in System Settings → Privacy & Security → Accessibility,
   the app must be relaunched for the trust state to flip.
+- During a normal hotkey invocation, Accessibility is optional context:
+  missing AX permission must not interrupt the screenshot heartbeat.
 
 ## Future permissions (placeholders only)
 
@@ -86,19 +86,18 @@ script for what it does and how to dry-run it.
 
 - Per-target. Sending an event to e.g. Terminal prompts a per-app
   grant. There is no global "Apple Events on" toggle.
-- We will not request these in PR 1.
+- We will not request these before the planner/executor milestone.
 
 ### Input Monitoring
 
 - Required if we ever use a low-level `CGEventTap` for global hotkey
-  capture. We avoid this in PR 1 by using KeyboardShortcuts (which
-  uses Carbon HotKey APIs and does not require Input Monitoring).
+  capture. We avoid this by using KeyboardShortcuts, which uses Carbon
+  HotKey APIs and does not require Input Monitoring.
 
 ## Logs
 
-`LocalLogService` keeps an in-memory ring buffer of `InvocationLog`
-rows in PR 1. To inspect after a session, use the menubar "Show recent
-invocations" item (planned for PR 2). For now, attach a debugger.
+`LocalLogService` keeps an in-memory ring buffer of `InvocationLog` rows.
+To inspect after a session, attach a debugger and call `recent()`.
 
 ## Things we have not yet observed but expect
 

--- a/docs/ProtectedAPICallPolicy.md
+++ b/docs/ProtectedAPICallPolicy.md
@@ -8,17 +8,20 @@ This is an **architectural rule**, not a guideline.
 
 ## What is a "protected API call"?
 
-| Surface | Examples | TCC permission | Status in PR 1 |
+| Surface | Examples | TCC permission | Current status |
 |---|---|---|---|
-| Screen capture | `SCScreenshotManager`, `CGDisplayStream`, `CGWindowListCreateImage` | Screen Recording | **Active** — gated through `PermissionsGate` with `.screenRecording`. |
-| Accessibility tree | `AXUIElement*`, `AXObserver*` | Accessibility | **Active (PR 4)** — gated through `PermissionsGate` with `.accessibility`. PR 4 lands the permission check (`AXIsProcessTrusted`); the actual AX tree read lands in PR 5. |
+| Screen capture | `SCScreenshotManager`, `CGDisplayStream`, `CGWindowListCreateImage` | Screen Recording | **Active**. Gated through `PermissionsGate` with `.screenRecording`. |
+| Focused-window metadata | `AXUIElement*`, `AXObserver*` | Accessibility | **Active**. `AXService` consumes a `.accessibility` grant for frontmost app and focused-window metadata. |
 | Microphone | `AVAudioEngine`, `AVCaptureDevice` (audio) | Microphone | Future. Enum placeholder only. |
 | Apple Events / scripting | `NSAppleScript`, `OSAScript`, `appleScriptObjectSpecifier` | Apple Events / Automation | Future. Enum placeholder only. |
 | Keyboard/mouse synthesis | `CGEvent.post`, `CGEventTapCreate` | Input Monitoring / Accessibility | Future. Enum placeholder only. |
-| Subprocess execution | `Process()`, `posix_spawn`, `system()` | n/a (but treated as protected by `SafetyPolicy`) | Future. Not in PR 1. Will go through `SafeExecutor`. |
-| Clipboard write | `NSPasteboard.general.set*` | n/a (but treated as protected by `SafetyPolicy`) | Future. Not in PR 1. Will go through `ClipboardExecutor`. |
+| Subprocess execution | `Process()`, `posix_spawn`, `system()` | n/a (but treated as protected by `SafetyPolicy`) | Future. Will go through `SafeExecutor`. |
+| Clipboard write | `NSPasteboard.general.set*` | n/a (but treated as protected by `SafetyPolicy`) | Future. Will go through `ClipboardExecutor`. |
 
-For PR 4, Screen Recording and Accessibility are active. Microphone, Apple Events, and Input Monitoring remain future policy entries — their enum cases exist (so the gate has a complete vocabulary) but `PermissionsChecker` does not query them, and no service consumes their grants yet.
+Screen Recording and Accessibility are active. Microphone, Apple Events, and
+Input Monitoring remain future policy entries. Their enum cases exist so the
+gate has a complete vocabulary, but `PermissionsChecker` does not query them
+and no service consumes their grants yet.
 
 ## How the gate works
 
@@ -34,12 +37,15 @@ struct PermissionGrant {
 final class PermissionsGate {
     func withPermission<T>(
         _ kind: PermissionKind,
+        showMissingUI: Bool = true,
         operation: (PermissionGrant) async throws -> T
     ) async throws -> T {
         let status = await checker.status(for: kind)
 
         guard status == .granted else {
-            await permissionUI.showGate(for: kind)
+            if showMissingUI {
+                await permissionUI.showGate(for: kind)
+            }
             throw PermissionError.missing(kind)
         }
 
@@ -58,9 +64,10 @@ Two properties:
    without going through the gate, because the closure body
    `PermissionsGate.withPermission` runs is the only place a grant
    exists.
-2. **Single source of permission UI.** Missing permission always shows
-   the same `PermissionGateView`. There is no per-feature ad-hoc
-   "did you grant…" sheet.
+2. **Single source of permission UI.** Required missing permissions show
+   the same `PermissionGateView`. Optional context reads may pass
+   `showMissingUI: false` but still receive a grant only through the gate.
+   There is no per-feature ad-hoc "did you grant..." sheet.
 
 ## Required usage pattern
 

--- a/scripts/package-alpha-dmg.sh
+++ b/scripts/package-alpha-dmg.sh
@@ -55,6 +55,7 @@ require_command xcodebuild
 require_command xcrun
 require_command hdiutil
 require_command codesign
+require_command security
 require_command spctl
 require_command ditto
 

--- a/scripts/package-alpha-dmg.sh
+++ b/scripts/package-alpha-dmg.sh
@@ -1,0 +1,125 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+PROJECT="$ROOT_DIR/TAELMacAgent/TAELMacAgent.xcodeproj"
+SCHEME="TAELMacAgent"
+TEAM_ID="${TEAM_ID:-4X8U3NCLQ8}"
+APP_NAME="TAELMacAgent"
+VERSION="${VERSION:-0.1.0-alpha}"
+BUILD_DIR="$ROOT_DIR/dist/alpha"
+ARCHIVE_PATH="$BUILD_DIR/$APP_NAME.xcarchive"
+APP_ZIP="$BUILD_DIR/$APP_NAME-$VERSION.app.zip"
+DMG_PATH="$BUILD_DIR/$APP_NAME-$VERSION.dmg"
+DEVELOPER_ID_APPLICATION="${DEVELOPER_ID_APPLICATION:-}"
+NOTARYTOOL_PROFILE="${NOTARYTOOL_PROFILE:-}"
+
+usage() {
+    cat <<EOF
+Usage:
+  DEVELOPER_ID_APPLICATION="Developer ID Application: ..." \\
+  NOTARYTOOL_PROFILE="tael-notary" \\
+  VERSION="0.1.0-alpha.1" \\
+  $0
+
+Required:
+  DEVELOPER_ID_APPLICATION  Developer ID Application signing identity.
+  NOTARYTOOL_PROFILE        Keychain profile created with xcrun notarytool store-credentials.
+
+Output:
+  $DMG_PATH
+EOF
+}
+
+require_value() {
+    local name="$1"
+    local value="$2"
+    if [[ -z "$value" ]]; then
+        echo "error: $name is required." >&2
+        usage >&2
+        exit 2
+    fi
+}
+
+require_command() {
+    local name="$1"
+    if ! command -v "$name" >/dev/null 2>&1; then
+        echo "error: required command not found: $name" >&2
+        exit 2
+    fi
+}
+
+require_value "DEVELOPER_ID_APPLICATION" "$DEVELOPER_ID_APPLICATION"
+require_value "NOTARYTOOL_PROFILE" "$NOTARYTOOL_PROFILE"
+require_command xcodebuild
+require_command xcrun
+require_command hdiutil
+require_command codesign
+require_command spctl
+require_command ditto
+
+if ! security find-identity -v -p codesigning | grep -F "$DEVELOPER_ID_APPLICATION" >/dev/null; then
+    echo "error: Developer ID identity not found in keychain: $DEVELOPER_ID_APPLICATION" >&2
+    echo "Install the Developer ID Application certificate before packaging alpha DMGs." >&2
+    exit 2
+fi
+
+rm -rf "$BUILD_DIR"
+mkdir -p "$BUILD_DIR"
+
+echo "==> Archiving $APP_NAME $VERSION"
+xcodebuild \
+    -project "$PROJECT" \
+    -scheme "$SCHEME" \
+    -configuration Release \
+    -destination 'generic/platform=macOS' \
+    -archivePath "$ARCHIVE_PATH" \
+    DEVELOPMENT_TEAM="$TEAM_ID" \
+    CODE_SIGN_STYLE=Manual \
+    CODE_SIGN_IDENTITY="$DEVELOPER_ID_APPLICATION" \
+    archive
+
+APP_PATH="$ARCHIVE_PATH/Products/Applications/$APP_NAME.app"
+if [[ ! -d "$APP_PATH" ]]; then
+    echo "error: archive did not produce $APP_PATH" >&2
+    exit 1
+fi
+
+echo "==> Verifying app signature"
+codesign --verify --deep --strict --verbose=2 "$APP_PATH"
+
+echo "==> Submitting app for notarization"
+ditto -c -k --keepParent "$APP_PATH" "$APP_ZIP"
+xcrun notarytool submit "$APP_ZIP" \
+    --keychain-profile "$NOTARYTOOL_PROFILE" \
+    --wait
+
+echo "==> Stapling app notarization ticket"
+xcrun stapler staple "$APP_PATH"
+xcrun stapler validate "$APP_PATH"
+
+echo "==> Gatekeeper app assessment"
+spctl -a -vvv "$APP_PATH"
+
+echo "==> Creating DMG"
+rm -f "$DMG_PATH"
+hdiutil create \
+    -volname "TAEL AI Alpha" \
+    -srcfolder "$APP_PATH" \
+    -ov \
+    -format UDZO \
+    "$DMG_PATH"
+
+echo "==> Submitting DMG for notarization"
+xcrun notarytool submit "$DMG_PATH" \
+    --keychain-profile "$NOTARYTOOL_PROFILE" \
+    --wait
+
+echo "==> Stapling notarization ticket"
+xcrun stapler staple "$DMG_PATH"
+xcrun stapler validate "$DMG_PATH"
+
+echo "==> Gatekeeper DMG assessment"
+spctl -a -vvv --type open "$DMG_PATH"
+
+echo "Alpha DMG ready: $DMG_PATH"


### PR DESCRIPTION
## Summary
- Fixes signing source drift so the test bundle and host app use the same Apple Development team settings after XcodeGen regeneration.
- Adds focused-window metadata to the hotkey context flow while keeping screenshot capture as the primary heartbeat.
- Adds internal alpha DMG packaging docs and a release script with Developer ID and notarization prerequisites.

## Why
- `make test` was blocked by mismatched signing between `TAELMacAgent` and `TAELMacAgentTests`.
- The next alpha milestone needs focused-window context, current repo docs, closed stale Week 1 issues, and a concrete DMG path.

## Changes
- Adds `FocusedWindowMetadata`, `ContextBundle`, `FocusedWindowReading`, and `AXService`.
- Extends `PermissionsGate.withPermission` with `showMissingUI` for optional context reads that still require a grant but should not interrupt screenshot capture.
- Updates the HUD to render screenshot plus focused-window metadata when Accessibility is granted.
- Updates XcodeGen signing settings, README, architecture docs, permission policy notes, manual QA checklist, TODOs, and PR template.
- Adds `scripts/package-alpha-dmg.sh` and `docs/AlphaReleaseChecklist.md`.

## Validation
- `git diff --check`
- `make xcodeproj`
- `make test` (20 tests passed)
- `make build`
- `scripts/package-alpha-dmg.sh` without env vars exits with the expected prerequisite error
- Launched the debug app and confirmed a `TAELMacAgent` process starts; terminated it after the process check
- Closed stale GitHub Issues #1-#13 after confirming Week 1 work had already landed

## Risks / follow-ups
- Full DMG creation is blocked until a Developer ID Application certificate and `notarytool` keychain profile are installed locally.
- Screen Recording and Accessibility manual QA still needs to be run interactively from Terminal, VS Code/Cursor, Safari, full-screen mode, and revoked-permission states.
- Claude review checkpoint should happen before merge to `develop`.