### PR TITLE
Week 1–2 heartbeat: ScreenCaptureKit capture + AX focused-window metadata + alpha DMG + CI

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -8,12 +8,12 @@
 
 - [ ] Inside the v0.3 milestone scope (no scope creep)
 - [ ] No protected macOS API call bypasses `PermissionsGate`
-- [ ] Week 1 only: Screen Recording is the only real permission check
 - [ ] Screenshot path uses `SCScreenshotManager.captureImage(contentFilter:configuration:)`
       (not `captureImage(in:)`) when applicable
 - [ ] No screenshot, audio, or transcript persisted to disk unless the
       milestone explicitly added it
 - [ ] No new third-party package without an entry in `docs/Architecture.md`
+- [ ] Claude review checkpoint completed before merge to `develop`
 
 ## Permissions impact
 
@@ -29,6 +29,7 @@
 - [ ] `xcodebuild ... test` passes
 - [ ] App launches as menubar utility and quits cleanly from menu
 - [ ] Manual checks from `docs/ManualTestChecklist.md` relevant to this PR
+- [ ] For release changes: `docs/AlphaReleaseChecklist.md` is updated or confirmed unchanged
 
 ## Out of scope / follow-ups
 
@@ -36,14 +37,12 @@
 
 ## Risk
 
-- [ ] Low — purely additive, behind a feature
-- [ ] Medium — touches PermissionsGate / capture path
-- [ ] High — touches signing, entitlements, or executor
+- [ ] Low: purely additive, behind a feature
+- [ ] Medium: touches PermissionsGate, capture path, or AX metadata
+- [ ] High: touches signing, entitlements, release packaging, or executor
 
 ## Screenshots / recordings
 
 <!-- Optional. Drag in a HUD screenshot or short clip for UI changes. -->
 
 ---
-
-🤖 Generated with [Claude Code](https://claude.com/claude-code)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,59 @@
+name: CI
+
+on:
+  push:
+    branches: [main, develop]
+  pull_request:
+    branches: [main, develop]
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build-and-test:
+    name: build + test (macOS 14)
+    runs-on: macos-14
+    timeout-minutes: 20
+
+    env:
+      PROJECT: TAELMacAgent/TAELMacAgent.xcodeproj
+      SCHEME: TAELMacAgent
+      DEST: platform=macOS
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Show toolchain
+        run: |
+          sw_vers
+          xcodebuild -version
+          swift --version
+
+      - name: Resolve SPM packages
+        run: |
+          xcodebuild \
+            -project "$PROJECT" \
+            -scheme "$SCHEME" \
+            -destination "$DEST" \
+            -resolvePackageDependencies
+
+      - name: Build (Debug)
+        run: |
+          xcodebuild \
+            -project "$PROJECT" \
+            -scheme "$SCHEME" \
+            -configuration Debug \
+            -destination "$DEST" \
+            CODE_SIGNING_ALLOWED=NO \
+            clean build
+
+      - name: Test
+        run: |
+          xcodebuild \
+            -project "$PROJECT" \
+            -scheme "$SCHEME" \
+            -configuration Debug \
+            -destination "$DEST" \
+            CODE_SIGNING_ALLOWED=NO \
+            test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,17 @@ jobs:
           xcodebuild -version
           swift --version
 
+      - name: Install xcodegen
+        run: brew install xcodegen
+
+      - name: Regenerate xcodeproj from project.yml
+        run: |
+          # The committed pbxproj is a convenience for local Xcode users.
+          # Source of truth is project.yml. Regenerating in CI also picks
+          # up any new files added under TAELMacAgent/ or TAELMacAgentTests/
+          # without needing every contributor to run xcodegen locally.
+          make xcodeproj
+
       - name: Resolve SPM packages
         run: |
           xcodebuild \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,9 +12,9 @@ concurrency:
 
 jobs:
   build-and-test:
-    name: build + test (macOS 14)
-    runs-on: macos-14
-    timeout-minutes: 20
+    name: build + test (macOS)
+    runs-on: macos-15
+    timeout-minutes: 25
 
     env:
       PROJECT: TAELMacAgent/TAELMacAgent.xcodeproj
@@ -24,9 +24,22 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Show toolchain
+      - name: List available Xcode versions
+        run: ls -1 /Applications | grep -i '^Xcode' || true
+
+      - name: Select Xcode 16
         run: |
-          sw_vers
+          # The committed pbxproj uses objectVersion = 77 (Xcode 16 format).
+          # Xcode 15.x cannot read it, so pin to a 16.x toolchain that the
+          # runner image ships. Falls back to xcode-select default if no
+          # 16.x is present (which would then surface a clear error in build).
+          XCODE_PATH=$(ls -d /Applications/Xcode_16*.app 2>/dev/null | sort -V | tail -n1)
+          if [ -n "$XCODE_PATH" ]; then
+            sudo xcode-select -s "$XCODE_PATH/Contents/Developer"
+            echo "Selected: $XCODE_PATH"
+          else
+            echo "::warning::No Xcode 16.x found on runner; using default"
+          fi
           xcodebuild -version
           swift --version
 
@@ -35,22 +48,23 @@ jobs:
 
       - name: Regenerate xcodeproj from project.yml
         run: |
-          # The committed pbxproj is a convenience for local Xcode users.
-          # Source of truth is project.yml. Regenerating in CI also picks
-          # up any new files added under TAELMacAgent/ or TAELMacAgentTests/
-          # without needing every contributor to run xcodegen locally.
+          # project.yml is the source of truth; the committed pbxproj is
+          # for local Xcode convenience. Regenerating here also picks up
+          # any new files globbed under TAELMacAgent/ or TAELMacAgentTests/
+          # without contributors having to run xcodegen locally.
+          set -x
           make xcodeproj
-
-      - name: Resolve SPM packages
-        run: |
-          xcodebuild \
-            -project "$PROJECT" \
-            -scheme "$SCHEME" \
-            -destination "$DEST" \
-            -resolvePackageDependencies
 
       - name: Build (Debug)
         run: |
+          set -x
+          xcodebuild \
+            -project "$PROJECT" \
+            -scheme "$SCHEME" \
+            -configuration Debug \
+            -destination "$DEST" \
+            CODE_SIGNING_ALLOWED=NO \
+            -showBuildSettings | head -40 || true
           xcodebuild \
             -project "$PROJECT" \
             -scheme "$SCHEME" \
@@ -61,6 +75,7 @@ jobs:
 
       - name: Test
         run: |
+          set -x
           xcodebuild \
             -project "$PROJECT" \
             -scheme "$SCHEME" \

--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -1,0 +1,6 @@
+{
+  "default": true,
+  "MD013": false,
+  "MD041": false,
+  "MD060": false
+}

--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,7 @@ help:
 	@echo "  make run             Build and launch the app"
 	@echo "  make clean           Clean build artifacts"
 	@echo "  make xcodeproj       Regenerate .xcodeproj from project.yml (requires xcodegen)"
+	@echo "  make package-alpha   Build, notarize, and staple internal alpha DMG"
 	@echo "  make tcc-reset       Reset TCC entries for ai.tael.macagent (dev only)"
 	@echo ""
 	@echo "Requirements: macOS 14.0+, Xcode 15.3+. See TODO_FOR_OZZY.md."
@@ -47,6 +48,10 @@ xcodeproj:
 	    exit 1; \
 	}
 	cd TAELMacAgent && xcodegen generate
+
+.PHONY: package-alpha
+package-alpha:
+	./scripts/package-alpha-dmg.sh
 
 .PHONY: tcc-reset
 tcc-reset:

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ heartbeat and the Week 1 implementation ticket order.
 
 ## Layout
 
-```
+```text
 tael-ai/
   README.md
   .gitignore

--- a/README.md
+++ b/README.md
@@ -10,30 +10,30 @@ freeze in [`TAEL_AI_mac_agent_build_plan_v0_3.md`](TAEL_AI_mac_agent_build_plan_
 
 ## Status
 
-PR 1 scope: native macOS menubar scaffold + Week 1 policy/docs.
-
-What works today:
+Current internal alpha track:
 
 - App launches as a native macOS menubar utility.
 - Stable bundle ID `ai.tael.macagent`, deployment target macOS 14.0+.
-- Quit cleanly from menubar.
-- Permissions boundary types (`PermissionKind`, `PermissionStatus`,
-  `PermissionError`, `PermissionGrant`) are in place.
+- Global hotkey `Command-Shift-T` runs the heartbeat.
 - `PermissionsGate` enforces a tokenized closure boundary for protected APIs.
-- `PermissionsChecker` v0 reports Screen Recording status only.
-- `HUDPanelController` placeholder (non-activating `NSPanel`).
-- `ScreenCaptureService` exists as a typed stub that requires a
-  `PermissionGrant`; the real `SCScreenshotManager` call lands in PR 2.
+- Screen Recording and Accessibility permission checks are active.
+- `ScreenCaptureService` captures the display containing the cursor with
+  `SCScreenshotManager.captureImage(contentFilter:configuration:)`.
+- HUD renders the captured screenshot and, when Accessibility is granted,
+  focused-window metadata.
+- `LocalLogService` keeps an in-memory invocation log only.
+- Internal alpha DMG packaging is scripted in `scripts/package-alpha-dmg.sh`,
+  but Developer ID certificate and notary credentials are local prerequisites.
 
-What is intentionally NOT in PR 1:
+Still intentionally deferred:
 
 - AI planner, speech capture, WhisperKit
-- AX tree, focused-window metadata
-- YAML skills, executor, clipboard / shell / AppleScript / CGEvent actions
+- AX tree dump beyond focused-window metadata
+- YAML skills, executor, clipboard, shell, AppleScript, CGEvent actions
 - Settings UI, polished onboarding
-- DMG packaging, Sparkle, analytics, token tracking
-- Screenshot persistence
-- Product naming / landing page
+- Sparkle updates, analytics, token tracking
+- Screenshot or AX context persistence
+- Public launch operations
 
 See [`docs/Week1Heartbeat.md`](docs/Week1Heartbeat.md) for the Week 1
 heartbeat and the Week 1 implementation ticket order.
@@ -80,21 +80,37 @@ tael-ai/
 ## Building
 
 ```bash
-open TAELMacAgent/TAELMacAgent.xcodeproj
+make xcodeproj
+make build
+make test
 ```
 
-In Xcode, select the `TAELMacAgent` scheme and press Run.
+For Xcode, open `TAELMacAgent/TAELMacAgent.xcodeproj`, select the
+`TAELMacAgent` scheme, and press Run.
 
 > Ad-hoc signing is **not** the intended dev path. TCC permissions are keyed
 > to bundle identity and signing requirements; unstable signing makes
 > permission debugging noisy. The real Team ID must be set before any
-> Screen Recording / TCC work — see TODO.
+> Screen Recording / TCC work. See TODO.
+
+## Alpha packaging
+
+Internal alpha packaging is manual DMG only:
+
+```bash
+DEVELOPER_ID_APPLICATION="Developer ID Application: OMER FARUK AKBEN (...)" \
+NOTARYTOOL_PROFILE="tael-notary" \
+VERSION="0.1.0-alpha.1" \
+./scripts/package-alpha-dmg.sh
+```
+
+See [`docs/AlphaReleaseChecklist.md`](docs/AlphaReleaseChecklist.md).
 
 ## Branches
 
-- `main` — frozen plan + scaffold
-- `dev-claude` — Maestro Claude development branch (this branch)
-- `dev-codex` — Codex development branch
+- `main` is the production/release branch.
+- `develop` is the integration branch.
+- `feature/*` and `codex/*` branches PR into `develop`.
 
 ## License
 

--- a/TAELMacAgent/TAELMacAgent.xcodeproj/project.pbxproj
+++ b/TAELMacAgent/TAELMacAgent.xcodeproj/project.pbxproj
@@ -3,404 +3,335 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 56;
+	objectVersion = 77;
 	objects = {
 
 /* Begin PBXBuildFile section */
-		2B00000000000000000000A1 /* TAELMacAgentApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A00000000000000000000A1 /* TAELMacAgentApp.swift */; };
-		2B00000000000000000000A2 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A00000000000000000000A2 /* AppDelegate.swift */; };
-		2B00000000000000000000A3 /* MenuBarController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A00000000000000000000A3 /* MenuBarController.swift */; };
-		2B00000000000000000000A4 /* HotkeyManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A00000000000000000000A4 /* HotkeyManager.swift */; };
-		2B00000000000000000000A5 /* PermissionKind.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A00000000000000000000A5 /* PermissionKind.swift */; };
-		2B00000000000000000000A6 /* PermissionStatus.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A00000000000000000000A6 /* PermissionStatus.swift */; };
-		2B00000000000000000000A7 /* PermissionError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A00000000000000000000A7 /* PermissionError.swift */; };
-		2B00000000000000000000A9 /* PermissionsChecker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A00000000000000000000A9 /* PermissionsChecker.swift */; };
-		2B00000000000000000000AA /* PermissionsGate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A00000000000000000000AA /* PermissionsGate.swift */; };
-		2B00000000000000000000AB /* HUDPanelController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A00000000000000000000AB /* HUDPanelController.swift */; };
-		2B00000000000000000000AC /* HUDView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A00000000000000000000AC /* HUDView.swift */; };
-		2B00000000000000000000AD /* PermissionGateView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A00000000000000000000AD /* PermissionGateView.swift */; };
-		2B00000000000000000000AE /* ScreenshotTarget.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A00000000000000000000AE /* ScreenshotTarget.swift */; };
-		2B00000000000000000000AF /* CapturedScreenshot.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A00000000000000000000AF /* CapturedScreenshot.swift */; };
-		2B00000000000000000000B0 /* ScreenCaptureService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A00000000000000000000B0 /* ScreenCaptureService.swift */; };
-		2B00000000000000000000B1 /* InvocationLog.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A00000000000000000000B1 /* InvocationLog.swift */; };
-		2B00000000000000000000B2 /* LocalLogService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A00000000000000000000B2 /* LocalLogService.swift */; };
-		2B00000000000000000000B3 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 1A00000000000000000000B3 /* Assets.xcassets */; };
-		2B00000000000000000000C1 /* PermissionsGateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A00000000000000000000C1 /* PermissionsGateTests.swift */; };
-		2B00000000000000000000C2 /* LocalLogServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A00000000000000000000C2 /* LocalLogServiceTests.swift */; };
+		0330637AAF26CC3C25DCD10F /* CapturedScreenshot.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6DEC30773055C5F4AE735610 /* CapturedScreenshot.swift */; };
+		033A279961698D88188A33AD /* MenuBarController.swift in Sources */ = {isa = PBXBuildFile; fileRef = EBD624AFDCE20EF4B613B9A4 /* MenuBarController.swift */; };
+		0B0660E9860988CD91DA599E /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB704571A9597F9AF9313D65 /* AppDelegate.swift */; };
+		1EFB0EA699153ADC53EA4286 /* LocalLogServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C654DA20715C3C6F29B9E6F4 /* LocalLogServiceTests.swift */; };
+		34F3D8094B35A969BEFEFE4A /* LocalLogService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F5C315999DFCC84BE675BE2 /* LocalLogService.swift */; };
+		3F34E0D14D96EB8D52BE71A0 /* TAELMacAgentApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 69DDCCAE89FD5A160E17AE49 /* TAELMacAgentApp.swift */; };
+		5AD70596B8B5BEBD936F2F60 /* PermissionsGateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14306A2EBDA587DA5C4E6182 /* PermissionsGateTests.swift */; };
+		6AB4701304241B41166818BB /* HotkeyManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 917682B8FDBFE7C755263E19 /* HotkeyManager.swift */; };
+		6BA0CBE1B80E6592A9C6983A /* PermissionGateView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 422D881643EB42E6E96F6073 /* PermissionGateView.swift */; };
+		7A08515211A39DD11A6E370B /* PermissionsGate.swift in Sources */ = {isa = PBXBuildFile; fileRef = F46F76B62679E79E964F4EAE /* PermissionsGate.swift */; };
+		8AC8665020F765D063A96609 /* HUDPanelController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9363E4D91044162835D20FAA /* HUDPanelController.swift */; };
+		C3C9015E4F181F2FC2A056BB /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 3900941745D06B0194400E8E /* Assets.xcassets */; };
+		CACD72769410271CF6577CC0 /* InvocationLog.swift in Sources */ = {isa = PBXBuildFile; fileRef = A74AE945B8920595491B2B29 /* InvocationLog.swift */; };
+		CF17A6BDF21FD1B3F8690D13 /* PermissionError.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED47D03840F40871272ED13C /* PermissionError.swift */; };
+		D4D7892F3C39042079C92DEC /* PermissionsChecker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D36CFA939327054CE038538 /* PermissionsChecker.swift */; };
+		E22538B7BAFDD6DE67CD39A6 /* PermissionKind.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E3601A9D97DFCC20CB1B190 /* PermissionKind.swift */; };
+		EE4E5F822C40DF6233CBDD2A /* ScreenshotTarget.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6C80394C10DB95ACE8B23410 /* ScreenshotTarget.swift */; };
+		F213518191A0D0FBED62E67B /* ScreenCaptureService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 198A12FCDFC021700C887DC3 /* ScreenCaptureService.swift */; };
+		F8A8B61233E0F29CD0725388 /* HUDView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1469160F2705F009163C15E0 /* HUDView.swift */; };
+		FC2769F84CA630E5B0E73F55 /* PermissionStatus.swift in Sources */ = {isa = PBXBuildFile; fileRef = 639F88F50828EB01F823718B /* PermissionStatus.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
-		9A00000000000000000000A1 /* PBXContainerItemProxy */ = {
+		A47BAD4074508EE5400D1CDF /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
-			containerPortal = 8A00000000000000000000A1 /* Project object */;
+			containerPortal = 5D9768FD172621FBD47CDD94 /* Project object */;
 			proxyType = 1;
-			remoteGlobalIDString = 7A00000000000000000000A1;
+			remoteGlobalIDString = 19B5206FF51EAAA5D9DD33BD;
 			remoteInfo = TAELMacAgent;
 		};
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
-		1A00000000000000000000A1 /* TAELMacAgentApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TAELMacAgentApp.swift; sourceTree = "<group>"; };
-		1A00000000000000000000A2 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
-		1A00000000000000000000A3 /* MenuBarController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MenuBarController.swift; sourceTree = "<group>"; };
-		1A00000000000000000000A4 /* HotkeyManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HotkeyManager.swift; sourceTree = "<group>"; };
-		1A00000000000000000000A5 /* PermissionKind.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PermissionKind.swift; sourceTree = "<group>"; };
-		1A00000000000000000000A6 /* PermissionStatus.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PermissionStatus.swift; sourceTree = "<group>"; };
-		1A00000000000000000000A7 /* PermissionError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PermissionError.swift; sourceTree = "<group>"; };
-		1A00000000000000000000A9 /* PermissionsChecker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PermissionsChecker.swift; sourceTree = "<group>"; };
-		1A00000000000000000000AA /* PermissionsGate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PermissionsGate.swift; sourceTree = "<group>"; };
-		1A00000000000000000000AB /* HUDPanelController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HUDPanelController.swift; sourceTree = "<group>"; };
-		1A00000000000000000000AC /* HUDView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HUDView.swift; sourceTree = "<group>"; };
-		1A00000000000000000000AD /* PermissionGateView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PermissionGateView.swift; sourceTree = "<group>"; };
-		1A00000000000000000000AE /* ScreenshotTarget.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScreenshotTarget.swift; sourceTree = "<group>"; };
-		1A00000000000000000000AF /* CapturedScreenshot.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CapturedScreenshot.swift; sourceTree = "<group>"; };
-		1A00000000000000000000B0 /* ScreenCaptureService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScreenCaptureService.swift; sourceTree = "<group>"; };
-		1A00000000000000000000B1 /* InvocationLog.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InvocationLog.swift; sourceTree = "<group>"; };
-		1A00000000000000000000B2 /* LocalLogService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalLogService.swift; sourceTree = "<group>"; };
-		1A00000000000000000000B3 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
-		1A00000000000000000000B4 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
-		1A00000000000000000000B5 /* TAELMacAgent.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = TAELMacAgent.entitlements; sourceTree = "<group>"; };
-		1A00000000000000000000C1 /* PermissionsGateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PermissionsGateTests.swift; sourceTree = "<group>"; };
-		1A00000000000000000000C2 /* LocalLogServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalLogServiceTests.swift; sourceTree = "<group>"; };
-		1A00000000000000000000F1 /* TAELMacAgent.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = TAELMacAgent.app; sourceTree = BUILT_PRODUCTS_DIR; };
-		1A00000000000000000000F2 /* TAELMacAgentTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = TAELMacAgentTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		09182C33476D9D80D775700D /* TAELMacAgent.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = TAELMacAgent.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		14306A2EBDA587DA5C4E6182 /* PermissionsGateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PermissionsGateTests.swift; sourceTree = "<group>"; };
+		1469160F2705F009163C15E0 /* HUDView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HUDView.swift; sourceTree = "<group>"; };
+		198A12FCDFC021700C887DC3 /* ScreenCaptureService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScreenCaptureService.swift; sourceTree = "<group>"; };
+		1D36CFA939327054CE038538 /* PermissionsChecker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PermissionsChecker.swift; sourceTree = "<group>"; };
+		3900941745D06B0194400E8E /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
+		422D881643EB42E6E96F6073 /* PermissionGateView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PermissionGateView.swift; sourceTree = "<group>"; };
+		639F88F50828EB01F823718B /* PermissionStatus.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PermissionStatus.swift; sourceTree = "<group>"; };
+		69DDCCAE89FD5A160E17AE49 /* TAELMacAgentApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TAELMacAgentApp.swift; sourceTree = "<group>"; };
+		6C80394C10DB95ACE8B23410 /* ScreenshotTarget.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScreenshotTarget.swift; sourceTree = "<group>"; };
+		6DEC30773055C5F4AE735610 /* CapturedScreenshot.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CapturedScreenshot.swift; sourceTree = "<group>"; };
+		6E3601A9D97DFCC20CB1B190 /* PermissionKind.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PermissionKind.swift; sourceTree = "<group>"; };
+		6F5C315999DFCC84BE675BE2 /* LocalLogService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalLogService.swift; sourceTree = "<group>"; };
+		917682B8FDBFE7C755263E19 /* HotkeyManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HotkeyManager.swift; sourceTree = "<group>"; };
+		9363E4D91044162835D20FAA /* HUDPanelController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HUDPanelController.swift; sourceTree = "<group>"; };
+		9A76044EF0F9B7BE7C3F5C00 /* TAELMacAgentTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = TAELMacAgentTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		A74AE945B8920595491B2B29 /* InvocationLog.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InvocationLog.swift; sourceTree = "<group>"; };
+		AB704571A9597F9AF9313D65 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
+		C654DA20715C3C6F29B9E6F4 /* LocalLogServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalLogServiceTests.swift; sourceTree = "<group>"; };
+		EBD624AFDCE20EF4B613B9A4 /* MenuBarController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MenuBarController.swift; sourceTree = "<group>"; };
+		ED47D03840F40871272ED13C /* PermissionError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PermissionError.swift; sourceTree = "<group>"; };
+		F46F76B62679E79E964F4EAE /* PermissionsGate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PermissionsGate.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
-/* Begin PBXFrameworksBuildPhase section */
-		4A00000000000000000000A2 /* Frameworks */ = {
-			isa = PBXFrameworksBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		4A00000000000000000000C2 /* Frameworks */ = {
-			isa = PBXFrameworksBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-/* End PBXFrameworksBuildPhase section */
-
 /* Begin PBXGroup section */
-		3A00000000000000000000A1 /* / */ = {
+		1D955BDFBFFB1E992ABC4E95 /* TAELMacAgentTests */ = {
 			isa = PBXGroup;
 			children = (
-				3A00000000000000000000A2 /* TAELMacAgent */,
-				3A00000000000000000000C0 /* TAELMacAgentTests */,
-				3A00000000000000000000F0 /* Products */,
-			);
-			sourceTree = "<group>";
-		};
-		3A00000000000000000000A2 /* TAELMacAgent */ = {
-			isa = PBXGroup;
-			children = (
-				3A00000000000000000000A3 /* App */,
-				3A00000000000000000000A4 /* Hotkey */,
-				3A00000000000000000000A5 /* Permissions */,
-				3A00000000000000000000A6 /* HUD */,
-				3A00000000000000000000A7 /* Capture */,
-				3A00000000000000000000A8 /* Logging */,
-				3A00000000000000000000A9 /* Resources */,
-			);
-			path = TAELMacAgent;
-			sourceTree = "<group>";
-		};
-		3A00000000000000000000A3 /* App */ = {
-			isa = PBXGroup;
-			children = (
-				1A00000000000000000000A1 /* TAELMacAgentApp.swift */,
-				1A00000000000000000000A2 /* AppDelegate.swift */,
-				1A00000000000000000000A3 /* MenuBarController.swift */,
-			);
-			path = App;
-			sourceTree = "<group>";
-		};
-		3A00000000000000000000A4 /* Hotkey */ = {
-			isa = PBXGroup;
-			children = (
-				1A00000000000000000000A4 /* HotkeyManager.swift */,
-			);
-			path = Hotkey;
-			sourceTree = "<group>";
-		};
-		3A00000000000000000000A5 /* Permissions */ = {
-			isa = PBXGroup;
-			children = (
-				1A00000000000000000000A5 /* PermissionKind.swift */,
-				1A00000000000000000000A6 /* PermissionStatus.swift */,
-				1A00000000000000000000A7 /* PermissionError.swift */,
-				1A00000000000000000000A9 /* PermissionsChecker.swift */,
-				1A00000000000000000000AA /* PermissionsGate.swift */,
-			);
-			path = Permissions;
-			sourceTree = "<group>";
-		};
-		3A00000000000000000000A6 /* HUD */ = {
-			isa = PBXGroup;
-			children = (
-				1A00000000000000000000AB /* HUDPanelController.swift */,
-				1A00000000000000000000AC /* HUDView.swift */,
-				1A00000000000000000000AD /* PermissionGateView.swift */,
-			);
-			path = HUD;
-			sourceTree = "<group>";
-		};
-		3A00000000000000000000A7 /* Capture */ = {
-			isa = PBXGroup;
-			children = (
-				1A00000000000000000000AE /* ScreenshotTarget.swift */,
-				1A00000000000000000000AF /* CapturedScreenshot.swift */,
-				1A00000000000000000000B0 /* ScreenCaptureService.swift */,
-			);
-			path = Capture;
-			sourceTree = "<group>";
-		};
-		3A00000000000000000000A8 /* Logging */ = {
-			isa = PBXGroup;
-			children = (
-				1A00000000000000000000B1 /* InvocationLog.swift */,
-				1A00000000000000000000B2 /* LocalLogService.swift */,
-			);
-			path = Logging;
-			sourceTree = "<group>";
-		};
-		3A00000000000000000000A9 /* Resources */ = {
-			isa = PBXGroup;
-			children = (
-				1A00000000000000000000B3 /* Assets.xcassets */,
-				1A00000000000000000000B4 /* Info.plist */,
-				1A00000000000000000000B5 /* TAELMacAgent.entitlements */,
-			);
-			path = Resources;
-			sourceTree = "<group>";
-		};
-		3A00000000000000000000C0 /* TAELMacAgentTests */ = {
-			isa = PBXGroup;
-			children = (
-				1A00000000000000000000C1 /* PermissionsGateTests.swift */,
-				1A00000000000000000000C2 /* LocalLogServiceTests.swift */,
+				C654DA20715C3C6F29B9E6F4 /* LocalLogServiceTests.swift */,
+				14306A2EBDA587DA5C4E6182 /* PermissionsGateTests.swift */,
 			);
 			path = TAELMacAgentTests;
 			sourceTree = "<group>";
 		};
-		3A00000000000000000000F0 /* Products */ = {
+		25F2B0347D98A8AADDF902E0 /* HUD */ = {
 			isa = PBXGroup;
 			children = (
-				1A00000000000000000000F1 /* TAELMacAgent.app */,
-				1A00000000000000000000F2 /* TAELMacAgentTests.xctest */,
+				9363E4D91044162835D20FAA /* HUDPanelController.swift */,
+				1469160F2705F009163C15E0 /* HUDView.swift */,
+				422D881643EB42E6E96F6073 /* PermissionGateView.swift */,
+			);
+			path = HUD;
+			sourceTree = "<group>";
+		};
+		79CF0DC83C35B3DE92D7BB44 = {
+			isa = PBXGroup;
+			children = (
+				97DC61CEC80B8232B91B4BA6 /* TAELMacAgent */,
+				1D955BDFBFFB1E992ABC4E95 /* TAELMacAgentTests */,
+				C965C9197045CDCA448A4FB4 /* Products */,
+			);
+			sourceTree = "<group>";
+		};
+		8CB452CA408F114826DD96AE /* App */ = {
+			isa = PBXGroup;
+			children = (
+				AB704571A9597F9AF9313D65 /* AppDelegate.swift */,
+				EBD624AFDCE20EF4B613B9A4 /* MenuBarController.swift */,
+				69DDCCAE89FD5A160E17AE49 /* TAELMacAgentApp.swift */,
+			);
+			path = App;
+			sourceTree = "<group>";
+		};
+		97DC61CEC80B8232B91B4BA6 /* TAELMacAgent */ = {
+			isa = PBXGroup;
+			children = (
+				8CB452CA408F114826DD96AE /* App */,
+				99C93CFB96CF8F9301DF4757 /* Capture */,
+				CBA9F060F0EAA0AC77F03091 /* Hotkey */,
+				25F2B0347D98A8AADDF902E0 /* HUD */,
+				C2646529B7BB101A453D1AD4 /* Logging */,
+				B93A3ED5294E22762F9486DE /* Permissions */,
+				E1AEF778526EC40069A64DB6 /* Resources */,
+			);
+			path = TAELMacAgent;
+			sourceTree = "<group>";
+		};
+		99C93CFB96CF8F9301DF4757 /* Capture */ = {
+			isa = PBXGroup;
+			children = (
+				6DEC30773055C5F4AE735610 /* CapturedScreenshot.swift */,
+				198A12FCDFC021700C887DC3 /* ScreenCaptureService.swift */,
+				6C80394C10DB95ACE8B23410 /* ScreenshotTarget.swift */,
+			);
+			path = Capture;
+			sourceTree = "<group>";
+		};
+		B93A3ED5294E22762F9486DE /* Permissions */ = {
+			isa = PBXGroup;
+			children = (
+				ED47D03840F40871272ED13C /* PermissionError.swift */,
+				6E3601A9D97DFCC20CB1B190 /* PermissionKind.swift */,
+				1D36CFA939327054CE038538 /* PermissionsChecker.swift */,
+				F46F76B62679E79E964F4EAE /* PermissionsGate.swift */,
+				639F88F50828EB01F823718B /* PermissionStatus.swift */,
+			);
+			path = Permissions;
+			sourceTree = "<group>";
+		};
+		C2646529B7BB101A453D1AD4 /* Logging */ = {
+			isa = PBXGroup;
+			children = (
+				A74AE945B8920595491B2B29 /* InvocationLog.swift */,
+				6F5C315999DFCC84BE675BE2 /* LocalLogService.swift */,
+			);
+			path = Logging;
+			sourceTree = "<group>";
+		};
+		C965C9197045CDCA448A4FB4 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				09182C33476D9D80D775700D /* TAELMacAgent.app */,
+				9A76044EF0F9B7BE7C3F5C00 /* TAELMacAgentTests.xctest */,
 			);
 			name = Products;
+			sourceTree = "<group>";
+		};
+		CBA9F060F0EAA0AC77F03091 /* Hotkey */ = {
+			isa = PBXGroup;
+			children = (
+				917682B8FDBFE7C755263E19 /* HotkeyManager.swift */,
+			);
+			path = Hotkey;
+			sourceTree = "<group>";
+		};
+		E1AEF778526EC40069A64DB6 /* Resources */ = {
+			isa = PBXGroup;
+			children = (
+				3900941745D06B0194400E8E /* Assets.xcassets */,
+			);
+			path = Resources;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
-		7A00000000000000000000A1 /* TAELMacAgent */ = {
+		19B5206FF51EAAA5D9DD33BD /* TAELMacAgent */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = 6A00000000000000000000A2 /* Build configuration list for PBXNativeTarget "TAELMacAgent" */;
+			buildConfigurationList = 117EFF58E2C38224B38B8B12 /* Build configuration list for PBXNativeTarget "TAELMacAgent" */;
 			buildPhases = (
-				4A00000000000000000000A1 /* Sources */,
-				4A00000000000000000000A2 /* Frameworks */,
-				4A00000000000000000000A3 /* Resources */,
+				A804338716259752E11524FD /* Sources */,
+				D18C72E98AF490A89259C1D9 /* Resources */,
 			);
 			buildRules = (
 			);
 			dependencies = (
 			);
 			name = TAELMacAgent;
+			packageProductDependencies = (
+			);
 			productName = TAELMacAgent;
-			productReference = 1A00000000000000000000F1 /* TAELMacAgent.app */;
+			productReference = 09182C33476D9D80D775700D /* TAELMacAgent.app */;
 			productType = "com.apple.product-type.application";
 		};
-		7A00000000000000000000C1 /* TAELMacAgentTests */ = {
+		7BBF771A19B870A8BDB655E7 /* TAELMacAgentTests */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = 6A00000000000000000000C2 /* Build configuration list for PBXNativeTarget "TAELMacAgentTests" */;
+			buildConfigurationList = 76317FEDB9101E1DC4C2585C /* Build configuration list for PBXNativeTarget "TAELMacAgentTests" */;
 			buildPhases = (
-				4A00000000000000000000C1 /* Sources */,
-				4A00000000000000000000C2 /* Frameworks */,
-				4A00000000000000000000C3 /* Resources */,
+				BF41B36D68ED461F93AE9C02 /* Sources */,
 			);
 			buildRules = (
 			);
 			dependencies = (
-				9A00000000000000000000B1 /* PBXTargetDependency */,
+				6C4ED6EB1C9863C9CCFC4C51 /* PBXTargetDependency */,
 			);
 			name = TAELMacAgentTests;
+			packageProductDependencies = (
+			);
 			productName = TAELMacAgentTests;
-			productReference = 1A00000000000000000000F2 /* TAELMacAgentTests.xctest */;
+			productReference = 9A76044EF0F9B7BE7C3F5C00 /* TAELMacAgentTests.xctest */;
 			productType = "com.apple.product-type.bundle.unit-test";
 		};
 /* End PBXNativeTarget section */
 
 /* Begin PBXProject section */
-		8A00000000000000000000A1 /* Project object */ = {
+		5D9768FD172621FBD47CDD94 /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
 				BuildIndependentTargetsInParallel = YES;
-				LastSwiftUpdateCheck = 1530;
-				LastUpgradeCheck = 1530;
+				LastUpgradeCheck = 1430;
 				TargetAttributes = {
-					7A00000000000000000000A1 = {
-						CreatedOnToolsVersion = 15.3;
+					19B5206FF51EAAA5D9DD33BD = {
+						DevelopmentTeam = "";
+						ProvisioningStyle = Automatic;
 					};
-					7A00000000000000000000C1 = {
-						CreatedOnToolsVersion = 15.3;
-						TestTargetID = 7A00000000000000000000A1;
+					7BBF771A19B870A8BDB655E7 = {
+						DevelopmentTeam = "";
 					};
 				};
 			};
-			buildConfigurationList = 6A00000000000000000000A1 /* Build configuration list for PBXProject "TAELMacAgent" */;
-			compatibilityVersion = "Xcode 14.0";
+			buildConfigurationList = 9EE8029557141161462E8753 /* Build configuration list for PBXProject "TAELMacAgent" */;
 			developmentRegion = en;
 			hasScannedForEncodings = 0;
 			knownRegions = (
-				en,
 				Base,
+				en,
 			);
-			mainGroup = 3A00000000000000000000A1;
-			productRefGroup = 3A00000000000000000000F0 /* Products */;
+			mainGroup = 79CF0DC83C35B3DE92D7BB44;
+			minimizedProjectReferenceProxies = 1;
+			preferredProjectObjectVersion = 77;
+			productRefGroup = C965C9197045CDCA448A4FB4 /* Products */;
 			projectDirPath = "";
 			projectRoot = "";
 			targets = (
-				7A00000000000000000000A1 /* TAELMacAgent */,
-				7A00000000000000000000C1 /* TAELMacAgentTests */,
+				19B5206FF51EAAA5D9DD33BD /* TAELMacAgent */,
+				7BBF771A19B870A8BDB655E7 /* TAELMacAgentTests */,
 			);
 		};
 /* End PBXProject section */
 
 /* Begin PBXResourcesBuildPhase section */
-		4A00000000000000000000A3 /* Resources */ = {
+		D18C72E98AF490A89259C1D9 /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				2B00000000000000000000B3 /* Assets.xcassets in Resources */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		4A00000000000000000000C3 /* Resources */ = {
-			isa = PBXResourcesBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
+				C3C9015E4F181F2FC2A056BB /* Assets.xcassets in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
-		4A00000000000000000000A1 /* Sources */ = {
+		A804338716259752E11524FD /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				2B00000000000000000000A1 /* TAELMacAgentApp.swift in Sources */,
-				2B00000000000000000000A2 /* AppDelegate.swift in Sources */,
-				2B00000000000000000000A3 /* MenuBarController.swift in Sources */,
-				2B00000000000000000000A4 /* HotkeyManager.swift in Sources */,
-				2B00000000000000000000A5 /* PermissionKind.swift in Sources */,
-				2B00000000000000000000A6 /* PermissionStatus.swift in Sources */,
-				2B00000000000000000000A7 /* PermissionError.swift in Sources */,
-				2B00000000000000000000A9 /* PermissionsChecker.swift in Sources */,
-				2B00000000000000000000AA /* PermissionsGate.swift in Sources */,
-				2B00000000000000000000AB /* HUDPanelController.swift in Sources */,
-				2B00000000000000000000AC /* HUDView.swift in Sources */,
-				2B00000000000000000000AD /* PermissionGateView.swift in Sources */,
-				2B00000000000000000000AE /* ScreenshotTarget.swift in Sources */,
-				2B00000000000000000000AF /* CapturedScreenshot.swift in Sources */,
-				2B00000000000000000000B0 /* ScreenCaptureService.swift in Sources */,
-				2B00000000000000000000B1 /* InvocationLog.swift in Sources */,
-				2B00000000000000000000B2 /* LocalLogService.swift in Sources */,
+				0B0660E9860988CD91DA599E /* AppDelegate.swift in Sources */,
+				0330637AAF26CC3C25DCD10F /* CapturedScreenshot.swift in Sources */,
+				8AC8665020F765D063A96609 /* HUDPanelController.swift in Sources */,
+				F8A8B61233E0F29CD0725388 /* HUDView.swift in Sources */,
+				6AB4701304241B41166818BB /* HotkeyManager.swift in Sources */,
+				CACD72769410271CF6577CC0 /* InvocationLog.swift in Sources */,
+				34F3D8094B35A969BEFEFE4A /* LocalLogService.swift in Sources */,
+				033A279961698D88188A33AD /* MenuBarController.swift in Sources */,
+				CF17A6BDF21FD1B3F8690D13 /* PermissionError.swift in Sources */,
+				6BA0CBE1B80E6592A9C6983A /* PermissionGateView.swift in Sources */,
+				E22538B7BAFDD6DE67CD39A6 /* PermissionKind.swift in Sources */,
+				FC2769F84CA630E5B0E73F55 /* PermissionStatus.swift in Sources */,
+				D4D7892F3C39042079C92DEC /* PermissionsChecker.swift in Sources */,
+				7A08515211A39DD11A6E370B /* PermissionsGate.swift in Sources */,
+				F213518191A0D0FBED62E67B /* ScreenCaptureService.swift in Sources */,
+				EE4E5F822C40DF6233CBDD2A /* ScreenshotTarget.swift in Sources */,
+				3F34E0D14D96EB8D52BE71A0 /* TAELMacAgentApp.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		4A00000000000000000000C1 /* Sources */ = {
+		BF41B36D68ED461F93AE9C02 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				2B00000000000000000000C1 /* PermissionsGateTests.swift in Sources */,
-				2B00000000000000000000C2 /* LocalLogServiceTests.swift in Sources */,
+				1EFB0EA699153ADC53EA4286 /* LocalLogServiceTests.swift in Sources */,
+				5AD70596B8B5BEBD936F2F60 /* PermissionsGateTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
-		9A00000000000000000000B1 /* PBXTargetDependency */ = {
+		6C4ED6EB1C9863C9CCFC4C51 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
-			target = 7A00000000000000000000A1 /* TAELMacAgent */;
-			targetProxy = 9A00000000000000000000A1 /* PBXContainerItemProxy */;
+			target = 19B5206FF51EAAA5D9DD33BD /* TAELMacAgent */;
+			targetProxy = A47BAD4074508EE5400D1CDF /* PBXContainerItemProxy */;
 		};
 /* End PBXTargetDependency section */
 
 /* Begin XCBuildConfiguration section */
-		5A00000000000000000000A1 /* Debug */ = {
+		0E16266BE06C30C4664F152D /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				ALWAYS_SEARCH_USER_PATHS = NO;
-				CLANG_ANALYZER_NONNULL = YES;
-				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
-				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
-				CLANG_ENABLE_MODULES = YES;
-				CLANG_ENABLE_OBJC_ARC = YES;
-				CLANG_ENABLE_OBJC_WEAK = YES;
-				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
-				CLANG_WARN_BOOL_CONVERSION = YES;
-				CLANG_WARN_COMMA = YES;
-				CLANG_WARN_CONSTANT_CONVERSION = YES;
-				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
-				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
-				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
-				CLANG_WARN_EMPTY_BODY = YES;
-				CLANG_WARN_ENUM_CONVERSION = YES;
-				CLANG_WARN_INFINITE_RECURSION = YES;
-				CLANG_WARN_INT_CONVERSION = YES;
-				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
-				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
-				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
-				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
-				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
-				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
-				CLANG_WARN_STRICT_PROTOTYPES = YES;
-				CLANG_WARN_SUSPICIOUS_MOVE = YES;
-				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
-				CLANG_WARN_UNREACHABLE_CODE = YES;
-				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
-				COPY_PHASE_STRIP = NO;
-				DEBUG_INFORMATION_FORMAT = dwarf;
-				ENABLE_STRICT_OBJC_MSGSEND = YES;
-				ENABLE_TESTABILITY = YES;
-				GCC_C_LANGUAGE_STANDARD = gnu17;
-				GCC_DYNAMIC_NO_PIC = NO;
-				GCC_NO_COMMON_BLOCKS = YES;
-				GCC_OPTIMIZATION_LEVEL = 0;
-				GCC_PREPROCESSOR_DEFINITIONS = (
-					"DEBUG=1",
-					"$(inherited)",
-				);
-				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
-				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
-				GCC_WARN_UNDECLARED_SELECTOR = YES;
-				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
-				GCC_WARN_UNUSED_FUNCTION = YES;
-				GCC_WARN_UNUSED_VARIABLE = YES;
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CODE_SIGN_ENTITLEMENTS = TAELMacAgent/Resources/TAELMacAgent.entitlements;
+				CODE_SIGN_STYLE = Automatic;
+				COMBINE_HIDPI_IMAGES = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = YES;
+				GENERATE_INFOPLIST_FILE = NO;
+				INFOPLIST_FILE = TAELMacAgent/Resources/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 14.0;
-				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
-				MTL_FAST_MATH = YES;
-				ONLY_ACTIVE_ARCH = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = ai.tael.macagent;
+				PRODUCT_NAME = TAELMacAgent;
 				SDKROOT = macosx;
-				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
-				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				SWIFT_STRICT_CONCURRENCY = complete;
 			};
-			name = Debug;
+			name = Release;
 		};
-		5A00000000000000000000A2 /* Release */ = {
+		2F433CDCD1DA99C432DADA1A /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				CLANG_ANALYZER_NONNULL = YES;
 				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
-				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_CXX_LIBRARY = "libc++";
 				CLANG_ENABLE_MODULES = YES;
 				CLANG_ENABLE_OBJC_ARC = YES;
 				CLANG_ENABLE_OBJC_WEAK = YES;
@@ -428,9 +359,11 @@
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				COPY_PHASE_STRIP = NO;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				DEVELOPMENT_TEAM = "";
+				ENABLE_HARDENED_RUNTIME = YES;
 				ENABLE_NS_ASSERTIONS = NO;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
-				GCC_C_LANGUAGE_STANDARD = gnu17;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
 				GCC_NO_COMMON_BLOCKS = YES;
 				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
 				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
@@ -441,96 +374,131 @@
 				MACOSX_DEPLOYMENT_TARGET = 14.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				MTL_FAST_MATH = YES;
+				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = macosx;
 				SWIFT_COMPILATION_MODE = wholemodule;
+				SWIFT_OPTIMIZATION_LEVEL = "-O";
 				SWIFT_STRICT_CONCURRENCY = complete;
-			};
-			name = Release;
-		};
-		5A00000000000000000000A3 /* Debug */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
-				CODE_SIGN_ENTITLEMENTS = TAELMacAgent/Resources/TAELMacAgent.entitlements;
-				CODE_SIGN_STYLE = Automatic;
-				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = "";
-				ENABLE_HARDENED_RUNTIME = YES;
-				ENABLE_PREVIEWS = YES;
-				GENERATE_INFOPLIST_FILE = NO;
-				INFOPLIST_FILE = TAELMacAgent/Resources/Info.plist;
-				LD_RUNPATH_SEARCH_PATHS = (
-					"$(inherited)",
-					"@executable_path/../Frameworks",
-				);
-				MACOSX_DEPLOYMENT_TARGET = 14.0;
-				MARKETING_VERSION = 0.1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = ai.tael.macagent;
-				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_EMIT_LOC_STRINGS = YES;
-				SWIFT_VERSION = 5.0;
-			};
-			name = Debug;
-		};
-		5A00000000000000000000A4 /* Release */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
-				CODE_SIGN_ENTITLEMENTS = TAELMacAgent/Resources/TAELMacAgent.entitlements;
-				CODE_SIGN_STYLE = Automatic;
-				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = "";
-				ENABLE_HARDENED_RUNTIME = YES;
-				ENABLE_PREVIEWS = YES;
-				GENERATE_INFOPLIST_FILE = NO;
-				INFOPLIST_FILE = TAELMacAgent/Resources/Info.plist;
-				LD_RUNPATH_SEARCH_PATHS = (
-					"$(inherited)",
-					"@executable_path/../Frameworks",
-				);
-				MACOSX_DEPLOYMENT_TARGET = 14.0;
-				MARKETING_VERSION = 0.1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = ai.tael.macagent;
-				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_VERSION = 5.0;
 			};
 			name = Release;
 		};
-		5A00000000000000000000C1 /* Debug */ = {
+		30CD9C0A39029D9324927179 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
-				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = "";
-				GENERATE_INFOPLIST_FILE = YES;
+				COMBINE_HIDPI_IMAGES = YES;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/../Frameworks",
+					"@loader_path/../Frameworks",
+				);
 				MACOSX_DEPLOYMENT_TARGET = 14.0;
-				MARKETING_VERSION = 1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = ai.tael.macagent.tests;
-				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_EMIT_LOC_STRINGS = NO;
-				SWIFT_VERSION = 5.0;
+				PRODUCT_NAME = TAELMacAgentTests;
+				SDKROOT = macosx;
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/TAELMacAgent.app/Contents/MacOS/TAELMacAgent";
 			};
 			name = Debug;
 		};
-		5A00000000000000000000C2 /* Release */ = {
+		3D3753EFBE210BA568497A6B /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				DEVELOPMENT_TEAM = "";
+				ENABLE_HARDENED_RUNTIME = YES;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"$(inherited)",
+					"DEBUG=1",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				MACOSX_DEPLOYMENT_TARGET = 14.0;
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = macosx;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_STRICT_CONCURRENCY = complete;
+				SWIFT_VERSION = 5.0;
+			};
+			name = Debug;
+		};
+		97E6B9E4270F081105DFF762 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CODE_SIGN_ENTITLEMENTS = TAELMacAgent/Resources/TAELMacAgent.entitlements;
+				CODE_SIGN_STYLE = Automatic;
+				COMBINE_HIDPI_IMAGES = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = YES;
+				GENERATE_INFOPLIST_FILE = NO;
+				INFOPLIST_FILE = TAELMacAgent/Resources/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks";
+				MACOSX_DEPLOYMENT_TARGET = 14.0;
+				PRODUCT_BUNDLE_IDENTIFIER = ai.tael.macagent;
+				PRODUCT_NAME = TAELMacAgent;
+				SDKROOT = macosx;
+			};
+			name = Debug;
+		};
+		EDA2C5DF0A791BA5388D23C2 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
-				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = "";
-				GENERATE_INFOPLIST_FILE = YES;
+				COMBINE_HIDPI_IMAGES = YES;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/../Frameworks",
+					"@loader_path/../Frameworks",
+				);
 				MACOSX_DEPLOYMENT_TARGET = 14.0;
-				MARKETING_VERSION = 1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = ai.tael.macagent.tests;
-				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_EMIT_LOC_STRINGS = NO;
-				SWIFT_VERSION = 5.0;
+				PRODUCT_NAME = TAELMacAgentTests;
+				SDKROOT = macosx;
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/TAELMacAgent.app/Contents/MacOS/TAELMacAgent";
 			};
 			name = Release;
@@ -538,34 +506,34 @@
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
-		6A00000000000000000000A1 /* Build configuration list for PBXProject "TAELMacAgent" */ = {
+		117EFF58E2C38224B38B8B12 /* Build configuration list for PBXNativeTarget "TAELMacAgent" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				5A00000000000000000000A1 /* Debug */,
-				5A00000000000000000000A2 /* Release */,
+				97E6B9E4270F081105DFF762 /* Debug */,
+				0E16266BE06C30C4664F152D /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = Release;
+			defaultConfigurationName = Debug;
 		};
-		6A00000000000000000000A2 /* Build configuration list for PBXNativeTarget "TAELMacAgent" */ = {
+		76317FEDB9101E1DC4C2585C /* Build configuration list for PBXNativeTarget "TAELMacAgentTests" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				5A00000000000000000000A3 /* Debug */,
-				5A00000000000000000000A4 /* Release */,
+				30CD9C0A39029D9324927179 /* Debug */,
+				EDA2C5DF0A791BA5388D23C2 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = Release;
+			defaultConfigurationName = Debug;
 		};
-		6A00000000000000000000C2 /* Build configuration list for PBXNativeTarget "TAELMacAgentTests" */ = {
+		9EE8029557141161462E8753 /* Build configuration list for PBXProject "TAELMacAgent" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				5A00000000000000000000C1 /* Debug */,
-				5A00000000000000000000C2 /* Release */,
+				3D3753EFBE210BA568497A6B /* Debug */,
+				2F433CDCD1DA99C432DADA1A /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = Release;
+			defaultConfigurationName = Debug;
 		};
 /* End XCConfigurationList section */
 	};
-	rootObject = 8A00000000000000000000A1 /* Project object */;
+	rootObject = 5D9768FD172621FBD47CDD94 /* Project object */;
 }

--- a/TAELMacAgent/TAELMacAgent.xcodeproj/project.pbxproj
+++ b/TAELMacAgent/TAELMacAgent.xcodeproj/project.pbxproj
@@ -248,7 +248,6 @@
 				LastUpgradeCheck = 1430;
 				TargetAttributes = {
 					19B5206FF51EAAA5D9DD33BD = {
-						DevelopmentTeam = "";
 						ProvisioningStyle = Automatic;
 					};
 					7BBF771A19B870A8BDB655E7 = {
@@ -344,12 +343,17 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_ENTITLEMENTS = TAELMacAgent/Resources/TAELMacAgent.entitlements;
+				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
+				DEVELOPMENT_TEAM = 4X8U3NCLQ8;
 				ENABLE_USER_SCRIPT_SANDBOXING = YES;
 				GENERATE_INFOPLIST_FILE = NO;
 				INFOPLIST_FILE = TAELMacAgent/Resources/Info.plist;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/../Frameworks",
+				);
 				MACOSX_DEPLOYMENT_TARGET = 14.0;
 				PRODUCT_BUNDLE_IDENTIFIER = ai.tael.macagent;
 				PRODUCT_NAME = TAELMacAgent;
@@ -421,6 +425,7 @@
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				COMBINE_HIDPI_IMAGES = YES;
+				GENERATE_INFOPLIST_FILE = YES;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/../Frameworks",
@@ -505,12 +510,17 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_ENTITLEMENTS = TAELMacAgent/Resources/TAELMacAgent.entitlements;
+				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
+				DEVELOPMENT_TEAM = 4X8U3NCLQ8;
 				ENABLE_USER_SCRIPT_SANDBOXING = YES;
 				GENERATE_INFOPLIST_FILE = NO;
 				INFOPLIST_FILE = TAELMacAgent/Resources/Info.plist;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/../Frameworks",
+				);
 				MACOSX_DEPLOYMENT_TARGET = 14.0;
 				PRODUCT_BUNDLE_IDENTIFIER = ai.tael.macagent;
 				PRODUCT_NAME = TAELMacAgent;
@@ -523,6 +533,7 @@
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				COMBINE_HIDPI_IMAGES = YES;
+				GENERATE_INFOPLIST_FILE = YES;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/../Frameworks",

--- a/TAELMacAgent/TAELMacAgent.xcodeproj/project.pbxproj
+++ b/TAELMacAgent/TAELMacAgent.xcodeproj/project.pbxproj
@@ -11,6 +11,7 @@
 		033A279961698D88188A33AD /* MenuBarController.swift in Sources */ = {isa = PBXBuildFile; fileRef = EBD624AFDCE20EF4B613B9A4 /* MenuBarController.swift */; };
 		06ADDF6182CAEDB9CC8191F9 /* HotkeyHandlerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 600507D8811CFB057BB49AA4 /* HotkeyHandlerTests.swift */; };
 		354AC58980118264F0FF7B67 /* HotkeyManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11BA73F54C69186834610D30 /* HotkeyManagerTests.swift */; };
+		925C4AADEDDDF4182FB89AF8 /* PermissionsCheckerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3391ED18AB6186A614671A75 /* PermissionsCheckerTests.swift */; };
 		0B0660E9860988CD91DA599E /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB704571A9597F9AF9313D65 /* AppDelegate.swift */; };
 		1EFB0EA699153ADC53EA4286 /* LocalLogServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C654DA20715C3C6F29B9E6F4 /* LocalLogServiceTests.swift */; };
 		2BAF280AA3FB18E55785FAD8 /* KeyboardShortcuts in Frameworks */ = {isa = PBXBuildFile; productRef = 271157EB2BA4172C872A7408 /* KeyboardShortcuts */; };
@@ -56,6 +57,7 @@
 		422D881643EB42E6E96F6073 /* PermissionGateView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PermissionGateView.swift; sourceTree = "<group>"; };
 		600507D8811CFB057BB49AA4 /* HotkeyHandlerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HotkeyHandlerTests.swift; sourceTree = "<group>"; };
 		11BA73F54C69186834610D30 /* HotkeyManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HotkeyManagerTests.swift; sourceTree = "<group>"; };
+		3391ED18AB6186A614671A75 /* PermissionsCheckerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PermissionsCheckerTests.swift; sourceTree = "<group>"; };
 		639F88F50828EB01F823718B /* PermissionStatus.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PermissionStatus.swift; sourceTree = "<group>"; };
 		659ECE5A728C28C51E500F35 /* HUDScreenshotView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HUDScreenshotView.swift; sourceTree = "<group>"; };
 		A366B091A2CF78B079314AE1 /* HUDErrorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HUDErrorView.swift; sourceTree = "<group>"; };
@@ -95,6 +97,7 @@
 				600507D8811CFB057BB49AA4 /* HotkeyHandlerTests.swift */,
 				11BA73F54C69186834610D30 /* HotkeyManagerTests.swift */,
 				C654DA20715C3C6F29B9E6F4 /* LocalLogServiceTests.swift */,
+				3391ED18AB6186A614671A75 /* PermissionsCheckerTests.swift */,
 				14306A2EBDA587DA5C4E6182 /* PermissionsGateTests.swift */,
 			);
 			path = TAELMacAgentTests;
@@ -331,6 +334,7 @@
 				06ADDF6182CAEDB9CC8191F9 /* HotkeyHandlerTests.swift in Sources */,
 				354AC58980118264F0FF7B67 /* HotkeyManagerTests.swift in Sources */,
 				1EFB0EA699153ADC53EA4286 /* LocalLogServiceTests.swift in Sources */,
+				925C4AADEDDDF4182FB89AF8 /* PermissionsCheckerTests.swift in Sources */,
 				5AD70596B8B5BEBD936F2F60 /* PermissionsGateTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/TAELMacAgent/TAELMacAgent.xcodeproj/project.pbxproj
+++ b/TAELMacAgent/TAELMacAgent.xcodeproj/project.pbxproj
@@ -19,6 +19,7 @@
 		6BA0CBE1B80E6592A9C6983A /* PermissionGateView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 422D881643EB42E6E96F6073 /* PermissionGateView.swift */; };
 		7A08515211A39DD11A6E370B /* PermissionsGate.swift in Sources */ = {isa = PBXBuildFile; fileRef = F46F76B62679E79E964F4EAE /* PermissionsGate.swift */; };
 		8AC8665020F765D063A96609 /* HUDPanelController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9363E4D91044162835D20FAA /* HUDPanelController.swift */; };
+		9565442421E66D83C0B03CDF /* HotkeyName.swift in Sources */ = {isa = PBXBuildFile; fileRef = C96D7E9A9156DA07866B2574 /* HotkeyName.swift */; };
 		C3C9015E4F181F2FC2A056BB /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 3900941745D06B0194400E8E /* Assets.xcassets */; };
 		CACD72769410271CF6577CC0 /* InvocationLog.swift in Sources */ = {isa = PBXBuildFile; fileRef = A74AE945B8920595491B2B29 /* InvocationLog.swift */; };
 		CF17A6BDF21FD1B3F8690D13 /* PermissionError.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED47D03840F40871272ED13C /* PermissionError.swift */; };
@@ -60,6 +61,7 @@
 		A74AE945B8920595491B2B29 /* InvocationLog.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InvocationLog.swift; sourceTree = "<group>"; };
 		AB704571A9597F9AF9313D65 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		C654DA20715C3C6F29B9E6F4 /* LocalLogServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalLogServiceTests.swift; sourceTree = "<group>"; };
+		C96D7E9A9156DA07866B2574 /* HotkeyName.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HotkeyName.swift; sourceTree = "<group>"; };
 		EBD624AFDCE20EF4B613B9A4 /* MenuBarController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MenuBarController.swift; sourceTree = "<group>"; };
 		ED47D03840F40871272ED13C /* PermissionError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PermissionError.swift; sourceTree = "<group>"; };
 		F46F76B62679E79E964F4EAE /* PermissionsGate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PermissionsGate.swift; sourceTree = "<group>"; };
@@ -173,6 +175,7 @@
 			isa = PBXGroup;
 			children = (
 				917682B8FDBFE7C755263E19 /* HotkeyManager.swift */,
+				C96D7E9A9156DA07866B2574 /* HotkeyName.swift */,
 			);
 			path = Hotkey;
 			sourceTree = "<group>";
@@ -288,6 +291,7 @@
 				8AC8665020F765D063A96609 /* HUDPanelController.swift in Sources */,
 				F8A8B61233E0F29CD0725388 /* HUDView.swift in Sources */,
 				6AB4701304241B41166818BB /* HotkeyManager.swift in Sources */,
+				9565442421E66D83C0B03CDF /* HotkeyName.swift in Sources */,
 				CACD72769410271CF6577CC0 /* InvocationLog.swift in Sources */,
 				34F3D8094B35A969BEFEFE4A /* LocalLogService.swift in Sources */,
 				033A279961698D88188A33AD /* MenuBarController.swift in Sources */,

--- a/TAELMacAgent/TAELMacAgent.xcodeproj/project.pbxproj
+++ b/TAELMacAgent/TAELMacAgent.xcodeproj/project.pbxproj
@@ -24,6 +24,7 @@
 		CACD72769410271CF6577CC0 /* InvocationLog.swift in Sources */ = {isa = PBXBuildFile; fileRef = A74AE945B8920595491B2B29 /* InvocationLog.swift */; };
 		CF17A6BDF21FD1B3F8690D13 /* PermissionError.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED47D03840F40871272ED13C /* PermissionError.swift */; };
 		D4D7892F3C39042079C92DEC /* PermissionsChecker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D36CFA939327054CE038538 /* PermissionsChecker.swift */; };
+		DF3BAB13D3897B30011FF8B2 /* HUDScreenshotView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 659ECE5A728C28C51E500F35 /* HUDScreenshotView.swift */; };
 		E22538B7BAFDD6DE67CD39A6 /* PermissionKind.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E3601A9D97DFCC20CB1B190 /* PermissionKind.swift */; };
 		EE4E5F822C40DF6233CBDD2A /* ScreenshotTarget.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6C80394C10DB95ACE8B23410 /* ScreenshotTarget.swift */; };
 		F213518191A0D0FBED62E67B /* ScreenCaptureService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 198A12FCDFC021700C887DC3 /* ScreenCaptureService.swift */; };
@@ -50,6 +51,7 @@
 		3900941745D06B0194400E8E /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		422D881643EB42E6E96F6073 /* PermissionGateView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PermissionGateView.swift; sourceTree = "<group>"; };
 		639F88F50828EB01F823718B /* PermissionStatus.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PermissionStatus.swift; sourceTree = "<group>"; };
+		659ECE5A728C28C51E500F35 /* HUDScreenshotView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HUDScreenshotView.swift; sourceTree = "<group>"; };
 		69DDCCAE89FD5A160E17AE49 /* TAELMacAgentApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TAELMacAgentApp.swift; sourceTree = "<group>"; };
 		6C80394C10DB95ACE8B23410 /* ScreenshotTarget.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScreenshotTarget.swift; sourceTree = "<group>"; };
 		6DEC30773055C5F4AE735610 /* CapturedScreenshot.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CapturedScreenshot.swift; sourceTree = "<group>"; };
@@ -92,6 +94,7 @@
 			isa = PBXGroup;
 			children = (
 				9363E4D91044162835D20FAA /* HUDPanelController.swift */,
+				659ECE5A728C28C51E500F35 /* HUDScreenshotView.swift */,
 				1469160F2705F009163C15E0 /* HUDView.swift */,
 				422D881643EB42E6E96F6073 /* PermissionGateView.swift */,
 			);
@@ -289,6 +292,7 @@
 				0B0660E9860988CD91DA599E /* AppDelegate.swift in Sources */,
 				0330637AAF26CC3C25DCD10F /* CapturedScreenshot.swift in Sources */,
 				8AC8665020F765D063A96609 /* HUDPanelController.swift in Sources */,
+				DF3BAB13D3897B30011FF8B2 /* HUDScreenshotView.swift in Sources */,
 				F8A8B61233E0F29CD0725388 /* HUDView.swift in Sources */,
 				6AB4701304241B41166818BB /* HotkeyManager.swift in Sources */,
 				9565442421E66D83C0B03CDF /* HotkeyName.swift in Sources */,

--- a/TAELMacAgent/TAELMacAgent.xcodeproj/project.pbxproj
+++ b/TAELMacAgent/TAELMacAgent.xcodeproj/project.pbxproj
@@ -10,6 +10,7 @@
 		0330637AAF26CC3C25DCD10F /* CapturedScreenshot.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6DEC30773055C5F4AE735610 /* CapturedScreenshot.swift */; };
 		033A279961698D88188A33AD /* MenuBarController.swift in Sources */ = {isa = PBXBuildFile; fileRef = EBD624AFDCE20EF4B613B9A4 /* MenuBarController.swift */; };
 		06ADDF6182CAEDB9CC8191F9 /* HotkeyHandlerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 600507D8811CFB057BB49AA4 /* HotkeyHandlerTests.swift */; };
+		354AC58980118264F0FF7B67 /* HotkeyManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11BA73F54C69186834610D30 /* HotkeyManagerTests.swift */; };
 		0B0660E9860988CD91DA599E /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB704571A9597F9AF9313D65 /* AppDelegate.swift */; };
 		1EFB0EA699153ADC53EA4286 /* LocalLogServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C654DA20715C3C6F29B9E6F4 /* LocalLogServiceTests.swift */; };
 		2BAF280AA3FB18E55785FAD8 /* KeyboardShortcuts in Frameworks */ = {isa = PBXBuildFile; productRef = 271157EB2BA4172C872A7408 /* KeyboardShortcuts */; };
@@ -53,6 +54,7 @@
 		3900941745D06B0194400E8E /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		422D881643EB42E6E96F6073 /* PermissionGateView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PermissionGateView.swift; sourceTree = "<group>"; };
 		600507D8811CFB057BB49AA4 /* HotkeyHandlerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HotkeyHandlerTests.swift; sourceTree = "<group>"; };
+		11BA73F54C69186834610D30 /* HotkeyManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HotkeyManagerTests.swift; sourceTree = "<group>"; };
 		639F88F50828EB01F823718B /* PermissionStatus.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PermissionStatus.swift; sourceTree = "<group>"; };
 		659ECE5A728C28C51E500F35 /* HUDScreenshotView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HUDScreenshotView.swift; sourceTree = "<group>"; };
 		69DDCCAE89FD5A160E17AE49 /* TAELMacAgentApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TAELMacAgentApp.swift; sourceTree = "<group>"; };
@@ -89,6 +91,7 @@
 			isa = PBXGroup;
 			children = (
 				600507D8811CFB057BB49AA4 /* HotkeyHandlerTests.swift */,
+				11BA73F54C69186834610D30 /* HotkeyManagerTests.swift */,
 				C654DA20715C3C6F29B9E6F4 /* LocalLogServiceTests.swift */,
 				14306A2EBDA587DA5C4E6182 /* PermissionsGateTests.swift */,
 			);
@@ -322,6 +325,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				06ADDF6182CAEDB9CC8191F9 /* HotkeyHandlerTests.swift in Sources */,
+				354AC58980118264F0FF7B67 /* HotkeyManagerTests.swift in Sources */,
 				1EFB0EA699153ADC53EA4286 /* LocalLogServiceTests.swift in Sources */,
 				5AD70596B8B5BEBD936F2F60 /* PermissionsGateTests.swift in Sources */,
 			);

--- a/TAELMacAgent/TAELMacAgent.xcodeproj/project.pbxproj
+++ b/TAELMacAgent/TAELMacAgent.xcodeproj/project.pbxproj
@@ -9,6 +9,7 @@
 /* Begin PBXBuildFile section */
 		0330637AAF26CC3C25DCD10F /* CapturedScreenshot.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6DEC30773055C5F4AE735610 /* CapturedScreenshot.swift */; };
 		033A279961698D88188A33AD /* MenuBarController.swift in Sources */ = {isa = PBXBuildFile; fileRef = EBD624AFDCE20EF4B613B9A4 /* MenuBarController.swift */; };
+		06ADDF6182CAEDB9CC8191F9 /* HotkeyHandlerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 600507D8811CFB057BB49AA4 /* HotkeyHandlerTests.swift */; };
 		0B0660E9860988CD91DA599E /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB704571A9597F9AF9313D65 /* AppDelegate.swift */; };
 		1EFB0EA699153ADC53EA4286 /* LocalLogServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C654DA20715C3C6F29B9E6F4 /* LocalLogServiceTests.swift */; };
 		2BAF280AA3FB18E55785FAD8 /* KeyboardShortcuts in Frameworks */ = {isa = PBXBuildFile; productRef = 271157EB2BA4172C872A7408 /* KeyboardShortcuts */; };
@@ -28,6 +29,7 @@
 		E22538B7BAFDD6DE67CD39A6 /* PermissionKind.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E3601A9D97DFCC20CB1B190 /* PermissionKind.swift */; };
 		EE4E5F822C40DF6233CBDD2A /* ScreenshotTarget.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6C80394C10DB95ACE8B23410 /* ScreenshotTarget.swift */; };
 		F213518191A0D0FBED62E67B /* ScreenCaptureService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 198A12FCDFC021700C887DC3 /* ScreenCaptureService.swift */; };
+		F6E2AD25AAD3F1AE6D0CA2A6 /* HotkeyInvocationHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = C778F76C2BA992BFF35FF455 /* HotkeyInvocationHandler.swift */; };
 		F8A8B61233E0F29CD0725388 /* HUDView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1469160F2705F009163C15E0 /* HUDView.swift */; };
 		FC2769F84CA630E5B0E73F55 /* PermissionStatus.swift in Sources */ = {isa = PBXBuildFile; fileRef = 639F88F50828EB01F823718B /* PermissionStatus.swift */; };
 /* End PBXBuildFile section */
@@ -50,6 +52,7 @@
 		1D36CFA939327054CE038538 /* PermissionsChecker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PermissionsChecker.swift; sourceTree = "<group>"; };
 		3900941745D06B0194400E8E /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		422D881643EB42E6E96F6073 /* PermissionGateView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PermissionGateView.swift; sourceTree = "<group>"; };
+		600507D8811CFB057BB49AA4 /* HotkeyHandlerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HotkeyHandlerTests.swift; sourceTree = "<group>"; };
 		639F88F50828EB01F823718B /* PermissionStatus.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PermissionStatus.swift; sourceTree = "<group>"; };
 		659ECE5A728C28C51E500F35 /* HUDScreenshotView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HUDScreenshotView.swift; sourceTree = "<group>"; };
 		69DDCCAE89FD5A160E17AE49 /* TAELMacAgentApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TAELMacAgentApp.swift; sourceTree = "<group>"; };
@@ -63,6 +66,7 @@
 		A74AE945B8920595491B2B29 /* InvocationLog.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InvocationLog.swift; sourceTree = "<group>"; };
 		AB704571A9597F9AF9313D65 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		C654DA20715C3C6F29B9E6F4 /* LocalLogServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalLogServiceTests.swift; sourceTree = "<group>"; };
+		C778F76C2BA992BFF35FF455 /* HotkeyInvocationHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HotkeyInvocationHandler.swift; sourceTree = "<group>"; };
 		C96D7E9A9156DA07866B2574 /* HotkeyName.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HotkeyName.swift; sourceTree = "<group>"; };
 		EBD624AFDCE20EF4B613B9A4 /* MenuBarController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MenuBarController.swift; sourceTree = "<group>"; };
 		ED47D03840F40871272ED13C /* PermissionError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PermissionError.swift; sourceTree = "<group>"; };
@@ -84,6 +88,7 @@
 		1D955BDFBFFB1E992ABC4E95 /* TAELMacAgentTests */ = {
 			isa = PBXGroup;
 			children = (
+				600507D8811CFB057BB49AA4 /* HotkeyHandlerTests.swift */,
 				C654DA20715C3C6F29B9E6F4 /* LocalLogServiceTests.swift */,
 				14306A2EBDA587DA5C4E6182 /* PermissionsGateTests.swift */,
 			);
@@ -114,6 +119,7 @@
 			isa = PBXGroup;
 			children = (
 				AB704571A9597F9AF9313D65 /* AppDelegate.swift */,
+				C778F76C2BA992BFF35FF455 /* HotkeyInvocationHandler.swift */,
 				EBD624AFDCE20EF4B613B9A4 /* MenuBarController.swift */,
 				69DDCCAE89FD5A160E17AE49 /* TAELMacAgentApp.swift */,
 			);
@@ -294,6 +300,7 @@
 				8AC8665020F765D063A96609 /* HUDPanelController.swift in Sources */,
 				DF3BAB13D3897B30011FF8B2 /* HUDScreenshotView.swift in Sources */,
 				F8A8B61233E0F29CD0725388 /* HUDView.swift in Sources */,
+				F6E2AD25AAD3F1AE6D0CA2A6 /* HotkeyInvocationHandler.swift in Sources */,
 				6AB4701304241B41166818BB /* HotkeyManager.swift in Sources */,
 				9565442421E66D83C0B03CDF /* HotkeyName.swift in Sources */,
 				CACD72769410271CF6577CC0 /* InvocationLog.swift in Sources */,
@@ -315,6 +322,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				06ADDF6182CAEDB9CC8191F9 /* HotkeyHandlerTests.swift in Sources */,
 				1EFB0EA699153ADC53EA4286 /* LocalLogServiceTests.swift in Sources */,
 				5AD70596B8B5BEBD936F2F60 /* PermissionsGateTests.swift in Sources */,
 			);

--- a/TAELMacAgent/TAELMacAgent.xcodeproj/project.pbxproj
+++ b/TAELMacAgent/TAELMacAgent.xcodeproj/project.pbxproj
@@ -11,6 +11,7 @@
 		033A279961698D88188A33AD /* MenuBarController.swift in Sources */ = {isa = PBXBuildFile; fileRef = EBD624AFDCE20EF4B613B9A4 /* MenuBarController.swift */; };
 		0B0660E9860988CD91DA599E /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB704571A9597F9AF9313D65 /* AppDelegate.swift */; };
 		1EFB0EA699153ADC53EA4286 /* LocalLogServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C654DA20715C3C6F29B9E6F4 /* LocalLogServiceTests.swift */; };
+		2BAF280AA3FB18E55785FAD8 /* KeyboardShortcuts in Frameworks */ = {isa = PBXBuildFile; productRef = 271157EB2BA4172C872A7408 /* KeyboardShortcuts */; };
 		34F3D8094B35A969BEFEFE4A /* LocalLogService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F5C315999DFCC84BE675BE2 /* LocalLogService.swift */; };
 		3F34E0D14D96EB8D52BE71A0 /* TAELMacAgentApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 69DDCCAE89FD5A160E17AE49 /* TAELMacAgentApp.swift */; };
 		5AD70596B8B5BEBD936F2F60 /* PermissionsGateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14306A2EBDA587DA5C4E6182 /* PermissionsGateTests.swift */; };
@@ -63,6 +64,17 @@
 		ED47D03840F40871272ED13C /* PermissionError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PermissionError.swift; sourceTree = "<group>"; };
 		F46F76B62679E79E964F4EAE /* PermissionsGate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PermissionsGate.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		B46A07C92351F24C2BF9395E /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				2BAF280AA3FB18E55785FAD8 /* KeyboardShortcuts in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
 		1D955BDFBFFB1E992ABC4E95 /* TAELMacAgentTests */ = {
@@ -182,6 +194,7 @@
 			buildPhases = (
 				A804338716259752E11524FD /* Sources */,
 				D18C72E98AF490A89259C1D9 /* Resources */,
+				B46A07C92351F24C2BF9395E /* Frameworks */,
 			);
 			buildRules = (
 			);
@@ -189,6 +202,7 @@
 			);
 			name = TAELMacAgent;
 			packageProductDependencies = (
+				271157EB2BA4172C872A7408 /* KeyboardShortcuts */,
 			);
 			productName = TAELMacAgent;
 			productReference = 09182C33476D9D80D775700D /* TAELMacAgent.app */;
@@ -239,6 +253,9 @@
 			);
 			mainGroup = 79CF0DC83C35B3DE92D7BB44;
 			minimizedProjectReferenceProxies = 1;
+			packageReferences = (
+				85553E6FF0113F1817B596E9 /* XCRemoteSwiftPackageReference "KeyboardShortcuts" */,
+			);
 			preferredProjectObjectVersion = 77;
 			productRefGroup = C965C9197045CDCA448A4FB4 /* Products */;
 			projectDirPath = "";
@@ -534,6 +551,25 @@
 			defaultConfigurationName = Debug;
 		};
 /* End XCConfigurationList section */
+
+/* Begin XCRemoteSwiftPackageReference section */
+		85553E6FF0113F1817B596E9 /* XCRemoteSwiftPackageReference "KeyboardShortcuts" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/sindresorhus/KeyboardShortcuts";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 2.0.0;
+			};
+		};
+/* End XCRemoteSwiftPackageReference section */
+
+/* Begin XCSwiftPackageProductDependency section */
+		271157EB2BA4172C872A7408 /* KeyboardShortcuts */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 85553E6FF0113F1817B596E9 /* XCRemoteSwiftPackageReference "KeyboardShortcuts" */;
+			productName = KeyboardShortcuts;
+		};
+/* End XCSwiftPackageProductDependency section */
 	};
 	rootObject = 5D9768FD172621FBD47CDD94 /* Project object */;
 }

--- a/TAELMacAgent/TAELMacAgent.xcodeproj/project.pbxproj
+++ b/TAELMacAgent/TAELMacAgent.xcodeproj/project.pbxproj
@@ -27,6 +27,7 @@
 		CF17A6BDF21FD1B3F8690D13 /* PermissionError.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED47D03840F40871272ED13C /* PermissionError.swift */; };
 		D4D7892F3C39042079C92DEC /* PermissionsChecker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D36CFA939327054CE038538 /* PermissionsChecker.swift */; };
 		DF3BAB13D3897B30011FF8B2 /* HUDScreenshotView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 659ECE5A728C28C51E500F35 /* HUDScreenshotView.swift */; };
+		C6D0EFACE6A32A5B1339F60E /* HUDErrorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A366B091A2CF78B079314AE1 /* HUDErrorView.swift */; };
 		E22538B7BAFDD6DE67CD39A6 /* PermissionKind.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E3601A9D97DFCC20CB1B190 /* PermissionKind.swift */; };
 		EE4E5F822C40DF6233CBDD2A /* ScreenshotTarget.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6C80394C10DB95ACE8B23410 /* ScreenshotTarget.swift */; };
 		F213518191A0D0FBED62E67B /* ScreenCaptureService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 198A12FCDFC021700C887DC3 /* ScreenCaptureService.swift */; };
@@ -57,6 +58,7 @@
 		11BA73F54C69186834610D30 /* HotkeyManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HotkeyManagerTests.swift; sourceTree = "<group>"; };
 		639F88F50828EB01F823718B /* PermissionStatus.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PermissionStatus.swift; sourceTree = "<group>"; };
 		659ECE5A728C28C51E500F35 /* HUDScreenshotView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HUDScreenshotView.swift; sourceTree = "<group>"; };
+		A366B091A2CF78B079314AE1 /* HUDErrorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HUDErrorView.swift; sourceTree = "<group>"; };
 		69DDCCAE89FD5A160E17AE49 /* TAELMacAgentApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TAELMacAgentApp.swift; sourceTree = "<group>"; };
 		6C80394C10DB95ACE8B23410 /* ScreenshotTarget.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScreenshotTarget.swift; sourceTree = "<group>"; };
 		6DEC30773055C5F4AE735610 /* CapturedScreenshot.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CapturedScreenshot.swift; sourceTree = "<group>"; };
@@ -101,6 +103,7 @@
 		25F2B0347D98A8AADDF902E0 /* HUD */ = {
 			isa = PBXGroup;
 			children = (
+				A366B091A2CF78B079314AE1 /* HUDErrorView.swift */,
 				9363E4D91044162835D20FAA /* HUDPanelController.swift */,
 				659ECE5A728C28C51E500F35 /* HUDScreenshotView.swift */,
 				1469160F2705F009163C15E0 /* HUDView.swift */,
@@ -300,6 +303,7 @@
 				0B0660E9860988CD91DA599E /* AppDelegate.swift in Sources */,
 				0330637AAF26CC3C25DCD10F /* CapturedScreenshot.swift in Sources */,
 				8AC8665020F765D063A96609 /* HUDPanelController.swift in Sources */,
+				C6D0EFACE6A32A5B1339F60E /* HUDErrorView.swift in Sources */,
 				DF3BAB13D3897B30011FF8B2 /* HUDScreenshotView.swift in Sources */,
 				F8A8B61233E0F29CD0725388 /* HUDView.swift in Sources */,
 				F6E2AD25AAD3F1AE6D0CA2A6 /* HotkeyInvocationHandler.swift in Sources */,

--- a/TAELMacAgent/TAELMacAgent.xcodeproj/project.pbxproj
+++ b/TAELMacAgent/TAELMacAgent.xcodeproj/project.pbxproj
@@ -7,28 +7,33 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		02E5172BAA7A3A56E9952C59 /* HUDContextBundleView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A7BCC0DD380BCA035E3BE982 /* HUDContextBundleView.swift */; };
 		0330637AAF26CC3C25DCD10F /* CapturedScreenshot.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6DEC30773055C5F4AE735610 /* CapturedScreenshot.swift */; };
 		033A279961698D88188A33AD /* MenuBarController.swift in Sources */ = {isa = PBXBuildFile; fileRef = EBD624AFDCE20EF4B613B9A4 /* MenuBarController.swift */; };
 		06ADDF6182CAEDB9CC8191F9 /* HotkeyHandlerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 600507D8811CFB057BB49AA4 /* HotkeyHandlerTests.swift */; };
-		354AC58980118264F0FF7B67 /* HotkeyManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11BA73F54C69186834610D30 /* HotkeyManagerTests.swift */; };
-		925C4AADEDDDF4182FB89AF8 /* PermissionsCheckerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3391ED18AB6186A614671A75 /* PermissionsCheckerTests.swift */; };
 		0B0660E9860988CD91DA599E /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB704571A9597F9AF9313D65 /* AppDelegate.swift */; };
 		1EFB0EA699153ADC53EA4286 /* LocalLogServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C654DA20715C3C6F29B9E6F4 /* LocalLogServiceTests.swift */; };
+		2677B0F4DC46B483FCF1080D /* AXService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6117FF021320036888C63298 /* AXService.swift */; };
 		2BAF280AA3FB18E55785FAD8 /* KeyboardShortcuts in Frameworks */ = {isa = PBXBuildFile; productRef = 271157EB2BA4172C872A7408 /* KeyboardShortcuts */; };
 		34F3D8094B35A969BEFEFE4A /* LocalLogService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F5C315999DFCC84BE675BE2 /* LocalLogService.swift */; };
 		3F34E0D14D96EB8D52BE71A0 /* TAELMacAgentApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 69DDCCAE89FD5A160E17AE49 /* TAELMacAgentApp.swift */; };
+		554AB7D253B393D4F08AB225 /* ContextBundleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 995C4E3E4317B367CAFEBBC2 /* ContextBundleTests.swift */; };
+		5825405C894EAB8C49D44D00 /* ContextBundle.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB6EB3B92EA975E182EE38D0 /* ContextBundle.swift */; };
 		5AD70596B8B5BEBD936F2F60 /* PermissionsGateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14306A2EBDA587DA5C4E6182 /* PermissionsGateTests.swift */; };
 		6AB4701304241B41166818BB /* HotkeyManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 917682B8FDBFE7C755263E19 /* HotkeyManager.swift */; };
 		6BA0CBE1B80E6592A9C6983A /* PermissionGateView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 422D881643EB42E6E96F6073 /* PermissionGateView.swift */; };
 		7A08515211A39DD11A6E370B /* PermissionsGate.swift in Sources */ = {isa = PBXBuildFile; fileRef = F46F76B62679E79E964F4EAE /* PermissionsGate.swift */; };
+		849C242625ED0EA22FB38890 /* HotkeyManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61EC8235844217BF59E50B3F /* HotkeyManagerTests.swift */; };
+		8791A773E3A54879EF035D27 /* FocusedWindowMetadata.swift in Sources */ = {isa = PBXBuildFile; fileRef = E68A1DD137DD5E5D8291D4FB /* FocusedWindowMetadata.swift */; };
 		8AC8665020F765D063A96609 /* HUDPanelController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9363E4D91044162835D20FAA /* HUDPanelController.swift */; };
 		9565442421E66D83C0B03CDF /* HotkeyName.swift in Sources */ = {isa = PBXBuildFile; fileRef = C96D7E9A9156DA07866B2574 /* HotkeyName.swift */; };
 		C3C9015E4F181F2FC2A056BB /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 3900941745D06B0194400E8E /* Assets.xcassets */; };
 		CACD72769410271CF6577CC0 /* InvocationLog.swift in Sources */ = {isa = PBXBuildFile; fileRef = A74AE945B8920595491B2B29 /* InvocationLog.swift */; };
 		CF17A6BDF21FD1B3F8690D13 /* PermissionError.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED47D03840F40871272ED13C /* PermissionError.swift */; };
+		CFA7CDEDCA4642C836A4892A /* HUDErrorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 15EBB8FD7CC491B54EAD7C32 /* HUDErrorView.swift */; };
 		D4D7892F3C39042079C92DEC /* PermissionsChecker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D36CFA939327054CE038538 /* PermissionsChecker.swift */; };
+		DB297417A946D0AEA311F7BE /* PermissionsCheckerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 42F84AD2F6F1FE9B0EA2B5B0 /* PermissionsCheckerTests.swift */; };
 		DF3BAB13D3897B30011FF8B2 /* HUDScreenshotView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 659ECE5A728C28C51E500F35 /* HUDScreenshotView.swift */; };
-		C6D0EFACE6A32A5B1339F60E /* HUDErrorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A366B091A2CF78B079314AE1 /* HUDErrorView.swift */; };
 		E22538B7BAFDD6DE67CD39A6 /* PermissionKind.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E3601A9D97DFCC20CB1B190 /* PermissionKind.swift */; };
 		EE4E5F822C40DF6233CBDD2A /* ScreenshotTarget.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6C80394C10DB95ACE8B23410 /* ScreenshotTarget.swift */; };
 		F213518191A0D0FBED62E67B /* ScreenCaptureService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 198A12FCDFC021700C887DC3 /* ScreenCaptureService.swift */; };
@@ -51,16 +56,17 @@
 		09182C33476D9D80D775700D /* TAELMacAgent.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = TAELMacAgent.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		14306A2EBDA587DA5C4E6182 /* PermissionsGateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PermissionsGateTests.swift; sourceTree = "<group>"; };
 		1469160F2705F009163C15E0 /* HUDView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HUDView.swift; sourceTree = "<group>"; };
+		15EBB8FD7CC491B54EAD7C32 /* HUDErrorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HUDErrorView.swift; sourceTree = "<group>"; };
 		198A12FCDFC021700C887DC3 /* ScreenCaptureService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScreenCaptureService.swift; sourceTree = "<group>"; };
 		1D36CFA939327054CE038538 /* PermissionsChecker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PermissionsChecker.swift; sourceTree = "<group>"; };
 		3900941745D06B0194400E8E /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		422D881643EB42E6E96F6073 /* PermissionGateView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PermissionGateView.swift; sourceTree = "<group>"; };
+		42F84AD2F6F1FE9B0EA2B5B0 /* PermissionsCheckerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PermissionsCheckerTests.swift; sourceTree = "<group>"; };
 		600507D8811CFB057BB49AA4 /* HotkeyHandlerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HotkeyHandlerTests.swift; sourceTree = "<group>"; };
-		11BA73F54C69186834610D30 /* HotkeyManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HotkeyManagerTests.swift; sourceTree = "<group>"; };
-		3391ED18AB6186A614671A75 /* PermissionsCheckerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PermissionsCheckerTests.swift; sourceTree = "<group>"; };
+		6117FF021320036888C63298 /* AXService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AXService.swift; sourceTree = "<group>"; };
+		61EC8235844217BF59E50B3F /* HotkeyManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HotkeyManagerTests.swift; sourceTree = "<group>"; };
 		639F88F50828EB01F823718B /* PermissionStatus.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PermissionStatus.swift; sourceTree = "<group>"; };
 		659ECE5A728C28C51E500F35 /* HUDScreenshotView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HUDScreenshotView.swift; sourceTree = "<group>"; };
-		A366B091A2CF78B079314AE1 /* HUDErrorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HUDErrorView.swift; sourceTree = "<group>"; };
 		69DDCCAE89FD5A160E17AE49 /* TAELMacAgentApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TAELMacAgentApp.swift; sourceTree = "<group>"; };
 		6C80394C10DB95ACE8B23410 /* ScreenshotTarget.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScreenshotTarget.swift; sourceTree = "<group>"; };
 		6DEC30773055C5F4AE735610 /* CapturedScreenshot.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CapturedScreenshot.swift; sourceTree = "<group>"; };
@@ -68,15 +74,19 @@
 		6F5C315999DFCC84BE675BE2 /* LocalLogService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalLogService.swift; sourceTree = "<group>"; };
 		917682B8FDBFE7C755263E19 /* HotkeyManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HotkeyManager.swift; sourceTree = "<group>"; };
 		9363E4D91044162835D20FAA /* HUDPanelController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HUDPanelController.swift; sourceTree = "<group>"; };
+		995C4E3E4317B367CAFEBBC2 /* ContextBundleTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContextBundleTests.swift; sourceTree = "<group>"; };
 		9A76044EF0F9B7BE7C3F5C00 /* TAELMacAgentTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = TAELMacAgentTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		A74AE945B8920595491B2B29 /* InvocationLog.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InvocationLog.swift; sourceTree = "<group>"; };
+		A7BCC0DD380BCA035E3BE982 /* HUDContextBundleView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HUDContextBundleView.swift; sourceTree = "<group>"; };
 		AB704571A9597F9AF9313D65 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		C654DA20715C3C6F29B9E6F4 /* LocalLogServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalLogServiceTests.swift; sourceTree = "<group>"; };
 		C778F76C2BA992BFF35FF455 /* HotkeyInvocationHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HotkeyInvocationHandler.swift; sourceTree = "<group>"; };
 		C96D7E9A9156DA07866B2574 /* HotkeyName.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HotkeyName.swift; sourceTree = "<group>"; };
+		E68A1DD137DD5E5D8291D4FB /* FocusedWindowMetadata.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FocusedWindowMetadata.swift; sourceTree = "<group>"; };
 		EBD624AFDCE20EF4B613B9A4 /* MenuBarController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MenuBarController.swift; sourceTree = "<group>"; };
 		ED47D03840F40871272ED13C /* PermissionError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PermissionError.swift; sourceTree = "<group>"; };
 		F46F76B62679E79E964F4EAE /* PermissionsGate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PermissionsGate.swift; sourceTree = "<group>"; };
+		FB6EB3B92EA975E182EE38D0 /* ContextBundle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContextBundle.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -94,10 +104,11 @@
 		1D955BDFBFFB1E992ABC4E95 /* TAELMacAgentTests */ = {
 			isa = PBXGroup;
 			children = (
+				995C4E3E4317B367CAFEBBC2 /* ContextBundleTests.swift */,
 				600507D8811CFB057BB49AA4 /* HotkeyHandlerTests.swift */,
-				11BA73F54C69186834610D30 /* HotkeyManagerTests.swift */,
+				61EC8235844217BF59E50B3F /* HotkeyManagerTests.swift */,
 				C654DA20715C3C6F29B9E6F4 /* LocalLogServiceTests.swift */,
-				3391ED18AB6186A614671A75 /* PermissionsCheckerTests.swift */,
+				42F84AD2F6F1FE9B0EA2B5B0 /* PermissionsCheckerTests.swift */,
 				14306A2EBDA587DA5C4E6182 /* PermissionsGateTests.swift */,
 			);
 			path = TAELMacAgentTests;
@@ -106,7 +117,8 @@
 		25F2B0347D98A8AADDF902E0 /* HUD */ = {
 			isa = PBXGroup;
 			children = (
-				A366B091A2CF78B079314AE1 /* HUDErrorView.swift */,
+				A7BCC0DD380BCA035E3BE982 /* HUDContextBundleView.swift */,
+				15EBB8FD7CC491B54EAD7C32 /* HUDErrorView.swift */,
 				9363E4D91044162835D20FAA /* HUDPanelController.swift */,
 				659ECE5A728C28C51E500F35 /* HUDScreenshotView.swift */,
 				1469160F2705F009163C15E0 /* HUDView.swift */,
@@ -152,7 +164,10 @@
 		99C93CFB96CF8F9301DF4757 /* Capture */ = {
 			isa = PBXGroup;
 			children = (
+				6117FF021320036888C63298 /* AXService.swift */,
 				6DEC30773055C5F4AE735610 /* CapturedScreenshot.swift */,
+				FB6EB3B92EA975E182EE38D0 /* ContextBundle.swift */,
+				E68A1DD137DD5E5D8291D4FB /* FocusedWindowMetadata.swift */,
 				198A12FCDFC021700C887DC3 /* ScreenCaptureService.swift */,
 				6C80394C10DB95ACE8B23410 /* ScreenshotTarget.swift */,
 			);
@@ -257,10 +272,12 @@
 				LastUpgradeCheck = 1430;
 				TargetAttributes = {
 					19B5206FF51EAAA5D9DD33BD = {
+						DevelopmentTeam = 4X8U3NCLQ8;
 						ProvisioningStyle = Automatic;
 					};
 					7BBF771A19B870A8BDB655E7 = {
-						DevelopmentTeam = "";
+						DevelopmentTeam = 4X8U3NCLQ8;
+						ProvisioningStyle = Automatic;
 					};
 				};
 			};
@@ -303,10 +320,14 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				2677B0F4DC46B483FCF1080D /* AXService.swift in Sources */,
 				0B0660E9860988CD91DA599E /* AppDelegate.swift in Sources */,
 				0330637AAF26CC3C25DCD10F /* CapturedScreenshot.swift in Sources */,
+				5825405C894EAB8C49D44D00 /* ContextBundle.swift in Sources */,
+				8791A773E3A54879EF035D27 /* FocusedWindowMetadata.swift in Sources */,
+				02E5172BAA7A3A56E9952C59 /* HUDContextBundleView.swift in Sources */,
+				CFA7CDEDCA4642C836A4892A /* HUDErrorView.swift in Sources */,
 				8AC8665020F765D063A96609 /* HUDPanelController.swift in Sources */,
-				C6D0EFACE6A32A5B1339F60E /* HUDErrorView.swift in Sources */,
 				DF3BAB13D3897B30011FF8B2 /* HUDScreenshotView.swift in Sources */,
 				F8A8B61233E0F29CD0725388 /* HUDView.swift in Sources */,
 				F6E2AD25AAD3F1AE6D0CA2A6 /* HotkeyInvocationHandler.swift in Sources */,
@@ -331,10 +352,11 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				554AB7D253B393D4F08AB225 /* ContextBundleTests.swift in Sources */,
 				06ADDF6182CAEDB9CC8191F9 /* HotkeyHandlerTests.swift in Sources */,
-				354AC58980118264F0FF7B67 /* HotkeyManagerTests.swift in Sources */,
+				849C242625ED0EA22FB38890 /* HotkeyManagerTests.swift in Sources */,
 				1EFB0EA699153ADC53EA4286 /* LocalLogServiceTests.swift in Sources */,
-				925C4AADEDDDF4182FB89AF8 /* PermissionsCheckerTests.swift in Sources */,
+				DB297417A946D0AEA311F7BE /* PermissionsCheckerTests.swift in Sources */,
 				5AD70596B8B5BEBD936F2F60 /* PermissionsGateTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -358,14 +380,10 @@
 				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
-				DEVELOPMENT_TEAM = 4X8U3NCLQ8;
 				ENABLE_USER_SCRIPT_SANDBOXING = YES;
 				GENERATE_INFOPLIST_FILE = NO;
 				INFOPLIST_FILE = TAELMacAgent/Resources/Info.plist;
-				LD_RUNPATH_SEARCH_PATHS = (
-					"$(inherited)",
-					"@executable_path/../Frameworks",
-				);
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 14.0;
 				PRODUCT_BUNDLE_IDENTIFIER = ai.tael.macagent;
 				PRODUCT_NAME = TAELMacAgent;
@@ -408,7 +426,7 @@
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				COPY_PHASE_STRIP = NO;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
-				DEVELOPMENT_TEAM = "";
+				DEVELOPMENT_TEAM = 4X8U3NCLQ8;
 				ENABLE_HARDENED_RUNTIME = YES;
 				ENABLE_NS_ASSERTIONS = NO;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
@@ -436,6 +454,8 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
+				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Apple Development";
+				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -486,7 +506,7 @@
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				COPY_PHASE_STRIP = NO;
 				DEBUG_INFORMATION_FORMAT = dwarf;
-				DEVELOPMENT_TEAM = "";
+				DEVELOPMENT_TEAM = 4X8U3NCLQ8;
 				ENABLE_HARDENED_RUNTIME = YES;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				ENABLE_TESTABILITY = YES;
@@ -525,14 +545,10 @@
 				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
-				DEVELOPMENT_TEAM = 4X8U3NCLQ8;
 				ENABLE_USER_SCRIPT_SANDBOXING = YES;
 				GENERATE_INFOPLIST_FILE = NO;
 				INFOPLIST_FILE = TAELMacAgent/Resources/Info.plist;
-				LD_RUNPATH_SEARCH_PATHS = (
-					"$(inherited)",
-					"@executable_path/../Frameworks",
-				);
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 14.0;
 				PRODUCT_BUNDLE_IDENTIFIER = ai.tael.macagent;
 				PRODUCT_NAME = TAELMacAgent;
@@ -544,6 +560,8 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
+				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Apple Development";
+				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				LD_RUNPATH_SEARCH_PATHS = (

--- a/TAELMacAgent/TAELMacAgent.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/TAELMacAgent/TAELMacAgent.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,0 +1,15 @@
+{
+  "originHash" : "69c39523ac0471922b625cc56b8722155cfd2afd660bdd4f5ff67335b5b87714",
+  "pins" : [
+    {
+      "identity" : "keyboardshortcuts",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/sindresorhus/KeyboardShortcuts",
+      "state" : {
+        "revision" : "1aef85578fdd4f9eaeeb8d53b7b4fc31bf08fe27",
+        "version" : "2.4.0"
+      }
+    }
+  ],
+  "version" : 3
+}

--- a/TAELMacAgent/TAELMacAgent.xcodeproj/xcshareddata/xcschemes/TAELMacAgent.xcscheme
+++ b/TAELMacAgent/TAELMacAgent.xcodeproj/xcshareddata/xcschemes/TAELMacAgent.xcscheme
@@ -1,10 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1530"
+   LastUpgradeVersion = "1430"
    version = "1.7">
    <BuildAction
       parallelizeBuildables = "YES"
-      buildImplicitDependencies = "YES">
+      buildImplicitDependencies = "YES"
+      runPostActionsOnFailure = "NO">
       <BuildActionEntries>
          <BuildActionEntry
             buildForTesting = "YES"
@@ -14,7 +15,7 @@
             buildForAnalyzing = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "7A00000000000000000000A1"
+               BlueprintIdentifier = "19B5206FF51EAAA5D9DD33BD"
                BuildableName = "TAELMacAgent.app"
                BlueprintName = "TAELMacAgent"
                ReferencedContainer = "container:TAELMacAgent.xcodeproj">
@@ -28,7 +29,7 @@
             buildForAnalyzing = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "7A00000000000000000000C1"
+               BlueprintIdentifier = "7BBF771A19B870A8BDB655E7"
                BuildableName = "TAELMacAgentTests.xctest"
                BlueprintName = "TAELMacAgentTests"
                ReferencedContainer = "container:TAELMacAgent.xcodeproj">
@@ -40,19 +41,32 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      shouldUseLaunchSchemeArgsEnv = "YES">
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      onlyGenerateCoverageForSpecifiedTargets = "NO">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "19B5206FF51EAAA5D9DD33BD"
+            BuildableName = "TAELMacAgent.app"
+            BlueprintName = "TAELMacAgent"
+            ReferencedContainer = "container:TAELMacAgent.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
       <Testables>
          <TestableReference
-            skipped = "NO">
+            skipped = "NO"
+            parallelizable = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "7A00000000000000000000C1"
+               BlueprintIdentifier = "7BBF771A19B870A8BDB655E7"
                BuildableName = "TAELMacAgentTests.xctest"
                BlueprintName = "TAELMacAgentTests"
                ReferencedContainer = "container:TAELMacAgent.xcodeproj">
             </BuildableReference>
          </TestableReference>
       </Testables>
+      <CommandLineArguments>
+      </CommandLineArguments>
    </TestAction>
    <LaunchAction
       buildConfiguration = "Debug"
@@ -68,12 +82,14 @@
          runnableDebuggingMode = "0">
          <BuildableReference
             BuildableIdentifier = "primary"
-            BlueprintIdentifier = "7A00000000000000000000A1"
+            BlueprintIdentifier = "19B5206FF51EAAA5D9DD33BD"
             BuildableName = "TAELMacAgent.app"
             BlueprintName = "TAELMacAgent"
             ReferencedContainer = "container:TAELMacAgent.xcodeproj">
          </BuildableReference>
       </BuildableProductRunnable>
+      <CommandLineArguments>
+      </CommandLineArguments>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"
@@ -85,12 +101,14 @@
          runnableDebuggingMode = "0">
          <BuildableReference
             BuildableIdentifier = "primary"
-            BlueprintIdentifier = "7A00000000000000000000A1"
+            BlueprintIdentifier = "19B5206FF51EAAA5D9DD33BD"
             BuildableName = "TAELMacAgent.app"
             BlueprintName = "TAELMacAgent"
             ReferencedContainer = "container:TAELMacAgent.xcodeproj">
          </BuildableReference>
       </BuildableProductRunnable>
+      <CommandLineArguments>
+      </CommandLineArguments>
    </ProfileAction>
    <AnalyzeAction
       buildConfiguration = "Debug">

--- a/TAELMacAgent/TAELMacAgent/App/AppDelegate.swift
+++ b/TAELMacAgent/TAELMacAgent/App/AppDelegate.swift
@@ -5,8 +5,6 @@
 
 import AppKit
 import Foundation
-import os.log
-import SwiftUI
 
 @MainActor
 final class AppDelegate: NSObject, NSApplicationDelegate {
@@ -16,7 +14,6 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     private var permissionsGate: PermissionsGate?
     private var screenCaptureService: DisplayScreenshotCapturing?
     private var logService: LocalLogService?
-    private let log = Logger(subsystem: "ai.tael.macagent", category: "AppDelegate")
 
     func applicationDidFinishLaunching(_ notification: Notification) {
         // Belt and braces: even though `LSUIElement = YES`, force
@@ -52,9 +49,19 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         // Hotkey closure: gate → capture → HUD + log. Runs on the main
         // actor (the `@MainActor` class isolation already covers it).
         hotkeyManager.onTrigger = { [weak self] in
-            guard let self else { return }
+            guard let self,
+                  let permissionsGate = self.permissionsGate,
+                  let screenCaptureService = self.screenCaptureService,
+                  let hudController = self.hudController,
+                  let logService = self.logService else { return }
+            let handler = HotkeyInvocationHandler(
+                permissionsGate: permissionsGate,
+                screenCaptureService: screenCaptureService,
+                presentScreenshot: { shot in hudController.present(screenshot: shot) },
+                logService: logService
+            )
             Task { @MainActor in
-                await self.handleHotkeyInvocation()
+                await handler.run()
             }
         }
         hotkeyManager.installBinding()
@@ -63,57 +70,5 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     func applicationWillTerminate(_ notification: Notification) {
         hotkeyManager?.tearDown()
         hudController?.tearDown()
-    }
-
-    /// One invocation of the Week 1 heartbeat. Captures latency,
-    /// outcome, and target metadata into a LocalLogService row.
-    private func handleHotkeyInvocation() async {
-        guard let permissionsGate, let screenCaptureService, let hudController, let logService else {
-            log.fault("Hotkey fired before AppDelegate finished launch wiring; ignoring.")
-            return
-        }
-
-        let started = Date()
-        let gateStart = started
-
-        do {
-            let screenshot = try await permissionsGate.withPermission(.screenRecording) { grant in
-                let gateEnd = Date()
-                let captureStart = gateEnd
-                let result = try await screenCaptureService.captureDisplayScreenshot(grant, target: .week1Default)
-                let captureEnd = Date()
-
-                await logService.record(InvocationLog(
-                    hotkeyTimestamp: started,
-                    gateOutcome: .granted,
-                    gateLatencyMs: gateEnd.timeIntervalSince(gateStart) * 1000,
-                    captureLatencyMs: captureEnd.timeIntervalSince(captureStart) * 1000,
-                    targetDescription: "\(result.target) \(result.width)x\(result.height)"
-                ))
-
-                return result
-            }
-            hudController.present(screenshot: screenshot)
-        } catch let error as PermissionError {
-            // PermissionsGate already invoked permissionUI.showGate.
-            // Log the outcome and stop.
-            let outcome: InvocationLog.GateOutcome
-            switch error {
-            case .missing: outcome = .denied
-            case .notImplemented: outcome = .restricted
-            }
-            await logService.record(InvocationLog(
-                hotkeyTimestamp: started,
-                gateOutcome: outcome,
-                errorDescription: error.localizedDescription
-            ))
-        } catch {
-            await logService.record(InvocationLog(
-                hotkeyTimestamp: started,
-                gateOutcome: .errored,
-                errorDescription: error.localizedDescription
-            ))
-            log.error("Hotkey invocation failed: \(error.localizedDescription, privacy: .public)")
-        }
     }
 }

--- a/TAELMacAgent/TAELMacAgent/App/AppDelegate.swift
+++ b/TAELMacAgent/TAELMacAgent/App/AppDelegate.swift
@@ -16,6 +16,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     private var hudController: HUDPanelController?
     private var permissionsGate: PermissionsGate?
     private var screenCaptureService: DisplayScreenshotCapturing?
+    private var focusedWindowReader: FocusedWindowReading?
     private var logService: LocalLogService?
 
     func applicationDidFinishLaunching(_ notification: Notification) {
@@ -30,6 +31,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             permissionUI: hudController
         )
         let screenCaptureService = ScreenCaptureService()
+        let focusedWindowReader = AXService()
         let hotkeyManager = HotkeyManager()
         let menuBarController = MenuBarController(
             onShowHUD: { [weak hudController] in
@@ -44,6 +46,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         self.hudController = hudController
         self.permissionsGate = permissionsGate
         self.screenCaptureService = screenCaptureService
+        self.focusedWindowReader = focusedWindowReader
         self.hotkeyManager = hotkeyManager
         self.menuBarController = menuBarController
 
@@ -55,6 +58,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             guard let self,
                   let permissionsGate = self.permissionsGate,
                   let screenCaptureService = self.screenCaptureService,
+                  let focusedWindowReader = self.focusedWindowReader,
                   let hudController = self.hudController,
                   let logService = self.logService else {
                 AppDelegate.log.error("Hotkey fired but app state unavailable; ignoring")
@@ -63,7 +67,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             let handler = HotkeyInvocationHandler(
                 permissionsGate: permissionsGate,
                 screenCaptureService: screenCaptureService,
+                focusedWindowReader: focusedWindowReader,
                 presentScreenshot: { shot in hudController.present(screenshot: shot) },
+                presentContext: { bundle in hudController.present(context: bundle) },
                 presentError: { msg in hudController.present(error: msg) },
                 logService: logService
             )

--- a/TAELMacAgent/TAELMacAgent/App/AppDelegate.swift
+++ b/TAELMacAgent/TAELMacAgent/App/AppDelegate.swift
@@ -5,9 +5,12 @@
 
 import AppKit
 import Foundation
+import os.log
 
 @MainActor
 final class AppDelegate: NSObject, NSApplicationDelegate {
+    private static let log = Logger(subsystem: "ai.tael.macagent", category: "AppDelegate")
+
     private var menuBarController: MenuBarController?
     private var hotkeyManager: HotkeyManager?
     private var hudController: HUDPanelController?
@@ -53,16 +56,17 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                   let permissionsGate = self.permissionsGate,
                   let screenCaptureService = self.screenCaptureService,
                   let hudController = self.hudController,
-                  let logService = self.logService else { return }
+                  let logService = self.logService else {
+                AppDelegate.log.error("Hotkey fired but app state unavailable; ignoring")
+                return
+            }
             let handler = HotkeyInvocationHandler(
                 permissionsGate: permissionsGate,
                 screenCaptureService: screenCaptureService,
                 presentScreenshot: { shot in hudController.present(screenshot: shot) },
                 logService: logService
             )
-            Task { @MainActor in
-                await handler.run()
-            }
+            await handler.run()
         }
         hotkeyManager.installBinding()
     }

--- a/TAELMacAgent/TAELMacAgent/App/AppDelegate.swift
+++ b/TAELMacAgent/TAELMacAgent/App/AppDelegate.swift
@@ -64,6 +64,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                 permissionsGate: permissionsGate,
                 screenCaptureService: screenCaptureService,
                 presentScreenshot: { shot in hudController.present(screenshot: shot) },
+                presentError: { msg in hudController.present(error: msg) },
                 logService: logService
             )
             await handler.run()

--- a/TAELMacAgent/TAELMacAgent/App/AppDelegate.swift
+++ b/TAELMacAgent/TAELMacAgent/App/AppDelegate.swift
@@ -4,6 +4,8 @@
 //
 
 import AppKit
+import Foundation
+import os.log
 import SwiftUI
 
 @MainActor
@@ -12,8 +14,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     private var hotkeyManager: HotkeyManager?
     private var hudController: HUDPanelController?
     private var permissionsGate: PermissionsGate?
-    private var screenCaptureService: ScreenCaptureService?
+    private var screenCaptureService: DisplayScreenshotCapturing?
     private var logService: LocalLogService?
+    private let log = Logger(subsystem: "ai.tael.macagent", category: "AppDelegate")
 
     func applicationDidFinishLaunching(_ notification: Notification) {
         // Belt and braces: even though `LSUIElement = YES`, force
@@ -46,16 +49,71 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 
         menuBarController.install()
 
-        // PR 1: do NOT register a real global hotkey yet. The hotkey
-        // package + the hotkey → gate → capture wire-up land in PR 2
-        // (Week 1 tickets 6–9). For now, only the placeholder callback
-        // exists, so launching the app does not call any protected
-        // API.
-        hotkeyManager.installPlaceholderBinding()
+        // Hotkey closure: gate → capture → HUD + log. Runs on the main
+        // actor (the `@MainActor` class isolation already covers it).
+        hotkeyManager.onTrigger = { [weak self] in
+            guard let self else { return }
+            Task { @MainActor in
+                await self.handleHotkeyInvocation()
+            }
+        }
+        hotkeyManager.installBinding()
     }
 
     func applicationWillTerminate(_ notification: Notification) {
         hotkeyManager?.tearDown()
         hudController?.tearDown()
+    }
+
+    /// One invocation of the Week 1 heartbeat. Captures latency,
+    /// outcome, and target metadata into a LocalLogService row.
+    private func handleHotkeyInvocation() async {
+        guard let permissionsGate, let screenCaptureService, let hudController, let logService else {
+            log.fault("Hotkey fired before AppDelegate finished launch wiring; ignoring.")
+            return
+        }
+
+        let started = Date()
+        let gateStart = started
+
+        do {
+            let screenshot = try await permissionsGate.withPermission(.screenRecording) { grant in
+                let gateEnd = Date()
+                let captureStart = gateEnd
+                let result = try await screenCaptureService.captureDisplayScreenshot(grant, target: .week1Default)
+                let captureEnd = Date()
+
+                await logService.record(InvocationLog(
+                    hotkeyTimestamp: started,
+                    gateOutcome: .granted,
+                    gateLatencyMs: gateEnd.timeIntervalSince(gateStart) * 1000,
+                    captureLatencyMs: captureEnd.timeIntervalSince(captureStart) * 1000,
+                    targetDescription: "\(result.target) \(result.width)x\(result.height)"
+                ))
+
+                return result
+            }
+            hudController.present(screenshot: screenshot)
+        } catch let error as PermissionError {
+            // PermissionsGate already invoked permissionUI.showGate.
+            // Log the outcome and stop.
+            let outcome: InvocationLog.GateOutcome
+            switch error {
+            case .missing: outcome = .denied
+            case .notImplemented: outcome = .restricted
+            }
+            await logService.record(InvocationLog(
+                hotkeyTimestamp: started,
+                gateOutcome: outcome,
+                errorDescription: error.localizedDescription
+            ))
+        } catch {
+            await logService.record(InvocationLog(
+                hotkeyTimestamp: started,
+                gateOutcome: .errored,
+                errorDescription: error.localizedDescription
+            ))
+            log.error("Hotkey invocation failed: \(error.localizedDescription, privacy: .public)")
+        }
     }
 }

--- a/TAELMacAgent/TAELMacAgent/App/HotkeyInvocationHandler.swift
+++ b/TAELMacAgent/TAELMacAgent/App/HotkeyInvocationHandler.swift
@@ -2,9 +2,8 @@
 //  HotkeyInvocationHandler.swift
 //  TAELMacAgent
 //
-//  Single invocation of the Week 1 heartbeat: gate → capture → HUD +
-//  log. Extracted from AppDelegate so the wire-up is unit-testable
-//  without spinning up a real menubar or NSPanel.
+//  Single invocation of the gate → capture → HUD pipeline.
+//  Lives outside `AppDelegate` so it can be unit-tested without a menubar or NSPanel.
 //
 
 import Foundation

--- a/TAELMacAgent/TAELMacAgent/App/HotkeyInvocationHandler.swift
+++ b/TAELMacAgent/TAELMacAgent/App/HotkeyInvocationHandler.swift
@@ -16,19 +16,22 @@ struct HotkeyInvocationHandler {
     let presentScreenshot: (CapturedScreenshot) -> Void
     let logService: LocalLogService
     let now: () -> Date
+    let kind: PermissionKind
 
     init(
         permissionsGate: PermissionsGate,
         screenCaptureService: any DisplayScreenshotCapturing,
         presentScreenshot: @escaping (CapturedScreenshot) -> Void,
         logService: LocalLogService,
-        now: @escaping () -> Date = Date.init
+        now: @escaping () -> Date = Date.init,
+        kind: PermissionKind = .screenRecording
     ) {
         self.permissionsGate = permissionsGate
         self.screenCaptureService = screenCaptureService
         self.presentScreenshot = presentScreenshot
         self.logService = logService
         self.now = now
+        self.kind = kind
     }
 
     private static let log = Logger(subsystem: "ai.tael.macagent", category: "HotkeyInvocationHandler")
@@ -39,7 +42,7 @@ struct HotkeyInvocationHandler {
         var gateLatencyMs: Double?
 
         do {
-            let screenshot = try await permissionsGate.withPermission(.screenRecording) { grant in
+            let screenshot = try await permissionsGate.withPermission(kind) { grant in
                 let gateEnd = self.now()
                 gateLatencyMs = gateEnd.timeIntervalSince(gateStart) * 1000
                 let captureStart = gateEnd

--- a/TAELMacAgent/TAELMacAgent/App/HotkeyInvocationHandler.swift
+++ b/TAELMacAgent/TAELMacAgent/App/HotkeyInvocationHandler.swift
@@ -13,7 +13,9 @@ import os.log
 struct HotkeyInvocationHandler {
     let permissionsGate: PermissionsGate
     let screenCaptureService: any DisplayScreenshotCapturing
+    let focusedWindowReader: (any FocusedWindowReading)?
     let presentScreenshot: (CapturedScreenshot) -> Void
+    let presentContext: ((ContextBundle) -> Void)?
     let presentError: (String) -> Void
     let logService: LocalLogService
     let now: () -> Date
@@ -22,7 +24,9 @@ struct HotkeyInvocationHandler {
     init(
         permissionsGate: PermissionsGate,
         screenCaptureService: any DisplayScreenshotCapturing,
+        focusedWindowReader: (any FocusedWindowReading)? = nil,
         presentScreenshot: @escaping (CapturedScreenshot) -> Void,
+        presentContext: ((ContextBundle) -> Void)? = nil,
         presentError: @escaping (String) -> Void = { _ in },
         logService: LocalLogService,
         now: @escaping () -> Date = Date.init,
@@ -30,7 +34,9 @@ struct HotkeyInvocationHandler {
     ) {
         self.permissionsGate = permissionsGate
         self.screenCaptureService = screenCaptureService
+        self.focusedWindowReader = focusedWindowReader
         self.presentScreenshot = presentScreenshot
+        self.presentContext = presentContext
         self.presentError = presentError
         self.logService = logService
         self.now = now
@@ -43,6 +49,7 @@ struct HotkeyInvocationHandler {
         let started = now()
         let gateStart = started
         var gateLatencyMs: Double?
+        var captureLatencyMs: Double?
 
         do {
             let screenshot = try await permissionsGate.withPermission(kind) { grant in
@@ -51,18 +58,26 @@ struct HotkeyInvocationHandler {
                 let captureStart = gateEnd
                 let result = try await screenCaptureService.captureDisplayScreenshot(grant, target: .week1Default)
                 let captureEnd = self.now()
-
-                await logService.record(InvocationLog(
-                    hotkeyTimestamp: started,
-                    gateOutcome: .granted,
-                    gateLatencyMs: gateLatencyMs,
-                    captureLatencyMs: captureEnd.timeIntervalSince(captureStart) * 1000,
-                    targetDescription: "\(result.target) \(result.width)x\(result.height)"
-                ))
+                captureLatencyMs = captureEnd.timeIntervalSince(captureStart) * 1000
 
                 return result
             }
-            presentScreenshot(screenshot)
+
+            let focusedWindow = await captureFocusedWindowIfAvailable()
+            let bundle = ContextBundle(screenshot: screenshot, focusedWindow: focusedWindow)
+            await logService.record(InvocationLog(
+                hotkeyTimestamp: started,
+                gateOutcome: .granted,
+                gateLatencyMs: gateLatencyMs,
+                captureLatencyMs: captureLatencyMs,
+                targetDescription: bundle.logTargetDescription
+            ))
+
+            if let presentContext {
+                presentContext(bundle)
+            } else {
+                presentScreenshot(screenshot)
+            }
         } catch let error as PermissionError {
             let outcome: InvocationLog.GateOutcome
             switch error {
@@ -83,6 +98,22 @@ struct HotkeyInvocationHandler {
             ))
             presentError("Screen capture failed: \(error.localizedDescription)")
             Self.log.error("Hotkey invocation failed: \(error.localizedDescription, privacy: .public)")
+        }
+    }
+
+    private func captureFocusedWindowIfAvailable() async -> FocusedWindowMetadata? {
+        guard let focusedWindowReader else { return nil }
+
+        do {
+            return try await permissionsGate.withPermission(.accessibility, showMissingUI: false) { grant in
+                try await focusedWindowReader.captureFocusedWindowMetadata(grant)
+            }
+        } catch let error as PermissionError {
+            Self.log.info("Focused-window metadata skipped: \(error.localizedDescription, privacy: .public)")
+            return nil
+        } catch {
+            Self.log.error("Focused-window metadata failed: \(error.localizedDescription, privacy: .public)")
+            return nil
         }
     }
 }

--- a/TAELMacAgent/TAELMacAgent/App/HotkeyInvocationHandler.swift
+++ b/TAELMacAgent/TAELMacAgent/App/HotkeyInvocationHandler.swift
@@ -56,7 +56,7 @@ struct HotkeyInvocationHandler {
                 let gateEnd = self.now()
                 gateLatencyMs = gateEnd.timeIntervalSince(gateStart) * 1000
                 let captureStart = gateEnd
-                let result = try await screenCaptureService.captureDisplayScreenshot(grant, target: .week1Default)
+                let result = try await screenCaptureService.captureDisplayScreenshot(grant, target: .defaultTarget)
                 let captureEnd = self.now()
                 captureLatencyMs = captureEnd.timeIntervalSince(captureStart) * 1000
 

--- a/TAELMacAgent/TAELMacAgent/App/HotkeyInvocationHandler.swift
+++ b/TAELMacAgent/TAELMacAgent/App/HotkeyInvocationHandler.swift
@@ -1,0 +1,82 @@
+//
+//  HotkeyInvocationHandler.swift
+//  TAELMacAgent
+//
+//  Single invocation of the Week 1 heartbeat: gate → capture → HUD +
+//  log. Extracted from AppDelegate so the wire-up is unit-testable
+//  without spinning up a real menubar or NSPanel.
+//
+
+import Foundation
+import os.log
+
+@MainActor
+struct HotkeyInvocationHandler {
+    let permissionsGate: PermissionsGate
+    let screenCaptureService: any DisplayScreenshotCapturing
+    let presentScreenshot: (CapturedScreenshot) -> Void
+    let logService: LocalLogService
+    let now: () -> Date
+
+    init(
+        permissionsGate: PermissionsGate,
+        screenCaptureService: any DisplayScreenshotCapturing,
+        presentScreenshot: @escaping (CapturedScreenshot) -> Void,
+        logService: LocalLogService,
+        now: @escaping () -> Date = Date.init
+    ) {
+        self.permissionsGate = permissionsGate
+        self.screenCaptureService = screenCaptureService
+        self.presentScreenshot = presentScreenshot
+        self.logService = logService
+        self.now = now
+    }
+
+    private static let log = Logger(subsystem: "ai.tael.macagent", category: "HotkeyInvocationHandler")
+
+    func run() async {
+        let started = now()
+        let gateStart = started
+
+        do {
+            let screenshot = try await permissionsGate.withPermission(.screenRecording) { grant in
+                let gateEnd = self.now()
+                let captureStart = gateEnd
+                let result = try await screenCaptureService.captureDisplayScreenshot(grant, target: .week1Default)
+                let captureEnd = self.now()
+
+                await logService.record(InvocationLog(
+                    hotkeyTimestamp: started,
+                    gateOutcome: .granted,
+                    gateLatencyMs: gateEnd.timeIntervalSince(gateStart) * 1000,
+                    captureLatencyMs: captureEnd.timeIntervalSince(captureStart) * 1000,
+                    targetDescription: "\(result.target) \(result.width)x\(result.height)"
+                ))
+
+                return result
+            }
+            presentScreenshot(screenshot)
+        } catch let error as PermissionError {
+            let outcome: InvocationLog.GateOutcome
+            switch error {
+            case .missing: outcome = .denied
+            case .notImplemented: outcome = .restricted
+            }
+            await logService.record(InvocationLog(
+                hotkeyTimestamp: started,
+                gateOutcome: outcome,
+                errorDescription: error.localizedDescription
+            ))
+        } catch {
+            // Use case-form so debug-mode log inspection sees
+            // `captureFailed("…")` rather than the generic NSError-bridged
+            // string that Swift errors get without LocalizedError.
+            await logService.record(InvocationLog(
+                hotkeyTimestamp: started,
+                gateOutcome: .errored,
+                errorDescription: String(describing: error)
+            ))
+            Self.log.error("Hotkey invocation failed: \(error.localizedDescription, privacy: .public)")
+        }
+    }
+}

--- a/TAELMacAgent/TAELMacAgent/App/HotkeyInvocationHandler.swift
+++ b/TAELMacAgent/TAELMacAgent/App/HotkeyInvocationHandler.swift
@@ -36,10 +36,12 @@ struct HotkeyInvocationHandler {
     func run() async {
         let started = now()
         let gateStart = started
+        var gateLatencyMs: Double?
 
         do {
             let screenshot = try await permissionsGate.withPermission(.screenRecording) { grant in
                 let gateEnd = self.now()
+                gateLatencyMs = gateEnd.timeIntervalSince(gateStart) * 1000
                 let captureStart = gateEnd
                 let result = try await screenCaptureService.captureDisplayScreenshot(grant, target: .week1Default)
                 let captureEnd = self.now()
@@ -47,7 +49,7 @@ struct HotkeyInvocationHandler {
                 await logService.record(InvocationLog(
                     hotkeyTimestamp: started,
                     gateOutcome: .granted,
-                    gateLatencyMs: gateEnd.timeIntervalSince(gateStart) * 1000,
+                    gateLatencyMs: gateLatencyMs,
                     captureLatencyMs: captureEnd.timeIntervalSince(captureStart) * 1000,
                     targetDescription: "\(result.target) \(result.width)x\(result.height)"
                 ))
@@ -67,12 +69,10 @@ struct HotkeyInvocationHandler {
                 errorDescription: error.localizedDescription
             ))
         } catch {
-            // Use case-form so debug-mode log inspection sees
-            // `captureFailed("…")` rather than the generic NSError-bridged
-            // string that Swift errors get without LocalizedError.
             await logService.record(InvocationLog(
                 hotkeyTimestamp: started,
                 gateOutcome: .errored,
+                gateLatencyMs: gateLatencyMs,
                 errorDescription: String(describing: error)
             ))
             Self.log.error("Hotkey invocation failed: \(error.localizedDescription, privacy: .public)")

--- a/TAELMacAgent/TAELMacAgent/App/HotkeyInvocationHandler.swift
+++ b/TAELMacAgent/TAELMacAgent/App/HotkeyInvocationHandler.swift
@@ -14,6 +14,7 @@ struct HotkeyInvocationHandler {
     let permissionsGate: PermissionsGate
     let screenCaptureService: any DisplayScreenshotCapturing
     let presentScreenshot: (CapturedScreenshot) -> Void
+    let presentError: (String) -> Void
     let logService: LocalLogService
     let now: () -> Date
     let kind: PermissionKind
@@ -22,6 +23,7 @@ struct HotkeyInvocationHandler {
         permissionsGate: PermissionsGate,
         screenCaptureService: any DisplayScreenshotCapturing,
         presentScreenshot: @escaping (CapturedScreenshot) -> Void,
+        presentError: @escaping (String) -> Void = { _ in },
         logService: LocalLogService,
         now: @escaping () -> Date = Date.init,
         kind: PermissionKind = .screenRecording
@@ -29,6 +31,7 @@ struct HotkeyInvocationHandler {
         self.permissionsGate = permissionsGate
         self.screenCaptureService = screenCaptureService
         self.presentScreenshot = presentScreenshot
+        self.presentError = presentError
         self.logService = logService
         self.now = now
         self.kind = kind
@@ -78,6 +81,7 @@ struct HotkeyInvocationHandler {
                 gateLatencyMs: gateLatencyMs,
                 errorDescription: String(describing: error)
             ))
+            presentError("Screen capture failed: \(error.localizedDescription)")
             Self.log.error("Hotkey invocation failed: \(error.localizedDescription, privacy: .public)")
         }
     }

--- a/TAELMacAgent/TAELMacAgent/App/HotkeyInvocationHandler.swift
+++ b/TAELMacAgent/TAELMacAgent/App/HotkeyInvocationHandler.swift
@@ -96,8 +96,23 @@ struct HotkeyInvocationHandler {
                 gateLatencyMs: gateLatencyMs,
                 errorDescription: String(describing: error)
             ))
-            presentError("Screen capture failed: \(error.localizedDescription)")
+            presentError(Self.userFacingMessage(for: error))
             Self.log.error("Hotkey invocation failed: \(error.localizedDescription, privacy: .public)")
+        }
+    }
+
+    /// Curated, user-facing copy for the capture error HUD. The raw
+    /// `localizedDescription` may include framework-internal strings or
+    /// paths; only the typed cases we know about reach the user. Everything
+    /// else collapses to a generic message and the detail goes to `os.log`.
+    static func userFacingMessage(for error: Error) -> String {
+        switch error {
+        case ScreenCaptureError.noDisplaysAvailable:
+            return "Screen capture failed: no display is available right now."
+        case ScreenCaptureError.captureFailed:
+            return "Screen capture failed. Try again, or quit and relaunch TAEL."
+        default:
+            return "Screen capture failed."
         }
     }
 

--- a/TAELMacAgent/TAELMacAgent/Capture/AXService.swift
+++ b/TAELMacAgent/TAELMacAgent/Capture/AXService.swift
@@ -60,6 +60,15 @@ public final class AXService: FocusedWindowReading {
             )
         }
 
+        guard CFGetTypeID(focusedWindowRef) == AXUIElementGetTypeID() else {
+            return FocusedWindowMetadata(
+                bundleIdentifier: bundleIdentifier,
+                applicationName: applicationName,
+                windowTitle: nil,
+                windowRole: nil,
+                capturedAt: capturedAt
+            )
+        }
         let focusedWindow = focusedWindowRef as! AXUIElement
         return FocusedWindowMetadata(
             bundleIdentifier: bundleIdentifier,

--- a/TAELMacAgent/TAELMacAgent/Capture/AXService.swift
+++ b/TAELMacAgent/TAELMacAgent/Capture/AXService.swift
@@ -1,0 +1,79 @@
+//
+//  AXService.swift
+//  TAELMacAgent
+//
+//  Reads frontmost/focused-window metadata through Accessibility APIs.
+//  The service is read-only and requires a .accessibility PermissionGrant.
+//
+
+import AppKit
+import Foundation
+#if canImport(ApplicationServices)
+import ApplicationServices
+#endif
+
+public protocol FocusedWindowReading: Sendable {
+    @MainActor
+    func captureFocusedWindowMetadata(_ grant: PermissionGrant) async throws -> FocusedWindowMetadata
+}
+
+@MainActor
+public final class AXService: FocusedWindowReading {
+    public init() {}
+
+    public func captureFocusedWindowMetadata(_ grant: PermissionGrant) async throws -> FocusedWindowMetadata {
+        precondition(
+            grant.kind == .accessibility,
+            "AXService requires a .accessibility grant"
+        )
+
+        let app = NSWorkspace.shared.frontmostApplication
+        let bundleIdentifier = app?.bundleIdentifier
+        let applicationName = app?.localizedName
+        let capturedAt = Date()
+
+        guard let app, app.processIdentifier > 0 else {
+            return FocusedWindowMetadata(
+                bundleIdentifier: bundleIdentifier,
+                applicationName: applicationName,
+                windowTitle: nil,
+                windowRole: nil,
+                capturedAt: capturedAt
+            )
+        }
+
+        let appElement = AXUIElementCreateApplication(app.processIdentifier)
+        var focusedWindowRef: CFTypeRef?
+        let err = AXUIElementCopyAttributeValue(
+            appElement,
+            kAXFocusedWindowAttribute as CFString,
+            &focusedWindowRef
+        )
+
+        guard err == .success, let focusedWindowRef else {
+            return FocusedWindowMetadata(
+                bundleIdentifier: bundleIdentifier,
+                applicationName: applicationName,
+                windowTitle: nil,
+                windowRole: nil,
+                capturedAt: capturedAt
+            )
+        }
+
+        let focusedWindow = focusedWindowRef as! AXUIElement
+        return FocusedWindowMetadata(
+            bundleIdentifier: bundleIdentifier,
+            applicationName: applicationName,
+            windowTitle: copyStringAttribute(focusedWindow, kAXTitleAttribute as CFString),
+            windowRole: copyStringAttribute(focusedWindow, kAXRoleAttribute as CFString),
+            capturedAt: capturedAt
+        )
+    }
+
+    private func copyStringAttribute(_ element: AXUIElement, _ attribute: CFString) -> String? {
+        var value: CFTypeRef?
+        let err = AXUIElementCopyAttributeValue(element, attribute, &value)
+        guard err == .success else { return nil }
+        return value as? String
+    }
+}

--- a/TAELMacAgent/TAELMacAgent/Capture/ContextBundle.swift
+++ b/TAELMacAgent/TAELMacAgent/Capture/ContextBundle.swift
@@ -1,0 +1,42 @@
+//
+//  ContextBundle.swift
+//  TAELMacAgent
+//
+//  One invocation's visible context. Screenshot is the Week 1 heartbeat;
+//  focused-window metadata is Week 2 context and must degrade gracefully.
+//
+
+import Foundation
+
+public struct ContextBundle: Sendable {
+    public let screenshot: CapturedScreenshot?
+    public let focusedWindow: FocusedWindowMetadata?
+    public let capturedAt: Date
+
+    public init(
+        screenshot: CapturedScreenshot?,
+        focusedWindow: FocusedWindowMetadata?,
+        capturedAt: Date = Date()
+    ) {
+        self.screenshot = screenshot
+        self.focusedWindow = focusedWindow
+        self.capturedAt = capturedAt
+    }
+
+    public var hasFocusedWindowData: Bool {
+        focusedWindow?.hasAnyData == true
+    }
+
+    public var logTargetDescription: String? {
+        var parts: [String] = []
+        if let screenshot {
+            parts.append("\(screenshot.target) \(screenshot.width)x\(screenshot.height)")
+        }
+        if let focusedWindow, focusedWindow.hasAnyData {
+            let app = focusedWindow.applicationName ?? focusedWindow.bundleIdentifier ?? "unknown app"
+            let title = focusedWindow.windowTitle ?? "untitled window"
+            parts.append("\(app): \(title)")
+        }
+        return parts.isEmpty ? nil : parts.joined(separator: " | ")
+    }
+}

--- a/TAELMacAgent/TAELMacAgent/Capture/FocusedWindowMetadata.swift
+++ b/TAELMacAgent/TAELMacAgent/Capture/FocusedWindowMetadata.swift
@@ -1,0 +1,39 @@
+//
+//  FocusedWindowMetadata.swift
+//  TAELMacAgent
+//
+//  Snapshot of the frontmost app's focused window taken alongside
+//  the screenshot during a hotkey invocation. All fields are optional
+//  because AX availability varies by app, sandbox, and visibility.
+//
+
+import Foundation
+
+public struct FocusedWindowMetadata: Equatable, Sendable {
+    public let bundleIdentifier: String?
+    public let applicationName: String?
+    public let windowTitle: String?
+    public let windowRole: String?
+    public let capturedAt: Date
+
+    public init(
+        bundleIdentifier: String?,
+        applicationName: String?,
+        windowTitle: String?,
+        windowRole: String?,
+        capturedAt: Date = Date()
+    ) {
+        self.bundleIdentifier = bundleIdentifier
+        self.applicationName = applicationName
+        self.windowTitle = windowTitle
+        self.windowRole = windowRole
+        self.capturedAt = capturedAt
+    }
+
+    public var hasAnyData: Bool {
+        bundleIdentifier != nil ||
+            applicationName != nil ||
+            windowTitle != nil ||
+            windowRole != nil
+    }
+}

--- a/TAELMacAgent/TAELMacAgent/Capture/ScreenCaptureService.swift
+++ b/TAELMacAgent/TAELMacAgent/Capture/ScreenCaptureService.swift
@@ -33,7 +33,23 @@ public enum ScreenCaptureError: Error, Equatable {
     case captureFailed(String)
 }
 
-public final class ScreenCaptureService {
+/// Minimal protocol the hotkey/wiring layer depends on. Lets tests
+/// inject a mock that returns a synthetic `CapturedScreenshot` without
+/// pulling in ScreenCaptureKit or requiring a real TCC grant.
+public protocol DisplayScreenshotCapturing: Sendable {
+    func captureDisplayScreenshot(
+        _ grant: PermissionGrant,
+        target: ScreenshotTarget
+    ) async throws -> CapturedScreenshot
+}
+
+public extension DisplayScreenshotCapturing {
+    func captureDisplayScreenshot(_ grant: PermissionGrant) async throws -> CapturedScreenshot {
+        try await captureDisplayScreenshot(grant, target: .week1Default)
+    }
+}
+
+public final class ScreenCaptureService: DisplayScreenshotCapturing {
     public init() {}
 
     /// Capture a screenshot of `target`, falling back to `.mainDisplay`
@@ -43,7 +59,7 @@ public final class ScreenCaptureService {
     /// is the contract that PR 2 will fill in.
     public func captureDisplayScreenshot(
         _ grant: PermissionGrant,
-        target: ScreenshotTarget = .week1Default
+        target: ScreenshotTarget
     ) async throws -> CapturedScreenshot {
         precondition(
             grant.kind == .screenRecording,

--- a/TAELMacAgent/TAELMacAgent/Capture/ScreenCaptureService.swift
+++ b/TAELMacAgent/TAELMacAgent/Capture/ScreenCaptureService.swift
@@ -116,8 +116,8 @@ public final class ScreenCaptureService: DisplayScreenshotCapturing {
         let scale = NSScreen.screens
             .first { ($0.deviceDescription[NSDeviceDescriptionKey("NSScreenNumber")] as? CGDirectDisplayID) == display.displayID }?
             .backingScaleFactor ?? 2.0
-        cfg.width = display.width * Int(scale)
-        cfg.height = display.height * Int(scale)
+        cfg.width = Int((CGFloat(display.width) * scale).rounded())
+        cfg.height = Int((CGFloat(display.height) * scale).rounded())
         cfg.showsCursor = true
         cfg.queueDepth = 1
 

--- a/TAELMacAgent/TAELMacAgent/Capture/ScreenCaptureService.swift
+++ b/TAELMacAgent/TAELMacAgent/Capture/ScreenCaptureService.swift
@@ -5,13 +5,11 @@
 //  Protected service. Only callable with a `PermissionGrant` minted by
 //  `PermissionsGate.withPermission(.screenRecording)`.
 //
-//  PR 1: this is a typed stub. The real ScreenCaptureKit path lands in
-//  PR 2 (Week 1 ticket 8) using:
-//
-//      SCShareableContent
-//      SCContentFilter
-//      SCStreamConfiguration
-//      SCScreenshotManager.captureImage(contentFilter:configuration:)
+//  Real ScreenCaptureKit capture: SCShareableContent → SCContentFilter
+//  → SCStreamConfiguration → SCScreenshotManager.captureImage. Cursor
+//  display first, mainDisplay fallback (v0.3 §23.2). Width/height are
+//  multiplied by the NSScreen backingScaleFactor — explicit per
+//  v0.3 §23.10 (the cfg defaults give the wrong dimensions).
 //
 //  Do NOT use `SCScreenshotManager.captureImage(in:)` — that overload
 //  is macOS 15.2+, and our deployment target is macOS 14.0+
@@ -22,10 +20,14 @@ import Foundation
 #if canImport(CoreGraphics)
 import CoreGraphics
 #endif
+#if canImport(ScreenCaptureKit)
+import ScreenCaptureKit
+#endif
+#if canImport(AppKit)
+import AppKit
+#endif
 
 public enum ScreenCaptureError: Error, Equatable {
-    /// PR 1 placeholder. Removed when ScreenCaptureKit lands in PR 2.
-    case notImplemented
     /// `SCShareableContent` returned no displays.
     case noDisplaysAvailable
     /// Underlying ScreenCaptureKit error. Wrapped to keep call sites
@@ -49,14 +51,44 @@ public extension DisplayScreenshotCapturing {
     }
 }
 
+/// Resolves the target display per v0.3 §23.2: cursor display first,
+/// fallback to main display, fallback to the first available display.
+/// Returns the resolved `(SCDisplay, ScreenshotTarget)` so the caller
+/// knows whether it got the cursor display or fell back.
+@available(macOS 14.0, *)
+private func resolveTargetDisplay(
+    in content: SCShareableContent,
+    requested: ScreenshotTarget
+) -> (display: SCDisplay, resolved: ScreenshotTarget)? {
+    guard !content.displays.isEmpty else { return nil }
+
+    let mainDisplayID = CGMainDisplayID()
+
+    if requested == .displayContainingCursor {
+        let cursorPoint = NSEvent.mouseLocation
+        if let nsScreen = NSScreen.screens.first(where: { $0.frame.contains(cursorPoint) }),
+           let screenNumber = nsScreen.deviceDescription[NSDeviceDescriptionKey("NSScreenNumber")] as? CGDirectDisplayID,
+           let display = content.displays.first(where: { $0.displayID == screenNumber })
+        {
+            return (display, .displayContainingCursor)
+        }
+    }
+
+    // Fallback path: main display, then first available.
+    if let main = content.displays.first(where: { $0.displayID == mainDisplayID }) {
+        return (main, .mainDisplay)
+    }
+    if let first = content.displays.first {
+        return (first, .mainDisplay)
+    }
+    return nil
+}
+
 public final class ScreenCaptureService: DisplayScreenshotCapturing {
     public init() {}
 
     /// Capture a screenshot of `target`, falling back to `.mainDisplay`
     /// if `displayContainingCursor` cannot be resolved.
-    ///
-    /// PR 1 throws `ScreenCaptureError.notImplemented`. The signature
-    /// is the contract that PR 2 will fill in.
     public func captureDisplayScreenshot(
         _ grant: PermissionGrant,
         target: ScreenshotTarget
@@ -66,20 +98,39 @@ public final class ScreenCaptureService: DisplayScreenshotCapturing {
             "ScreenCaptureService requires a .screenRecording grant"
         )
 
-        // PR 2 implementation outline (do not enable in PR 1):
-        //
-        //   let content = try await SCShareableContent.current
-        //   let display = resolveTargetDisplay(content, target: target)
-        //   let filter = SCContentFilter(display: display, excludingWindows: [])
-        //   let cfg = SCStreamConfiguration()
-        //   cfg.width  = display.width  * Int(display.backingScaleFactor)
-        //   cfg.height = display.height * Int(display.backingScaleFactor)
-        //   cfg.showsCursor = true
-        //   let cgImage = try await SCScreenshotManager.captureImage(
-        //       contentFilter: filter, configuration: cfg
-        //   )
-        //   return CapturedScreenshot(image: cgImage, target: resolvedTarget)
+        let content: SCShareableContent
+        do {
+            content = try await SCShareableContent.current
+        } catch {
+            throw ScreenCaptureError.captureFailed("SCShareableContent.current failed: \(error.localizedDescription)")
+        }
 
-        throw ScreenCaptureError.notImplemented
+        guard let resolved = resolveTargetDisplay(in: content, requested: target) else {
+            throw ScreenCaptureError.noDisplaysAvailable
+        }
+
+        let display = resolved.display
+        let filter = SCContentFilter(display: display, excludingWindows: [])
+
+        let cfg = SCStreamConfiguration()
+        let scale = NSScreen.screens
+            .first { ($0.deviceDescription[NSDeviceDescriptionKey("NSScreenNumber")] as? CGDirectDisplayID) == display.displayID }?
+            .backingScaleFactor ?? 2.0
+        cfg.width = display.width * Int(scale)
+        cfg.height = display.height * Int(scale)
+        cfg.showsCursor = true
+        cfg.queueDepth = 1
+
+        let cgImage: CGImage
+        do {
+            cgImage = try await SCScreenshotManager.captureImage(
+                contentFilter: filter,
+                configuration: cfg
+            )
+        } catch {
+            throw ScreenCaptureError.captureFailed("SCScreenshotManager.captureImage failed: \(error.localizedDescription)")
+        }
+
+        return CapturedScreenshot(image: cgImage, target: resolved.resolved)
     }
 }

--- a/TAELMacAgent/TAELMacAgent/Capture/ScreenCaptureService.swift
+++ b/TAELMacAgent/TAELMacAgent/Capture/ScreenCaptureService.swift
@@ -51,37 +51,68 @@ public extension DisplayScreenshotCapturing {
     }
 }
 
-/// Resolves the target display per v0.3 §23.2: cursor display first,
-/// fallback to main display, fallback to the first available display.
-/// Returns the resolved `(SCDisplay, ScreenshotTarget)` so the caller
-/// knows whether it got the cursor display or fell back.
+/// Pure resolution rule per v0.3 §23.2: cursor display first, fallback
+/// to main display, fallback to the first available display. Generic
+/// over the candidate type so unit tests can pass plain structs without
+/// instantiating `SCShareableContent` or reading `NSEvent.mouseLocation`.
+///
+/// Resolution order:
+///   1. requested == .displayContainingCursor and cursor display is in
+///      candidates → `(cursorDisplay, .displayContainingCursor)`
+///   2. main display ID is in candidates → `(mainDisplay, .mainDisplay)`
+///   3. any candidate exists → `(first, .mainDisplay)` (best-effort fallback)
+///   4. no candidates → `nil`
+struct DisplayResolution<D> {
+    let display: D
+    let resolved: ScreenshotTarget
+}
+
+func resolveDisplay<D>(
+    candidates: [D],
+    displayID: (D) -> CGDirectDisplayID,
+    cursorDisplayID: CGDirectDisplayID?,
+    mainDisplayID: CGDirectDisplayID,
+    requested: ScreenshotTarget
+) -> DisplayResolution<D>? {
+    guard !candidates.isEmpty else { return nil }
+
+    if requested == .displayContainingCursor,
+       let cursorID = cursorDisplayID,
+       let display = candidates.first(where: { displayID($0) == cursorID })
+    {
+        return DisplayResolution(display: display, resolved: .displayContainingCursor)
+    }
+
+    if let main = candidates.first(where: { displayID($0) == mainDisplayID }) {
+        return DisplayResolution(display: main, resolved: .mainDisplay)
+    }
+    if let first = candidates.first {
+        return DisplayResolution(display: first, resolved: .mainDisplay)
+    }
+    return nil
+}
+
+/// Adapter: reads cursor location from `NSEvent` and delegates to the
+/// pure `resolveDisplay` resolver above. Side-effecting; not unit-tested.
 @available(macOS 14.0, *)
 private func resolveTargetDisplay(
     in content: SCShareableContent,
     requested: ScreenshotTarget
 ) -> (display: SCDisplay, resolved: ScreenshotTarget)? {
-    guard !content.displays.isEmpty else { return nil }
+    let cursorPoint = NSEvent.mouseLocation
+    let cursorDisplayID = NSScreen.screens
+        .first(where: { $0.frame.contains(cursorPoint) })?
+        .deviceDescription[NSDeviceDescriptionKey("NSScreenNumber")] as? CGDirectDisplayID
 
-    let mainDisplayID = CGMainDisplayID()
+    guard let resolution = resolveDisplay(
+        candidates: content.displays,
+        displayID: { $0.displayID },
+        cursorDisplayID: cursorDisplayID,
+        mainDisplayID: CGMainDisplayID(),
+        requested: requested
+    ) else { return nil }
 
-    if requested == .displayContainingCursor {
-        let cursorPoint = NSEvent.mouseLocation
-        if let nsScreen = NSScreen.screens.first(where: { $0.frame.contains(cursorPoint) }),
-           let screenNumber = nsScreen.deviceDescription[NSDeviceDescriptionKey("NSScreenNumber")] as? CGDirectDisplayID,
-           let display = content.displays.first(where: { $0.displayID == screenNumber })
-        {
-            return (display, .displayContainingCursor)
-        }
-    }
-
-    // Fallback path: main display, then first available.
-    if let main = content.displays.first(where: { $0.displayID == mainDisplayID }) {
-        return (main, .mainDisplay)
-    }
-    if let first = content.displays.first {
-        return (first, .mainDisplay)
-    }
-    return nil
+    return (resolution.display, resolution.resolved)
 }
 
 public final class ScreenCaptureService: DisplayScreenshotCapturing {

--- a/TAELMacAgent/TAELMacAgent/Capture/ScreenCaptureService.swift
+++ b/TAELMacAgent/TAELMacAgent/Capture/ScreenCaptureService.swift
@@ -47,7 +47,7 @@ public protocol DisplayScreenshotCapturing: Sendable {
 
 public extension DisplayScreenshotCapturing {
     func captureDisplayScreenshot(_ grant: PermissionGrant) async throws -> CapturedScreenshot {
-        try await captureDisplayScreenshot(grant, target: .week1Default)
+        try await captureDisplayScreenshot(grant, target: .defaultTarget)
     }
 }
 

--- a/TAELMacAgent/TAELMacAgent/Capture/ScreenshotTarget.swift
+++ b/TAELMacAgent/TAELMacAgent/Capture/ScreenshotTarget.swift
@@ -2,12 +2,12 @@
 //  ScreenshotTarget.swift
 //  TAELMacAgent
 //
-//  Week 1 capture target. v0.3 §23.2 is explicit:
+//  Default capture target. v0.3 §23.2 is explicit:
 //
 //      "Display containing cursor, fallback to main display."
 //
-//  This is NOT focused-window capture. Focused-window context is AX
-//  work and starts in Week 2.
+//  This is NOT focused-window capture. Focused-window AX context lives
+//  alongside the screenshot in `ContextBundle` (Week 2).
 //
 
 import Foundation
@@ -16,8 +16,8 @@ public enum ScreenshotTarget: Sendable, Equatable {
     case displayContainingCursor
     case mainDisplay
 
-    /// Week 1 default. Try `displayContainingCursor` first; the
-    /// capture service falls back to `.mainDisplay` if no display
+    /// Default capture target. Try `displayContainingCursor` first;
+    /// the capture service falls back to `.mainDisplay` if no display
     /// matches the cursor location.
-    public static let week1Default: ScreenshotTarget = .displayContainingCursor
+    public static let defaultTarget: ScreenshotTarget = .displayContainingCursor
 }

--- a/TAELMacAgent/TAELMacAgent/HUD/HUDContextBundleView.swift
+++ b/TAELMacAgent/TAELMacAgent/HUD/HUDContextBundleView.swift
@@ -5,7 +5,6 @@
 //  Renders the Week 1 screenshot plus Week 2 focused-window metadata.
 //
 
-import AppKit
 import SwiftUI
 
 struct HUDContextBundleView: View {

--- a/TAELMacAgent/TAELMacAgent/HUD/HUDContextBundleView.swift
+++ b/TAELMacAgent/TAELMacAgent/HUD/HUDContextBundleView.swift
@@ -1,0 +1,89 @@
+//
+//  HUDContextBundleView.swift
+//  TAELMacAgent
+//
+//  Renders the Week 1 screenshot plus Week 2 focused-window metadata.
+//
+
+import AppKit
+import SwiftUI
+
+struct HUDContextBundleView: View {
+    let context: ContextBundle
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            header
+
+            if let screenshot = context.screenshot {
+                Image(decorative: screenshot.image, scale: 1.0, orientation: .up)
+                    .resizable()
+                    .aspectRatio(contentMode: .fit)
+                    .frame(maxWidth: 720, maxHeight: 440)
+                    .background(Color.black.opacity(0.3))
+                    .cornerRadius(6)
+            }
+
+            Divider()
+
+            VStack(alignment: .leading, spacing: 4) {
+                Text("Focused window")
+                    .font(.caption.weight(.semibold))
+                    .foregroundStyle(.secondary)
+
+                if let focusedWindow = context.focusedWindow, focusedWindow.hasAnyData {
+                    Text(focusedWindow.applicationName ?? focusedWindow.bundleIdentifier ?? "Unknown app")
+                        .font(.subheadline.weight(.semibold))
+                        .lineLimit(1)
+
+                    Text(focusedWindow.windowTitle ?? "No focused window title")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                        .lineLimit(2)
+
+                    if let role = focusedWindow.windowRole {
+                        Text(role)
+                            .font(.caption2)
+                            .foregroundStyle(.tertiary)
+                    }
+                } else {
+                    Text("Accessibility metadata unavailable")
+                        .font(.caption)
+                        .foregroundStyle(.tertiary)
+                }
+            }
+        }
+        .padding(16)
+    }
+
+    private var header: some View {
+        HStack(alignment: .firstTextBaseline) {
+            if let screenshot = context.screenshot {
+                Text("Captured \(screenshot.width)x\(screenshot.height)")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+
+                Text(targetLabel(for: screenshot))
+                    .font(.caption2)
+                    .foregroundStyle(.tertiary)
+            } else {
+                Text("No screenshot captured")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+
+            Spacer()
+
+            Text(context.capturedAt.formatted(date: .omitted, time: .standard))
+                .font(.caption2)
+                .foregroundStyle(.tertiary)
+        }
+    }
+
+    private func targetLabel(for screenshot: CapturedScreenshot) -> String {
+        switch screenshot.target {
+        case .displayContainingCursor: return "cursor display"
+        case .mainDisplay: return "main display fallback"
+        }
+    }
+}

--- a/TAELMacAgent/TAELMacAgent/HUD/HUDErrorView.swift
+++ b/TAELMacAgent/TAELMacAgent/HUD/HUDErrorView.swift
@@ -1,0 +1,28 @@
+//
+//  HUDErrorView.swift
+//  TAELMacAgent
+//
+//  Shown when a hotkey invocation reaches the capture stage and fails.
+//  Mirrors HUDScreenshotView's layout for visual consistency.
+//
+
+import SwiftUI
+
+struct HUDErrorView: View {
+    let message: String
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Label("Capture failed", systemImage: "exclamationmark.triangle.fill")
+                .font(.headline)
+                .foregroundStyle(.orange)
+
+            Text(message)
+                .font(.body)
+                .foregroundStyle(.secondary)
+                .frame(maxWidth: 480, alignment: .leading)
+                .fixedSize(horizontal: false, vertical: true)
+        }
+        .padding(16)
+    }
+}

--- a/TAELMacAgent/TAELMacAgent/HUD/HUDPanelController.swift
+++ b/TAELMacAgent/TAELMacAgent/HUD/HUDPanelController.swift
@@ -31,6 +31,10 @@ final class HUDPanelController: NSObject, PermissionGatePresenting {
         presentNew(content: HUDScreenshotView(screenshot: screenshot))
     }
 
+    func present(error message: String) {
+        presentNew(content: HUDErrorView(message: message))
+    }
+
     /// `PermissionGatePresenting` implementation: show a sheet-like HUD that
     /// explains the missing permission and links to System Settings.
     /// `nonisolated` so it satisfies the non-isolated protocol

--- a/TAELMacAgent/TAELMacAgent/HUD/HUDPanelController.swift
+++ b/TAELMacAgent/TAELMacAgent/HUD/HUDPanelController.swift
@@ -6,8 +6,7 @@
 //  `PermissionGatePresenting` so `PermissionsGate` can route missing-
 //  permission states through the same surface as the placeholder content.
 //
-//  PR 1 ships an intentionally ugly placeholder. Real screenshot
-//  rendering lands in PR 2 (Week 1 ticket 10).
+//  Hosts placeholder, screenshot, context bundle, permission, and error HUDs.
 //
 
 import AppKit
@@ -28,7 +27,11 @@ final class HUDPanelController: NSObject, PermissionGatePresenting {
     }
 
     func present(screenshot: CapturedScreenshot) {
-        presentNew(content: HUDScreenshotView(screenshot: screenshot))
+        presentNew(content: HUDScreenshotView(screenshot: screenshot), size: NSSize(width: 760, height: 560))
+    }
+
+    func present(context: ContextBundle) {
+        presentNew(content: HUDContextBundleView(context: context), size: NSSize(width: 760, height: 620))
     }
 
     func present(error message: String) {
@@ -58,17 +61,20 @@ final class HUDPanelController: NSObject, PermissionGatePresenting {
     /// `content`. Avoids both the multi-panel leak and the "stale rootView"
     /// bug from reusing a panel that was created for a different surface
     /// (gate vs placeholder).
-    private func presentNew<Content: View>(content: Content) {
+    private func presentNew<Content: View>(
+        content: Content,
+        size: NSSize = NSSize(width: 480, height: 280)
+    ) {
         panel?.orderOut(nil)
         panel = nil
-        let next = makePanel(content: content)
+        let next = makePanel(content: content, size: size)
         panel = next
         present(next)
     }
 
-    private func makePanel<Content: View>(content: Content) -> NSPanel {
+    private func makePanel<Content: View>(content: Content, size: NSSize) -> NSPanel {
         let host = NSHostingController(rootView: AnyView(content))
-        host.view.frame = NSRect(x: 0, y: 0, width: 480, height: 280)
+        host.view.frame = NSRect(origin: .zero, size: size)
 
         // v0.3 §23.11 defaults. Borderless + non-activating gives the
         // overlay-on-top-of-the-user's-app feel; transient prevents

--- a/TAELMacAgent/TAELMacAgent/HUD/HUDPanelController.swift
+++ b/TAELMacAgent/TAELMacAgent/HUD/HUDPanelController.swift
@@ -28,9 +28,7 @@ final class HUDPanelController: NSObject, PermissionGatePresenting {
     }
 
     func present(screenshot: CapturedScreenshot) {
-        // Task 7 fills this in. Stub so Task 6's AppDelegate wiring
-        // compiles in its own commit.
-        showPlaceholder()
+        presentNew(content: HUDScreenshotView(screenshot: screenshot))
     }
 
     /// `PermissionGatePresenting` implementation: show a sheet-like HUD that

--- a/TAELMacAgent/TAELMacAgent/HUD/HUDPanelController.swift
+++ b/TAELMacAgent/TAELMacAgent/HUD/HUDPanelController.swift
@@ -27,6 +27,12 @@ final class HUDPanelController: NSObject, PermissionGatePresenting {
         presentNew(content: HUDView())
     }
 
+    func present(screenshot: CapturedScreenshot) {
+        // Task 7 fills this in. Stub so Task 6's AppDelegate wiring
+        // compiles in its own commit.
+        showPlaceholder()
+    }
+
     /// `PermissionGatePresenting` implementation: show a sheet-like HUD that
     /// explains the missing permission and links to System Settings.
     /// `nonisolated` so it satisfies the non-isolated protocol

--- a/TAELMacAgent/TAELMacAgent/HUD/HUDScreenshotView.swift
+++ b/TAELMacAgent/TAELMacAgent/HUD/HUDScreenshotView.swift
@@ -13,7 +13,7 @@ struct HUDScreenshotView: View {
 
     var body: some View {
         VStack(alignment: .leading, spacing: 8) {
-            Text("Captured \(screenshot.width)×\(screenshot.height) — \(targetLabel)")
+            Text("Captured \(screenshot.width)x\(screenshot.height) - \(targetLabel)")
                 .font(.caption)
                 .foregroundStyle(.secondary)
 

--- a/TAELMacAgent/TAELMacAgent/HUD/HUDScreenshotView.swift
+++ b/TAELMacAgent/TAELMacAgent/HUD/HUDScreenshotView.swift
@@ -2,9 +2,7 @@
 //  HUDScreenshotView.swift
 //  TAELMacAgent
 //
-//  Displays a CapturedScreenshot inside the HUD. PR 2: the shot is
-//  shown at a fixed maximum size so a full 5K display still fits in a
-//  reasonable HUD. Aspect ratio preserved.
+//  Caps screenshots at 720x480 so a full 5K display still fits in the HUD.
 //
 
 import SwiftUI

--- a/TAELMacAgent/TAELMacAgent/HUD/HUDScreenshotView.swift
+++ b/TAELMacAgent/TAELMacAgent/HUD/HUDScreenshotView.swift
@@ -1,0 +1,42 @@
+//
+//  HUDScreenshotView.swift
+//  TAELMacAgent
+//
+//  Displays a CapturedScreenshot inside the HUD. PR 2: the shot is
+//  shown at a fixed maximum size so a full 5K display still fits in a
+//  reasonable HUD. Aspect ratio preserved.
+//
+
+import SwiftUI
+import AppKit
+
+struct HUDScreenshotView: View {
+    let screenshot: CapturedScreenshot
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text("Captured \(screenshot.width)×\(screenshot.height) — \(targetLabel)")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+
+            Image(decorative: screenshot.image, scale: 1.0, orientation: .up)
+                .resizable()
+                .aspectRatio(contentMode: .fit)
+                .frame(maxWidth: 720, maxHeight: 480)
+                .background(Color.black.opacity(0.3))
+                .cornerRadius(6)
+
+            Text(screenshot.capturedAt.formatted(date: .omitted, time: .standard))
+                .font(.caption2)
+                .foregroundStyle(.tertiary)
+        }
+        .padding(16)
+    }
+
+    private var targetLabel: String {
+        switch screenshot.target {
+        case .displayContainingCursor: return "cursor display"
+        case .mainDisplay: return "main display (fallback)"
+        }
+    }
+}

--- a/TAELMacAgent/TAELMacAgent/HUD/PermissionGateView.swift
+++ b/TAELMacAgent/TAELMacAgent/HUD/PermissionGateView.swift
@@ -51,7 +51,7 @@ struct PermissionGateView: View {
         case .screenRecording:
             return "Used to capture the display containing the cursor when you invoke TAEL. Screenshots are not saved to disk."
         case .accessibility:
-            return "Used to read the focused window's UI tree (title, role, content text) so TAEL can scope context to what you're looking at. Read-only — TAEL does not synthesize keyboard or mouse events."
+            return "Used to read the focused window's UI tree (title, role, content text) so TAEL can scope context to what you're looking at. Read-only: TAEL does not synthesize keyboard or mouse events."
         case .microphone:
             return "Used to capture your voice for the active invocation. Not yet implemented."
         case .appleEvents:

--- a/TAELMacAgent/TAELMacAgent/HUD/PermissionGateView.swift
+++ b/TAELMacAgent/TAELMacAgent/HUD/PermissionGateView.swift
@@ -51,7 +51,7 @@ struct PermissionGateView: View {
         case .screenRecording:
             return "Used to capture the display containing the cursor when you invoke TAEL. Screenshots are not saved to disk."
         case .accessibility:
-            return "Used to read the focused window's UI tree. Not yet implemented."
+            return "Used to read the focused window's UI tree (title, role, content text) so TAEL can scope context to what you're looking at. Read-only — TAEL does not synthesize keyboard or mouse events."
         case .microphone:
             return "Used to capture your voice for the active invocation. Not yet implemented."
         case .appleEvents:

--- a/TAELMacAgent/TAELMacAgent/Hotkey/HotkeyManager.swift
+++ b/TAELMacAgent/TAELMacAgent/Hotkey/HotkeyManager.swift
@@ -24,14 +24,6 @@ final class HotkeyManager {
         }
     }
 
-    /// Backwards-compatible alias for the PR 1 call site. Removed in
-    /// the same commit that updates `AppDelegate` to call
-    /// `installBinding()` directly (Task 6).
-    @available(*, deprecated, renamed: "installBinding")
-    func installPlaceholderBinding() {
-        installBinding()
-    }
-
     func tearDown() {
         KeyboardShortcuts.disable(.toggleTAEL)
         onTrigger = nil

--- a/TAELMacAgent/TAELMacAgent/Hotkey/HotkeyManager.swift
+++ b/TAELMacAgent/TAELMacAgent/Hotkey/HotkeyManager.swift
@@ -2,36 +2,38 @@
 //  HotkeyManager.swift
 //  TAELMacAgent
 //
-//  Global hotkey owner. PR 1 contains only a placeholder binding hook
-//  (no real registration), so the app can launch without pulling in a
-//  third-party package and without calling any protected API.
-//
-//  PR 2 (Week 1 ticket 6) adds the `KeyboardShortcuts` SPM package and
-//  registers a real shortcut that calls `onTrigger`.
+//  Owns the global hotkey registration via the KeyboardShortcuts
+//  package. The actual work (gate → capture → HUD) is the closure
+//  assigned to `onTrigger` by `AppDelegate`.
 //
 
 import Foundation
+import KeyboardShortcuts
 
 @MainActor
 final class HotkeyManager {
-    /// Set by the wiring code in `AppDelegate` once the gate, capture
-    /// service, and HUD exist. PR 1 leaves this nil-by-default; PR 2
-    /// will assign a closure that runs:
-    ///
-    ///     try await permissionsGate.withPermission(.screenRecording) { grant in
-    ///         let shot = try await screenCaptureService
-    ///             .captureDisplayScreenshot(grant)
-    ///         hudController.present(shot)
-    ///     }
+    /// Set by `AppDelegate` to the gate→capture→HUD closure.
+    /// Read inside the KeyboardShortcuts callback.
     var onTrigger: (() -> Void)?
 
-    /// PR 1 no-op binding. Exists so the call site in `AppDelegate`
-    /// can be wired now and the PR 2 change is purely additive.
+    /// Registers the real global hotkey with KeyboardShortcuts.
+    /// Call once during `applicationDidFinishLaunching`.
+    func installBinding() {
+        KeyboardShortcuts.onKeyDown(for: .toggleTAEL) { [weak self] in
+            self?.onTrigger?()
+        }
+    }
+
+    /// Backwards-compatible alias for the PR 1 call site. Removed in
+    /// the same commit that updates `AppDelegate` to call
+    /// `installBinding()` directly (Task 6).
+    @available(*, deprecated, renamed: "installBinding")
     func installPlaceholderBinding() {
-        // Intentionally empty.
+        installBinding()
     }
 
     func tearDown() {
+        KeyboardShortcuts.disable(.toggleTAEL)
         onTrigger = nil
     }
 }

--- a/TAELMacAgent/TAELMacAgent/Hotkey/HotkeyManager.swift
+++ b/TAELMacAgent/TAELMacAgent/Hotkey/HotkeyManager.swift
@@ -12,20 +12,41 @@ import KeyboardShortcuts
 
 @MainActor
 final class HotkeyManager {
-    /// Set by `AppDelegate` to the gate→capture→HUD closure.
-    /// Read inside the KeyboardShortcuts callback.
-    var onTrigger: (() -> Void)?
+    /// Set by `AppDelegate` to the gate→capture→HUD pipeline. Async so
+    /// the manager can await it and clear the in-flight guard only
+    /// after the full invocation completes — so re-entrant presses
+    /// during a slow capture get dropped instead of stacking.
+    var onTrigger: (() async -> Void)?
+
+    private var isInFlight = false
 
     /// Registers the real global hotkey with KeyboardShortcuts.
     /// Call once during `applicationDidFinishLaunching`.
     func installBinding() {
         KeyboardShortcuts.onKeyDown(for: .toggleTAEL) { [weak self] in
-            self?.onTrigger?()
+            self?.fireIfFree()
+        }
+    }
+
+    private func fireIfFree() {
+        guard !isInFlight else { return }
+        guard let onTrigger else { return }
+        isInFlight = true
+        Task { @MainActor [weak self] in
+            await onTrigger()
+            self?.isInFlight = false
         }
     }
 
     func tearDown() {
         KeyboardShortcuts.disable(.toggleTAEL)
         onTrigger = nil
+        isInFlight = false
+    }
+
+    /// Test-only entry: simulates a hotkey press without going through
+    /// the KeyboardShortcuts package. Exposed via @testable import.
+    func simulatePressForTesting() {
+        fireIfFree()
     }
 }

--- a/TAELMacAgent/TAELMacAgent/Hotkey/HotkeyName.swift
+++ b/TAELMacAgent/TAELMacAgent/Hotkey/HotkeyName.swift
@@ -3,15 +3,13 @@
 //  TAELMacAgent
 //
 //  Declares the global hotkey name used by KeyboardShortcuts.
-//  Default chord: ⌘⇧T ("T" for TAEL). User can rebind via Settings
-//  later (post-PR 2).
+//  Default chord: ⌘⇧T ("T" for TAEL). User-rebindable when Settings ships.
 //
 
 import KeyboardShortcuts
 
 extension KeyboardShortcuts.Name {
-    /// Primary "summon TAEL" hotkey. v0.3 §1: this triggers the full
-    /// hotkey → gate → capture → HUD pipeline.
+    /// Primary "summon TAEL" hotkey (v0.3 §1).
     static let toggleTAEL = Self(
         "toggleTAEL",
         default: .init(.t, modifiers: [.command, .shift])

--- a/TAELMacAgent/TAELMacAgent/Hotkey/HotkeyName.swift
+++ b/TAELMacAgent/TAELMacAgent/Hotkey/HotkeyName.swift
@@ -1,0 +1,19 @@
+//
+//  HotkeyName.swift
+//  TAELMacAgent
+//
+//  Declares the global hotkey name used by KeyboardShortcuts.
+//  Default chord: ⌘⇧T ("T" for TAEL). User can rebind via Settings
+//  later (post-PR 2).
+//
+
+import KeyboardShortcuts
+
+extension KeyboardShortcuts.Name {
+    /// Primary "summon TAEL" hotkey. v0.3 §1: this triggers the full
+    /// hotkey → gate → capture → HUD pipeline.
+    static let toggleTAEL = Self(
+        "toggleTAEL",
+        default: .init(.t, modifiers: [.command, .shift])
+    )
+}

--- a/TAELMacAgent/TAELMacAgent/Permissions/PermissionKind.swift
+++ b/TAELMacAgent/TAELMacAgent/Permissions/PermissionKind.swift
@@ -23,8 +23,8 @@ public enum PermissionKind: String, CaseIterable, Sendable, Hashable {
     /// kind in the current build. PR 1: only screen recording is real.
     public var isImplemented: Bool {
         switch self {
-        case .screenRecording: return true
-        case .accessibility, .microphone, .appleEvents, .inputMonitoring:
+        case .screenRecording, .accessibility: return true
+        case .microphone, .appleEvents, .inputMonitoring:
             return false
         }
     }

--- a/TAELMacAgent/TAELMacAgent/Permissions/PermissionsChecker.swift
+++ b/TAELMacAgent/TAELMacAgent/Permissions/PermissionsChecker.swift
@@ -6,9 +6,11 @@
 //  triggering a prompt. The actual prompt is the user's job (via the
 //  permission gate sheet → "Open System Settings" → real grant).
 //
-//  PR 1: Screen Recording is implemented for real. The other kinds
-//  return `.notDetermined` so the gate can still be exercised by tests
-//  without making system calls.
+//  PR 1: Screen Recording is implemented for real.
+//  PR 4: Accessibility is implemented for real.
+//  Microphone, Apple Events, and Input Monitoring still return
+//  `.notDetermined` so the gate can be exercised by tests without
+//  making system calls until their milestones land.
 //
 //  See docs/ProtectedAPICallPolicy.md and docs/PermissionNotes.md.
 //
@@ -16,6 +18,9 @@
 import Foundation
 #if canImport(CoreGraphics)
 import CoreGraphics
+#endif
+#if canImport(ApplicationServices)
+import ApplicationServices
 #endif
 
 public protocol PermissionChecking: Sendable {
@@ -29,7 +34,9 @@ public final class PermissionsChecker: PermissionChecking {
         switch kind {
         case .screenRecording:
             return screenRecordingStatus()
-        case .accessibility, .microphone, .appleEvents, .inputMonitoring:
+        case .accessibility:
+            return accessibilityStatus()
+        case .microphone, .appleEvents, .inputMonitoring:
             // Placeholder. Real checks land with their milestones.
             return .notDetermined
         }
@@ -53,6 +60,22 @@ public final class PermissionsChecker: PermissionChecking {
         // `true` even when ScreenCaptureKit later fails. PR 2 may add
         // an `SCShareableContent` sanity probe on top of preflight.
         return CGPreflightScreenCaptureAccess() ? .granted : .notDetermined
+        #else
+        return .notDetermined
+        #endif
+    }
+
+    // MARK: - Accessibility
+
+    private func accessibilityStatus() -> PermissionStatus {
+        #if os(macOS)
+        // AXIsProcessTrusted reads the current trust state without
+        // prompting. The prompting variant
+        // AXIsProcessTrustedWithOptions([kAXTrustedCheckOptionPrompt: true])
+        // is intentionally NOT used — the gate UI owns the prompt path so
+        // the user always lands in the same flow regardless of which TCC
+        // surface is missing.
+        return AXIsProcessTrusted() ? .granted : .notDetermined
         #else
         return .notDetermined
         #endif

--- a/TAELMacAgent/TAELMacAgent/Permissions/PermissionsGate.swift
+++ b/TAELMacAgent/TAELMacAgent/Permissions/PermissionsGate.swift
@@ -79,6 +79,7 @@ public final class PermissionsGate: Sendable {
     @discardableResult
     public func withPermission<T>(
         _ kind: PermissionKind,
+        showMissingUI: Bool = true,
         operation: (PermissionGrant) async throws -> T
     ) async throws -> T {
         // Unimplemented kinds short-circuit before the checker. Showing
@@ -92,7 +93,9 @@ public final class PermissionsGate: Sendable {
         let status = await checker.status(for: kind)
 
         guard status == .granted else {
-            await permissionUI.showGate(for: kind)
+            if showMissingUI {
+                await permissionUI.showGate(for: kind)
+            }
             throw PermissionError.missing(kind)
         }
 

--- a/TAELMacAgent/TAELMacAgentTests/ContextBundleTests.swift
+++ b/TAELMacAgent/TAELMacAgentTests/ContextBundleTests.swift
@@ -1,0 +1,59 @@
+//
+//  ContextBundleTests.swift
+//  TAELMacAgentTests
+//
+
+import CoreGraphics
+import XCTest
+@testable import TAELMacAgent
+
+final class ContextBundleTests: XCTestCase {
+    func test_focusedWindowMetadata_hasAnyDataReflectsOptionalFields() {
+        let empty = FocusedWindowMetadata(
+            bundleIdentifier: nil,
+            applicationName: nil,
+            windowTitle: nil,
+            windowRole: nil
+        )
+        XCTAssertFalse(empty.hasAnyData)
+
+        let populated = FocusedWindowMetadata(
+            bundleIdentifier: "com.example.App",
+            applicationName: nil,
+            windowTitle: nil,
+            windowRole: nil
+        )
+        XCTAssertTrue(populated.hasAnyData)
+    }
+
+    func test_contextBundle_logTargetDescriptionCombinesScreenshotAndFocusedWindow() throws {
+        let screenshot = makeStubScreenshot()
+        let window = FocusedWindowMetadata(
+            bundleIdentifier: "com.example.Terminal",
+            applicationName: "Terminal",
+            windowTitle: "tael-ai",
+            windowRole: "AXWindow"
+        )
+
+        let bundle = ContextBundle(screenshot: screenshot, focusedWindow: window)
+
+        let description = try XCTUnwrap(bundle.logTargetDescription)
+        XCTAssertTrue(description.contains("displayContainingCursor 1x1"))
+        XCTAssertTrue(description.contains("Terminal: tael-ai"))
+    }
+
+    private func makeStubScreenshot() -> CapturedScreenshot {
+        let cs = CGColorSpaceCreateDeviceRGB()
+        let ctx = CGContext(
+            data: nil,
+            width: 1,
+            height: 1,
+            bitsPerComponent: 8,
+            bytesPerRow: 4,
+            space: cs,
+            bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue
+        )!
+        let image = ctx.makeImage()!
+        return CapturedScreenshot(image: image, target: .displayContainingCursor)
+    }
+}

--- a/TAELMacAgent/TAELMacAgentTests/HotkeyHandlerTests.swift
+++ b/TAELMacAgent/TAELMacAgentTests/HotkeyHandlerTests.swift
@@ -85,10 +85,12 @@ final class HotkeyHandlerTests: XCTestCase {
         ])
 
         var presented: [CapturedScreenshot] = []
+        var presentedErrors: [String] = []
         let handler = HotkeyInvocationHandler(
             permissionsGate: gate,
             screenCaptureService: capture,
             presentScreenshot: { presented.append($0) },
+            presentError: { presentedErrors.append($0) },
             logService: logService,
             now: { clock.next() }
         )
@@ -98,6 +100,7 @@ final class HotkeyHandlerTests: XCTestCase {
         let targets = await capture.observedTargets()
         XCTAssertEqual(targets, [.week1Default])
         XCTAssertEqual(presented.count, 1)
+        XCTAssertTrue(presentedErrors.isEmpty, "Granted path must not present an error HUD")
 
         let logs = await logService.recent(10)
         XCTAssertEqual(logs.count, 1)
@@ -162,10 +165,12 @@ final class HotkeyHandlerTests: XCTestCase {
         ])
 
         var presented: [CapturedScreenshot] = []
+        var presentedErrors: [String] = []
         let handler = HotkeyInvocationHandler(
             permissionsGate: gate,
             screenCaptureService: capture,
             presentScreenshot: { presented.append($0) },
+            presentError: { presentedErrors.append($0) },
             logService: logService,
             now: { clock.next() }
         )
@@ -173,6 +178,10 @@ final class HotkeyHandlerTests: XCTestCase {
         await handler.run()
 
         XCTAssertTrue(presented.isEmpty)
+        XCTAssertEqual(presentedErrors.count, 1)
+        let msg = try XCTUnwrap(presentedErrors.first)
+        XCTAssertTrue(msg.contains("Screen capture failed"),
+            "Error HUD message should lead with the user-facing prefix")
         let logs = await logService.recent(10)
         XCTAssertEqual(logs.count, 1)
         let row = try XCTUnwrap(logs.first)

--- a/TAELMacAgent/TAELMacAgentTests/HotkeyHandlerTests.swift
+++ b/TAELMacAgent/TAELMacAgentTests/HotkeyHandlerTests.swift
@@ -144,4 +144,43 @@ final class HotkeyHandlerTests: XCTestCase {
         XCTAssertNotNil(logs.first?.gateLatencyMs)
         XCTAssertEqual(logs.first?.errorDescription, "captureFailed(\"simulated\")")
     }
+
+    // MARK: - Not-implemented kind
+
+    func test_run_whenKindNotImplemented_doesNotCapture_logsRestricted() async {
+        // Use a kind whose isImplemented returns false today (Week 1
+        // implements only .screenRecording). The gate throws .notImplemented
+        // before any capture work runs.
+        let checker = StubChecker(.granted)
+        let ui = SpyUI()
+        let gate = PermissionsGate(checker: checker, permissionUI: ui)
+        let capture = SpyCapture(stub: makeStubScreenshot())
+        let logService = LocalLogService(capacity: 16)
+
+        var presented: [CapturedScreenshot] = []
+        let handler = HotkeyInvocationHandler(
+            permissionsGate: gate,
+            screenCaptureService: capture,
+            presentScreenshot: { presented.append($0) },
+            logService: logService,
+            kind: .accessibility
+        )
+
+        await handler.run()
+
+        let observed = await capture.observedTargets()
+        XCTAssertTrue(observed.isEmpty, "Capture must not run when kind is unimplemented")
+        XCTAssertTrue(presented.isEmpty)
+
+        let logs = await logService.recent(10)
+        XCTAssertEqual(logs.count, 1)
+        XCTAssertEqual(logs.first?.gateOutcome, .restricted)
+        XCTAssertNil(logs.first?.gateLatencyMs, "gate didn't grant; latency must stay nil")
+        XCTAssertNotNil(logs.first?.errorDescription)
+
+        // The gate does NOT show UI for .notImplemented (per the existing
+        // PermissionsGateTests contract: not-implemented is silent).
+        let shown = await ui.shownKinds
+        XCTAssertTrue(shown.isEmpty)
+    }
 }

--- a/TAELMacAgent/TAELMacAgentTests/HotkeyHandlerTests.swift
+++ b/TAELMacAgent/TAELMacAgentTests/HotkeyHandlerTests.swift
@@ -44,12 +44,43 @@ final class HotkeyHandlerTests: XCTestCase {
         }
     }
 
+    @MainActor
+    private final class SpyFocusedWindowReader: FocusedWindowReading {
+        var thrownError: Error?
+        var callCount = 0
+        var stubMetadata: FocusedWindowMetadata
+
+        init(stub: FocusedWindowMetadata) {
+            self.stubMetadata = stub
+        }
+
+        func setError(_ error: Error?) { self.thrownError = error }
+        func observedCallCount() -> Int { callCount }
+
+        func captureFocusedWindowMetadata(_ grant: PermissionGrant) async throws -> FocusedWindowMetadata {
+            precondition(grant.kind == .accessibility)
+            callCount += 1
+            if let thrownError { throw thrownError }
+            return stubMetadata
+        }
+    }
+
     /// Builds a 1x1 transparent CGImage for tests; no real capture.
     private func makeStubScreenshot() -> CapturedScreenshot {
         let cs = CGColorSpaceCreateDeviceRGB()
         let ctx = CGContext(data: nil, width: 1, height: 1, bitsPerComponent: 8, bytesPerRow: 4, space: cs, bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue)!
         let image = ctx.makeImage()!
         return CapturedScreenshot(image: image, target: .displayContainingCursor)
+    }
+
+    private func makeStubFocusedWindow() -> FocusedWindowMetadata {
+        FocusedWindowMetadata(
+            bundleIdentifier: "com.example.Terminal",
+            applicationName: "Terminal",
+            windowTitle: "tael-ai",
+            windowRole: "AXWindow",
+            capturedAt: Date(timeIntervalSince1970: 10)
+        )
     }
 
     /// Pops dates from a fixed sequence each time it's read. The handler
@@ -110,6 +141,77 @@ final class HotkeyHandlerTests: XCTestCase {
             "gate took 100ms (0 → 0.1 second), value must be ms not seconds")
         XCTAssertEqual(row.captureLatencyMs ?? -1, 200, accuracy: 0.001,
             "capture took 200ms (0.1 → 0.3 second)")
+    }
+
+    func test_run_whenGrantedAndAccessibilityGranted_presentsContextBundle() async throws {
+        let checker = StubChecker(.granted)
+        let ui = SpyUI()
+        let gate = PermissionsGate(checker: checker, permissionUI: ui)
+        let capture = SpyCapture(stub: makeStubScreenshot())
+        let focusedWindowReader = SpyFocusedWindowReader(stub: makeStubFocusedWindow())
+        let logService = LocalLogService(capacity: 16)
+        let clock = StubClock([
+            Date(timeIntervalSince1970: 0),
+            Date(timeIntervalSince1970: 0.1),
+            Date(timeIntervalSince1970: 0.3),
+        ])
+
+        var presentedScreenshots: [CapturedScreenshot] = []
+        var presentedContexts: [ContextBundle] = []
+        let handler = HotkeyInvocationHandler(
+            permissionsGate: gate,
+            screenCaptureService: capture,
+            focusedWindowReader: focusedWindowReader,
+            presentScreenshot: { presentedScreenshots.append($0) },
+            presentContext: { presentedContexts.append($0) },
+            logService: logService,
+            now: { clock.next() }
+        )
+
+        await handler.run()
+
+        XCTAssertTrue(presentedScreenshots.isEmpty)
+        XCTAssertEqual(presentedContexts.count, 1)
+        let bundle = try XCTUnwrap(presentedContexts.first)
+        XCTAssertNotNil(bundle.screenshot)
+        XCTAssertEqual(bundle.focusedWindow?.applicationName, "Terminal")
+        XCTAssertEqual(bundle.focusedWindow?.windowTitle, "tael-ai")
+
+        let logs = await logService.recent(10)
+        let row = try XCTUnwrap(logs.first)
+        XCTAssertEqual(row.gateOutcome, .granted)
+        XCTAssertTrue(row.targetDescription?.contains("Terminal: tael-ai") == true)
+    }
+
+    func test_run_whenAccessibilityMissing_stillPresentsScreenshotContextWithoutShowingAXGate() async throws {
+        let ui = SpyUI()
+        let capture = SpyCapture(stub: makeStubScreenshot())
+        let focusedWindowReader = SpyFocusedWindowReader(stub: makeStubFocusedWindow())
+        let logService = LocalLogService(capacity: 16)
+
+        var presentedContexts: [ContextBundle] = []
+        let handler = HotkeyInvocationHandler(
+            permissionsGate: PermissionsGate(
+                checker: SplitChecker(screenRecording: .granted, accessibility: .notDetermined),
+                permissionUI: ui
+            ),
+            screenCaptureService: capture,
+            focusedWindowReader: focusedWindowReader,
+            presentScreenshot: { _ in },
+            presentContext: { presentedContexts.append($0) },
+            logService: logService
+        )
+
+        await handler.run()
+
+        XCTAssertEqual(presentedContexts.count, 1)
+        XCTAssertNotNil(presentedContexts.first?.screenshot)
+        XCTAssertNil(presentedContexts.first?.focusedWindow)
+        let focusedWindowCallCount = focusedWindowReader.observedCallCount()
+        XCTAssertEqual(focusedWindowCallCount, 0)
+
+        let shown = await ui.shownKinds
+        XCTAssertTrue(shown.isEmpty, "Optional AX metadata must not show the permission gate")
     }
 
     // MARK: - Denied path
@@ -229,5 +331,26 @@ final class HotkeyHandlerTests: XCTestCase {
         // PermissionsGateTests contract: not-implemented is silent).
         let shown = await ui.shownKinds
         XCTAssertTrue(shown.isEmpty)
+    }
+}
+
+private actor SplitChecker: PermissionChecking {
+    private let screenRecording: PermissionStatus
+    private let accessibility: PermissionStatus
+
+    init(screenRecording: PermissionStatus, accessibility: PermissionStatus) {
+        self.screenRecording = screenRecording
+        self.accessibility = accessibility
+    }
+
+    func status(for kind: PermissionKind) async -> PermissionStatus {
+        switch kind {
+        case .screenRecording:
+            return screenRecording
+        case .accessibility:
+            return accessibility
+        case .microphone, .appleEvents, .inputMonitoring:
+            return .notDetermined
+        }
     }
 }

--- a/TAELMacAgent/TAELMacAgentTests/HotkeyHandlerTests.swift
+++ b/TAELMacAgent/TAELMacAgentTests/HotkeyHandlerTests.swift
@@ -1,0 +1,145 @@
+//
+//  HotkeyHandlerTests.swift
+//  TAELMacAgentTests
+//
+
+import XCTest
+@testable import TAELMacAgent
+import CoreGraphics
+
+@MainActor
+final class HotkeyHandlerTests: XCTestCase {
+
+    // MARK: - Test doubles
+
+    private actor StubChecker: PermissionChecking {
+        private let status: PermissionStatus
+        init(_ status: PermissionStatus) { self.status = status }
+        func status(for kind: PermissionKind) async -> PermissionStatus { status }
+    }
+
+    private actor SpyUI: PermissionGatePresenting {
+        private(set) var shownKinds: [PermissionKind] = []
+        func showGate(for kind: PermissionKind) async { shownKinds.append(kind) }
+    }
+
+    private actor SpyCapture: DisplayScreenshotCapturing {
+        var thrownError: Error?
+        var capturedTargets: [ScreenshotTarget] = []
+        var stubScreenshot: CapturedScreenshot
+
+        init(stub: CapturedScreenshot) { self.stubScreenshot = stub }
+
+        func setError(_ error: Error?) { self.thrownError = error }
+        func observedTargets() -> [ScreenshotTarget] { capturedTargets }
+
+        func captureDisplayScreenshot(
+            _ grant: PermissionGrant,
+            target: ScreenshotTarget
+        ) async throws -> CapturedScreenshot {
+            precondition(grant.kind == .screenRecording)
+            capturedTargets.append(target)
+            if let thrownError { throw thrownError }
+            return stubScreenshot
+        }
+    }
+
+    /// Builds a 1x1 transparent CGImage for tests; no real capture.
+    private func makeStubScreenshot() -> CapturedScreenshot {
+        let cs = CGColorSpaceCreateDeviceRGB()
+        let ctx = CGContext(data: nil, width: 1, height: 1, bitsPerComponent: 8, bytesPerRow: 4, space: cs, bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue)!
+        let image = ctx.makeImage()!
+        return CapturedScreenshot(image: image, target: .displayContainingCursor)
+    }
+
+    // MARK: - Granted path
+
+    func test_run_whenGranted_callsCaptureAndPresentsAndLogsGranted() async {
+        let checker = StubChecker(.granted)
+        let ui = SpyUI()
+        let gate = PermissionsGate(checker: checker, permissionUI: ui)
+        let capture = SpyCapture(stub: makeStubScreenshot())
+        let logService = LocalLogService(capacity: 16)
+
+        var presented: [CapturedScreenshot] = []
+        let handler = HotkeyInvocationHandler(
+            permissionsGate: gate,
+            screenCaptureService: capture,
+            presentScreenshot: { presented.append($0) },
+            logService: logService
+        )
+
+        await handler.run()
+
+        let targets = await capture.observedTargets()
+        XCTAssertEqual(targets, [.week1Default])
+        XCTAssertEqual(presented.count, 1)
+
+        let logs = await logService.recent(10)
+        XCTAssertEqual(logs.count, 1)
+        XCTAssertEqual(logs.first?.gateOutcome, .granted)
+        XCTAssertNotNil(logs.first?.gateLatencyMs)
+        XCTAssertNotNil(logs.first?.captureLatencyMs)
+    }
+
+    // MARK: - Denied path
+
+    func test_run_whenDenied_doesNotCapture_doesNotPresent_logsDenied() async {
+        let checker = StubChecker(.denied)
+        let ui = SpyUI()
+        let gate = PermissionsGate(checker: checker, permissionUI: ui)
+        let capture = SpyCapture(stub: makeStubScreenshot())
+        let logService = LocalLogService(capacity: 16)
+
+        var presented: [CapturedScreenshot] = []
+        let handler = HotkeyInvocationHandler(
+            permissionsGate: gate,
+            screenCaptureService: capture,
+            presentScreenshot: { presented.append($0) },
+            logService: logService
+        )
+
+        await handler.run()
+
+        let targets = await capture.observedTargets()
+        XCTAssertTrue(targets.isEmpty)
+        XCTAssertTrue(presented.isEmpty)
+
+        let logs = await logService.recent(10)
+        XCTAssertEqual(logs.count, 1)
+        XCTAssertEqual(logs.first?.gateOutcome, .denied)
+        XCTAssertNotNil(logs.first?.errorDescription)
+
+        // The gate still surfaces the UI on missing permission.
+        let shown = await ui.shownKinds
+        XCTAssertEqual(shown, [.screenRecording])
+    }
+
+    // MARK: - Capture failure path
+
+    func test_run_whenCaptureFails_logsErroredOutcome() async {
+        let checker = StubChecker(.granted)
+        let ui = SpyUI()
+        let gate = PermissionsGate(checker: checker, permissionUI: ui)
+        let capture = SpyCapture(stub: makeStubScreenshot())
+        await capture.setError(ScreenCaptureError.captureFailed("simulated"))
+
+        let logService = LocalLogService(capacity: 16)
+
+        var presented: [CapturedScreenshot] = []
+        let handler = HotkeyInvocationHandler(
+            permissionsGate: gate,
+            screenCaptureService: capture,
+            presentScreenshot: { presented.append($0) },
+            logService: logService
+        )
+
+        await handler.run()
+
+        XCTAssertTrue(presented.isEmpty)
+        let logs = await logService.recent(10)
+        XCTAssertEqual(logs.count, 1)
+        XCTAssertEqual(logs.first?.gateOutcome, .errored)
+        XCTAssertEqual(logs.first?.errorDescription, "captureFailed(\"simulated\")")
+    }
+}

--- a/TAELMacAgent/TAELMacAgentTests/HotkeyHandlerTests.swift
+++ b/TAELMacAgent/TAELMacAgentTests/HotkeyHandlerTests.swift
@@ -52,21 +52,45 @@ final class HotkeyHandlerTests: XCTestCase {
         return CapturedScreenshot(image: image, target: .displayContainingCursor)
     }
 
+    /// Pops dates from a fixed sequence each time it's read. The handler
+    /// reads `now()` exactly three times on the granted path (started, then once
+    /// inside the closure for gateEnd which also serves as captureStart,
+    /// then once for captureEnd). Built as a class so the closure-captured
+    /// state survives across reads.
+    private final class StubClock: @unchecked Sendable {
+        private var ticks: [Date]
+        init(_ ticks: [Date]) { self.ticks = ticks }
+        func next() -> Date {
+            precondition(!ticks.isEmpty, "StubClock ran out of ticks")
+            return ticks.removeFirst()
+        }
+    }
+
     // MARK: - Granted path
 
-    func test_run_whenGranted_callsCaptureAndPresentsAndLogsGranted() async {
+    func test_run_whenGranted_callsCaptureAndPresentsAndLogsGranted() async throws {
         let checker = StubChecker(.granted)
         let ui = SpyUI()
         let gate = PermissionsGate(checker: checker, permissionUI: ui)
         let capture = SpyCapture(stub: makeStubScreenshot())
         let logService = LocalLogService(capacity: 16)
 
+        // Pin exact latencies: started=0, gateEnd=0.1 (100ms gate),
+        // captureEnd=0.3 (200ms capture). The handler reads now() three
+        // times on the granted path: started, gateEnd, captureEnd.
+        let clock = StubClock([
+            Date(timeIntervalSince1970: 0),
+            Date(timeIntervalSince1970: 0.1),
+            Date(timeIntervalSince1970: 0.3),
+        ])
+
         var presented: [CapturedScreenshot] = []
         let handler = HotkeyInvocationHandler(
             permissionsGate: gate,
             screenCaptureService: capture,
             presentScreenshot: { presented.append($0) },
-            logService: logService
+            logService: logService,
+            now: { clock.next() }
         )
 
         await handler.run()
@@ -77,9 +101,12 @@ final class HotkeyHandlerTests: XCTestCase {
 
         let logs = await logService.recent(10)
         XCTAssertEqual(logs.count, 1)
-        XCTAssertEqual(logs.first?.gateOutcome, .granted)
-        XCTAssertNotNil(logs.first?.gateLatencyMs)
-        XCTAssertNotNil(logs.first?.captureLatencyMs)
+        let row = try XCTUnwrap(logs.first)
+        XCTAssertEqual(row.gateOutcome, .granted)
+        XCTAssertEqual(row.gateLatencyMs ?? -1, 100, accuracy: 0.001,
+            "gate took 100ms (0 → 0.1 second), value must be ms not seconds")
+        XCTAssertEqual(row.captureLatencyMs ?? -1, 200, accuracy: 0.001,
+            "capture took 200ms (0.1 → 0.3 second)")
     }
 
     // MARK: - Denied path
@@ -118,7 +145,7 @@ final class HotkeyHandlerTests: XCTestCase {
 
     // MARK: - Capture failure path
 
-    func test_run_whenCaptureFails_logsErroredOutcome() async {
+    func test_run_whenCaptureFails_logsErroredOutcome() async throws {
         let checker = StubChecker(.granted)
         let ui = SpyUI()
         let gate = PermissionsGate(checker: checker, permissionUI: ui)
@@ -127,12 +154,20 @@ final class HotkeyHandlerTests: XCTestCase {
 
         let logService = LocalLogService(capacity: 16)
 
+        // started=0, gateEnd=0.05 (50ms). Capture fails immediately after
+        // the gate grants, so only two ticks are needed.
+        let clock = StubClock([
+            Date(timeIntervalSince1970: 0),
+            Date(timeIntervalSince1970: 0.05),
+        ])
+
         var presented: [CapturedScreenshot] = []
         let handler = HotkeyInvocationHandler(
             permissionsGate: gate,
             screenCaptureService: capture,
             presentScreenshot: { presented.append($0) },
-            logService: logService
+            logService: logService,
+            now: { clock.next() }
         )
 
         await handler.run()
@@ -140,9 +175,11 @@ final class HotkeyHandlerTests: XCTestCase {
         XCTAssertTrue(presented.isEmpty)
         let logs = await logService.recent(10)
         XCTAssertEqual(logs.count, 1)
-        XCTAssertEqual(logs.first?.gateOutcome, .errored)
-        XCTAssertNotNil(logs.first?.gateLatencyMs)
-        XCTAssertEqual(logs.first?.errorDescription, "captureFailed(\"simulated\")")
+        let row = try XCTUnwrap(logs.first)
+        XCTAssertEqual(row.gateOutcome, .errored)
+        XCTAssertEqual(row.errorDescription, "captureFailed(\"simulated\")")
+        XCTAssertEqual(row.gateLatencyMs ?? -1, 50, accuracy: 0.001,
+            "gate granted in 50ms before capture threw; latency must be retained")
     }
 
     // MARK: - Not-implemented kind

--- a/TAELMacAgent/TAELMacAgentTests/HotkeyHandlerTests.swift
+++ b/TAELMacAgent/TAELMacAgentTests/HotkeyHandlerTests.swift
@@ -129,7 +129,7 @@ final class HotkeyHandlerTests: XCTestCase {
         await handler.run()
 
         let targets = await capture.observedTargets()
-        XCTAssertEqual(targets, [.week1Default])
+        XCTAssertEqual(targets, [.defaultTarget])
         XCTAssertEqual(presented.count, 1)
         XCTAssertTrue(presentedErrors.isEmpty, "Granted path must not present an error HUD")
 

--- a/TAELMacAgent/TAELMacAgentTests/HotkeyHandlerTests.swift
+++ b/TAELMacAgent/TAELMacAgentTests/HotkeyHandlerTests.swift
@@ -293,6 +293,29 @@ final class HotkeyHandlerTests: XCTestCase {
             "gate granted in 50ms before capture threw; latency must be retained")
     }
 
+    // MARK: - User-facing error copy
+
+    func test_userFacingMessage_mapsKnownScreenCaptureErrors() {
+        XCTAssertEqual(
+            HotkeyInvocationHandler.userFacingMessage(for: ScreenCaptureError.noDisplaysAvailable),
+            "Screen capture failed: no display is available right now."
+        )
+        XCTAssertEqual(
+            HotkeyInvocationHandler.userFacingMessage(for: ScreenCaptureError.captureFailed("anything")),
+            "Screen capture failed. Try again, or quit and relaunch TAEL."
+        )
+    }
+
+    func test_userFacingMessage_doesNotLeakUnknownErrorDescriptions() {
+        struct LeakyError: Error {
+            var localizedDescription: String { "/Users/secret/path was unreadable" }
+        }
+        let copy = HotkeyInvocationHandler.userFacingMessage(for: LeakyError())
+        XCTAssertEqual(copy, "Screen capture failed.")
+        XCTAssertFalse(copy.contains("/Users/secret/path"),
+            "Unknown error types must not surface localizedDescription to the user")
+    }
+
     // MARK: - Not-implemented kind
 
     func test_run_whenKindNotImplemented_doesNotCapture_logsRestricted() async {

--- a/TAELMacAgent/TAELMacAgentTests/HotkeyHandlerTests.swift
+++ b/TAELMacAgent/TAELMacAgentTests/HotkeyHandlerTests.swift
@@ -194,9 +194,10 @@ final class HotkeyHandlerTests: XCTestCase {
     // MARK: - Not-implemented kind
 
     func test_run_whenKindNotImplemented_doesNotCapture_logsRestricted() async {
-        // Use a kind whose isImplemented returns false today (Week 1
-        // implements only .screenRecording). The gate throws .notImplemented
-        // before any capture work runs.
+        // Use a kind whose isImplemented returns false today (Week 1 implements
+        // .screenRecording, PR 4 implements .accessibility; .microphone,
+        // .appleEvents, .inputMonitoring stay placeholders until their
+        // milestones).
         let checker = StubChecker(.granted)
         let ui = SpyUI()
         let gate = PermissionsGate(checker: checker, permissionUI: ui)
@@ -209,7 +210,7 @@ final class HotkeyHandlerTests: XCTestCase {
             screenCaptureService: capture,
             presentScreenshot: { presented.append($0) },
             logService: logService,
-            kind: .accessibility
+            kind: .microphone
         )
 
         await handler.run()

--- a/TAELMacAgent/TAELMacAgentTests/HotkeyHandlerTests.swift
+++ b/TAELMacAgent/TAELMacAgentTests/HotkeyHandlerTests.swift
@@ -108,6 +108,7 @@ final class HotkeyHandlerTests: XCTestCase {
         let logs = await logService.recent(10)
         XCTAssertEqual(logs.count, 1)
         XCTAssertEqual(logs.first?.gateOutcome, .denied)
+        XCTAssertNil(logs.first?.gateLatencyMs)
         XCTAssertNotNil(logs.first?.errorDescription)
 
         // The gate still surfaces the UI on missing permission.
@@ -140,6 +141,7 @@ final class HotkeyHandlerTests: XCTestCase {
         let logs = await logService.recent(10)
         XCTAssertEqual(logs.count, 1)
         XCTAssertEqual(logs.first?.gateOutcome, .errored)
+        XCTAssertNotNil(logs.first?.gateLatencyMs)
         XCTAssertEqual(logs.first?.errorDescription, "captureFailed(\"simulated\")")
     }
 }

--- a/TAELMacAgent/TAELMacAgentTests/HotkeyManagerTests.swift
+++ b/TAELMacAgent/TAELMacAgentTests/HotkeyManagerTests.swift
@@ -1,0 +1,62 @@
+//
+//  HotkeyManagerTests.swift
+//  TAELMacAgentTests
+//
+
+import XCTest
+@testable import TAELMacAgent
+
+@MainActor
+final class HotkeyManagerTests: XCTestCase {
+
+    func test_simulatePress_invokesTriggerOnce_evenIfFiredTwiceConcurrently() async {
+        let manager = HotkeyManager()
+        let counter = Counter()
+
+        manager.onTrigger = {
+            await counter.increment()
+            // Hold the in-flight gate open long enough for a second press
+            // to race in. Sleep yields the Task and lets the second
+            // simulatePress run while we're still flagged in-flight.
+            try? await Task.sleep(nanoseconds: 50_000_000) // 50ms
+        }
+
+        manager.simulatePressForTesting()
+        manager.simulatePressForTesting()
+
+        // Wait for the in-flight Task to complete.
+        try? await Task.sleep(nanoseconds: 100_000_000) // 100ms
+
+        let count = await counter.value
+        XCTAssertEqual(count, 1, "Re-entrant press during in-flight invocation must be dropped")
+    }
+
+    func test_simulatePress_afterPreviousCompletes_invokesTriggerAgain() async {
+        let manager = HotkeyManager()
+        let counter = Counter()
+
+        manager.onTrigger = {
+            await counter.increment()
+        }
+
+        manager.simulatePressForTesting()
+        try? await Task.sleep(nanoseconds: 20_000_000)
+        manager.simulatePressForTesting()
+        try? await Task.sleep(nanoseconds: 20_000_000)
+
+        let count = await counter.value
+        XCTAssertEqual(count, 2, "Sequential presses must each fire once")
+    }
+
+    func test_tearDown_clearsOnTrigger() {
+        let manager = HotkeyManager()
+        manager.onTrigger = { /* no-op */ }
+        manager.tearDown()
+        XCTAssertNil(manager.onTrigger)
+    }
+
+    private actor Counter {
+        private(set) var value = 0
+        func increment() { value += 1 }
+    }
+}

--- a/TAELMacAgent/TAELMacAgentTests/PermissionsCheckerTests.swift
+++ b/TAELMacAgent/TAELMacAgentTests/PermissionsCheckerTests.swift
@@ -1,0 +1,22 @@
+//
+//  PermissionsCheckerTests.swift
+//  TAELMacAgentTests
+//
+
+import XCTest
+@testable import TAELMacAgent
+
+@MainActor
+final class PermissionsCheckerTests: XCTestCase {
+
+    // MARK: - Accessibility
+
+    func test_status_forAccessibility_returnsGrantedOrNotDetermined() async {
+        let checker = PermissionsChecker()
+        let status = await checker.status(for: .accessibility)
+        XCTAssertTrue(
+            status == .granted || status == .notDetermined,
+            "Accessibility status must be either .granted or .notDetermined; got \(status). The checker must never return .denied or .restricted for AX since AXIsProcessTrusted only distinguishes trusted/not-trusted."
+        )
+    }
+}

--- a/TAELMacAgent/TAELMacAgentTests/PermissionsGateTests.swift
+++ b/TAELMacAgent/TAELMacAgentTests/PermissionsGateTests.swift
@@ -11,7 +11,7 @@
 //       `.granted`, and the closure receives a `PermissionGrant`
 //       whose `kind` matches the requested kind.
 //    3. The grant's `kind` cannot be forged from outside
-//       `PermissionsGate.swift` — `PermissionGrant` is declared in
+//       `PermissionsGate.swift`; `PermissionGrant` is declared in
 //       that same file with a `fileprivate init`, so even
 //       `@testable import` cannot reach the initializer from this
 //       test file. Verified at compile time: this test file does not
@@ -168,6 +168,6 @@ final class PermissionsGateTests: XCTestCase {
 
         XCTAssertFalse(operationRan, "Operation must not run for unimplemented kinds.")
         let shown = await ui.shownKinds
-        XCTAssertTrue(shown.isEmpty, "Gate UI must not appear for unimplemented kinds — there is nothing the user can grant.")
+        XCTAssertTrue(shown.isEmpty, "Gate UI must not appear for unimplemented kinds; there is nothing the user can grant.")
     }
 }

--- a/TAELMacAgent/TAELMacAgentTests/PermissionsGateTests.swift
+++ b/TAELMacAgent/TAELMacAgentTests/PermissionsGateTests.swift
@@ -99,6 +99,30 @@ final class PermissionsGateTests: XCTestCase {
         XCTAssertEqual(shown, [.screenRecording])
     }
 
+    func test_withPermission_whenMissingAndShowMissingUIFalse_throwsWithoutShowingGate() async {
+        let checker = StubChecker([.accessibility: .denied])
+        let ui = SpyUI()
+        let gate = PermissionsGate(checker: checker, permissionUI: ui)
+
+        var operationRan = false
+
+        do {
+            _ = try await gate.withPermission(.accessibility, showMissingUI: false) { _ in
+                operationRan = true
+                return ()
+            }
+            XCTFail("Expected PermissionError.missing to be thrown.")
+        } catch let error as PermissionError {
+            XCTAssertEqual(error, .missing(.accessibility))
+        } catch {
+            XCTFail("Unexpected error: \(error)")
+        }
+
+        XCTAssertFalse(operationRan)
+        let shown = await ui.shownKinds
+        XCTAssertTrue(shown.isEmpty, "Gate UI must not appear when showMissingUI is false.")
+    }
+
     // MARK: - Granted path
 
     func test_withPermission_whenGranted_runsOperationOnceWithMatchingGrantKind() async throws {

--- a/TAELMacAgent/TAELMacAgentTests/ResolveDisplayTests.swift
+++ b/TAELMacAgent/TAELMacAgentTests/ResolveDisplayTests.swift
@@ -1,0 +1,94 @@
+//
+//  ResolveDisplayTests.swift
+//  TAELMacAgentTests
+//
+//  Pins the v0.3 §23.2 cursor → main → first-available resolution
+//  rule. Uses plain structs as display candidates so the test does
+//  not need SCShareableContent or NSEvent.mouseLocation.
+//
+
+import XCTest
+import CoreGraphics
+@testable import TAELMacAgent
+
+final class ResolveDisplayTests: XCTestCase {
+    private struct StubDisplay: Equatable {
+        let id: CGDirectDisplayID
+        let label: String
+    }
+
+    private static let cursorID: CGDirectDisplayID = 100
+    private static let mainID: CGDirectDisplayID = 1
+    private static let otherID: CGDirectDisplayID = 200
+
+    private let cursor = StubDisplay(id: cursorID, label: "cursor")
+    private let main = StubDisplay(id: mainID, label: "main")
+    private let other = StubDisplay(id: otherID, label: "other")
+
+    private func resolve(
+        candidates: [StubDisplay],
+        cursorDisplayID: CGDirectDisplayID?,
+        requested: ScreenshotTarget = .displayContainingCursor
+    ) -> DisplayResolution<StubDisplay>? {
+        resolveDisplay(
+            candidates: candidates,
+            displayID: { $0.id },
+            cursorDisplayID: cursorDisplayID,
+            mainDisplayID: Self.mainID,
+            requested: requested
+        )
+    }
+
+    func test_returnsCursorDisplay_whenRequestedAndAvailable() throws {
+        let resolution = try XCTUnwrap(resolve(
+            candidates: [main, cursor, other],
+            cursorDisplayID: Self.cursorID
+        ))
+        XCTAssertEqual(resolution.display, cursor)
+        XCTAssertEqual(resolution.resolved, .displayContainingCursor)
+    }
+
+    func test_fallsBackToMain_whenCursorDisplayMissingFromCandidates() throws {
+        let resolution = try XCTUnwrap(resolve(
+            candidates: [main, other],
+            cursorDisplayID: Self.cursorID
+        ))
+        XCTAssertEqual(resolution.display, main)
+        XCTAssertEqual(resolution.resolved, .mainDisplay,
+            "When cursor display has been disconnected, the resolved target must report .mainDisplay so the HUD can label it as a fallback.")
+    }
+
+    func test_fallsBackToMain_whenCursorDisplayIDIsNil() throws {
+        let resolution = try XCTUnwrap(resolve(
+            candidates: [main, other],
+            cursorDisplayID: nil
+        ))
+        XCTAssertEqual(resolution.display, main)
+        XCTAssertEqual(resolution.resolved, .mainDisplay)
+    }
+
+    func test_fallsBackToFirstAvailable_whenMainAndCursorBothMissing() throws {
+        let resolution = try XCTUnwrap(resolve(
+            candidates: [other],
+            cursorDisplayID: Self.cursorID
+        ))
+        XCTAssertEqual(resolution.display, other)
+        XCTAssertEqual(resolution.resolved, .mainDisplay,
+            "Best-effort fallback still reports .mainDisplay; we never claim cursor when we did not actually find it.")
+    }
+
+    func test_returnsNil_whenNoCandidates() {
+        XCTAssertNil(resolve(candidates: [], cursorDisplayID: Self.cursorID))
+    }
+
+    func test_skipsCursorPath_whenRequestedIsMainDisplay() throws {
+        let resolution = try XCTUnwrap(resolve(
+            candidates: [main, cursor],
+            cursorDisplayID: Self.cursorID,
+            requested: .mainDisplay
+        ))
+        XCTAssertEqual(resolution.display, main,
+            "An explicit .mainDisplay request must not be silently upgraded to cursor even if the cursor display is in the candidate list.")
+        XCTAssertEqual(resolution.resolved, .mainDisplay)
+    }
+}

--- a/TAELMacAgent/project.yml
+++ b/TAELMacAgent/project.yml
@@ -21,8 +21,7 @@ settings:
     # compiler is documented separately in README.md.
     SWIFT_VERSION: "5.0"
     MACOSX_DEPLOYMENT_TARGET: "14.0"
-    # DEVELOPMENT_TEAM is intentionally blank. See TODO_FOR_OZZY.md.
-    DEVELOPMENT_TEAM: ""
+    DEVELOPMENT_TEAM: 4X8U3NCLQ8
     ALWAYS_SEARCH_USER_PATHS: NO
     ENABLE_HARDENED_RUNTIME: YES
     SWIFT_STRICT_CONCURRENCY: complete
@@ -52,6 +51,7 @@ targets:
         INFOPLIST_FILE: TAELMacAgent/Resources/Info.plist
         CODE_SIGN_ENTITLEMENTS: TAELMacAgent/Resources/TAELMacAgent.entitlements
         CODE_SIGN_STYLE: Automatic
+        "CODE_SIGN_IDENTITY[sdk=macosx*]": Apple Development
         ASSETCATALOG_COMPILER_APPICON_NAME: AppIcon
         ENABLE_USER_SCRIPT_SANDBOXING: YES
         GENERATE_INFOPLIST_FILE: NO
@@ -71,6 +71,9 @@ targets:
         PRODUCT_NAME: TAELMacAgentTests
         BUNDLE_LOADER: $(TEST_HOST)
         TEST_HOST: $(BUILT_PRODUCTS_DIR)/TAELMacAgent.app/Contents/MacOS/TAELMacAgent
+        CODE_SIGN_STYLE: Automatic
+        "CODE_SIGN_IDENTITY[sdk=macosx*]": Apple Development
+        GENERATE_INFOPLIST_FILE: YES
 
 schemes:
   TAELMacAgent:

--- a/TAELMacAgent/project.yml
+++ b/TAELMacAgent/project.yml
@@ -38,10 +38,6 @@ targets:
           - "Resources/TAELMacAgent.entitlements"
     resources:
       - path: TAELMacAgent/Resources/Assets.xcassets
-    info:
-      path: TAELMacAgent/Resources/Info.plist
-    entitlements:
-      path: TAELMacAgent/Resources/TAELMacAgent.entitlements
     settings:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: ai.tael.macagent

--- a/TAELMacAgent/project.yml
+++ b/TAELMacAgent/project.yml
@@ -8,6 +8,11 @@ options:
   generateEmptyDirectories: false
   defaultConfig: Debug
 
+packages:
+  KeyboardShortcuts:
+    url: https://github.com/sindresorhus/KeyboardShortcuts
+    from: "2.0.0"
+
 settings:
   base:
     # Swift language *mode* (not toolchain version). Xcode's
@@ -31,6 +36,8 @@ targets:
     type: application
     platform: macOS
     deploymentTarget: "14.0"
+    dependencies:
+      - package: KeyboardShortcuts
     sources:
       - path: TAELMacAgent
         excludes:

--- a/TAEL_AI_mac_agent_build_plan_v0_2.md
+++ b/TAEL_AI_mac_agent_build_plan_v0_2.md
@@ -38,7 +38,6 @@ global hotkey -> PermissionsGate -> SCScreenshotManager -> NSPanel HUD with scre
 
 If the app cannot prove hotkey-to-screenshot by day 5, stop and diagnose before adding more scope.
 
-
 ### 1.1 v0.2 implementation freeze amendments
 
 These amendments are locked before repo creation:
@@ -53,7 +52,6 @@ These amendments are locked before repo creation:
 - Represent executable actions as structured executable + argv arrays, not raw shell strings.
 - Track context size, token estimates, and latency from the first planner integration.
 - Keep product naming unresolved until after the technical heartbeat works.
-
 
 ---
 
@@ -2417,7 +2415,6 @@ Mitigation:
 - no consumer productivity sprawl.
 
 ---
-
 
 ## 23. v0.2 implementation amendments before coding
 

--- a/TAEL_AI_mac_agent_build_plan_v0_3.md
+++ b/TAEL_AI_mac_agent_build_plan_v0_3.md
@@ -38,7 +38,6 @@ global hotkey -> PermissionsGate -> SCScreenshotManager -> NSPanel HUD with scre
 
 If the app cannot prove hotkey-to-screenshot by day 5, stop and diagnose before adding more scope.
 
-
 ### 1.1 v0.3 implementation freeze amendments
 
 These amendments are locked before repo creation:
@@ -58,7 +57,6 @@ These amendments are locked before repo creation:
 - Week 1 `PermissionsChecker` implements Screen Recording only. Accessibility and Microphone may exist as enum placeholders, but they are not real checks until their milestones.
 - `PermissionsGate` uses a tokenized closure boundary: protected services accept a `PermissionGrant`, not casual public calls.
 - First commit is only the native macOS menubar scaffold plus policy docs. Screenshot capture starts after the scaffold commit.
-
 
 ---
 
@@ -2446,7 +2444,6 @@ Mitigation:
 
 ---
 
-
 ## 23. v0.3 implementation amendments before coding
 
 ### 23.1 Deployment target
@@ -2688,7 +2685,6 @@ Use `dev.git.commit_preview` for Skill 3. The user thinks “commit this.” The
 
 ---
 
-
 ### 23.10 ScreenCaptureKit implementation notes for Week 1
 
 For macOS 14.0+, the Week 1 screenshot service uses:
@@ -2871,7 +2867,6 @@ tael-mac-agent
 ```
 
 Do not use `tael-ai` for the prototype repo. `tael-ai` is reserved for possible umbrella website, docs, backend, and brand assets later.
-
 
 ## 24. Final build checklist
 

--- a/TODO_FOR_OZZY.md
+++ b/TODO_FOR_OZZY.md
@@ -66,38 +66,30 @@ test does not require, or is a test-quality improvement that
 adds value without blocking the heartbeat. Pick them up in PR 3
 or as small follow-ups — none of them are urgent in isolation.
 
-- [ ] **User-facing error HUD on capture failure.**
-  Today `HotkeyInvocationHandler.run()` writes an `InvocationLog`
-  row and `os.log` line on capture failure, then returns silently.
-  v0.3 §23.4 only requires "does not crash," but the UX intent of
-  the heartbeat is feedback. Add an `HUDErrorView(message:)` and a
-  `presentError: (String) -> Void` closure on the handler, parallel
-  to `presentScreenshot`. Wire it from `AppDelegate`. Source: `silent-failure-hunter` review of PR #18.
-- [ ] **Hotkey closure teardown race.**
-  In `AppDelegate.swift:51-66` the hotkey closure early-returns
-  silently if any of `permissionsGate`, `screenCaptureService`,
-  `hudController`, `logService` is nil — only happens during
-  `applicationWillTerminate` race. Add at minimum
-  `Self.log.error("Hotkey fired but app state unavailable")` in the
-  guard's `else`. Source: `silent-failure-hunter` review of PR #18.
-- [ ] **Concurrent invocation guard.**
-  Two rapid hotkey presses spawn two concurrent `Task { await
-  handler.run() }` blocks. The slower one wins the HUD. If
-  invocation #1 succeeds late and #2 fails fast, the user sees
-  invocation #1's screenshot with no signal that the most recent
-  press failed. Add an in-flight token on the handler (or
-  `HotkeyManager` debounce). Source: `silent-failure-hunter` IMPORTANT
-  4 + `pr-test-analyzer` #7 from PR #18 review.
-- [ ] **Test: deterministic-clock latency assertions.**
-  `HotkeyHandlerTests` currently asserts `XCTAssertNotNil` on
-  `gateLatencyMs` / `captureLatencyMs`. Inject a deterministic
-  `now: () -> Date` (the handler already accepts one) and assert
-  exact ms values, ordering (`gateLatencyMs >= 0`,
-  `gateLatencyMs + captureLatencyMs <= elapsed`), and units
-  (regression-proof against a missing `* 1000`). Source:
-  `pr-test-analyzer` #2.
-- [ ] **Test: `.notImplemented` → `.restricted` mapping.**
-  `HotkeyInvocationHandler.swift` maps `PermissionError.notImplemented`
-  to `gateOutcome = .restricted`. No test exercises this branch.
-  Add a stub gate that throws `.notImplemented` and assert the
-  outcome is `.restricted`. Source: `pr-test-analyzer` #1.
+- [x] **User-facing error HUD on capture failure.**
+  Shipped 2026-04-26 in PR-3 (Task 6). `HUDErrorView` + a `presentError`
+  closure on `HotkeyInvocationHandler`, wired through `HUDPanelController`
+  and `AppDelegate`. Permission-error path intentionally does not call
+  `presentError` — `PermissionsGate` already shows the gate UI.
+- [x] **Hotkey closure teardown race.**
+  Shipped 2026-04-26 in PR-3 (Task 4). `AppDelegate.log` is now
+  `private static let` so the guard's `else` clause can log
+  `"Hotkey fired but app state unavailable; ignoring"` without a `self`
+  reference. Folded into the same commit as the concurrent-invocation guard.
+- [x] **Concurrent invocation guard.**
+  Shipped 2026-04-26 in PR-3 (Task 4). `HotkeyManager.onTrigger` is now
+  `() async -> Void`; the manager wraps the closure in a `Task` and gates
+  on a private `isInFlight` flag. Re-entrant presses during a slow capture
+  are dropped silently. New `HotkeyManagerTests` cover the in-flight drop,
+  the post-completion fire-again, and `tearDown` clearing state.
+- [x] **Test: deterministic-clock latency assertions.**
+  Shipped 2026-04-26 in PR-3 (Task 3). `StubClock` pops dates from a fixed
+  sequence and is wired through the handler's existing `now:` parameter.
+  Granted-path test asserts exact 100ms gate + 200ms capture; capture-
+  failure test asserts 50ms gate latency is retained across the failure.
+- [x] **Test: `.notImplemented` → `.restricted` mapping.**
+  Shipped 2026-04-26 in PR-3 (Task 2). `HotkeyInvocationHandler` accepts
+  a `kind: PermissionKind` init parameter (default `.screenRecording` —
+  no production behavior change). New test passes `.accessibility` (whose
+  `isImplemented` returns false in Week 1) and asserts the gate throws
+  `.notImplemented`, the handler logs `.restricted`, and no UI is shown.

--- a/TODO_FOR_OZZY.md
+++ b/TODO_FOR_OZZY.md
@@ -80,3 +80,48 @@ These are *not* PR 1 problems but Ozzy-side decisions that will land soon:
   vs hand-rolled. PR 2 will need to add it via SPM.
 - [ ] Decide on a HUD design language. PR 1 ships an intentionally
   ugly placeholder.
+
+## PR-3 follow-up items from PR #18 review
+
+The 5-agent review of PR #18 surfaced these gaps. They were
+deliberately not bundled into PR 2 because each one either
+exceeds Week 1 scope, touches behavior the v0.3 §23.4 acceptance
+test does not require, or is a test-quality improvement that
+adds value without blocking the heartbeat. Pick them up in PR 3
+or as small follow-ups — none of them are urgent in isolation.
+
+- [ ] **User-facing error HUD on capture failure.**
+  Today `HotkeyInvocationHandler.run()` writes an `InvocationLog`
+  row and `os.log` line on capture failure, then returns silently.
+  v0.3 §23.4 only requires "does not crash," but the UX intent of
+  the heartbeat is feedback. Add an `HUDErrorView(message:)` and a
+  `presentError: (String) -> Void` closure on the handler, parallel
+  to `presentScreenshot`. Wire it from `AppDelegate`. Source: `silent-failure-hunter` review of PR #18.
+- [ ] **Hotkey closure teardown race.**
+  In `AppDelegate.swift:51-66` the hotkey closure early-returns
+  silently if any of `permissionsGate`, `screenCaptureService`,
+  `hudController`, `logService` is nil — only happens during
+  `applicationWillTerminate` race. Add at minimum
+  `Self.log.error("Hotkey fired but app state unavailable")` in the
+  guard's `else`. Source: `silent-failure-hunter` review of PR #18.
+- [ ] **Concurrent invocation guard.**
+  Two rapid hotkey presses spawn two concurrent `Task { await
+  handler.run() }` blocks. The slower one wins the HUD. If
+  invocation #1 succeeds late and #2 fails fast, the user sees
+  invocation #1's screenshot with no signal that the most recent
+  press failed. Add an in-flight token on the handler (or
+  `HotkeyManager` debounce). Source: `silent-failure-hunter` IMPORTANT
+  4 + `pr-test-analyzer` #7 from PR #18 review.
+- [ ] **Test: deterministic-clock latency assertions.**
+  `HotkeyHandlerTests` currently asserts `XCTAssertNotNil` on
+  `gateLatencyMs` / `captureLatencyMs`. Inject a deterministic
+  `now: () -> Date` (the handler already accepts one) and assert
+  exact ms values, ordering (`gateLatencyMs >= 0`,
+  `gateLatencyMs + captureLatencyMs <= elapsed`), and units
+  (regression-proof against a missing `* 1000`). Source:
+  `pr-test-analyzer` #2.
+- [ ] **Test: `.notImplemented` → `.restricted` mapping.**
+  `HotkeyInvocationHandler.swift` maps `PermissionError.notImplemented`
+  to `gateOutcome = .restricted`. No test exercises this branch.
+  Add a stub gate that throws `.notImplemented` and assert the
+  outcome is `.restricted`. Source: `pr-test-analyzer` #1.

--- a/TODO_FOR_OZZY.md
+++ b/TODO_FOR_OZZY.md
@@ -53,6 +53,7 @@ the pain if these are not resolved.
   the project was not compiled here. Source files follow the v0.3 layout
   and the `PermissionsGate` tokenized pattern, but a real Xcode build
   on macOS 14.0+ is the only ground truth. To verify:
+
   ```bash
   xcodebuild -project TAELMacAgent/TAELMacAgent.xcodeproj \
              -scheme TAELMacAgent \
@@ -64,6 +65,7 @@ the pain if these are not resolved.
              -destination 'platform=macOS' \
              test
   ```
+
   Expected: clean build, all `TAELMacAgentTests` pass, app launches as a
   menubar utility, Quit menu works.
 

--- a/TODO_FOR_OZZY.md
+++ b/TODO_FOR_OZZY.md
@@ -1,8 +1,6 @@
 # TODO for Ozzy
 
-Items that require owner input before this repo is truly buildable
-on a real Mac. Nothing here blocks PR 1, but PR 2 will start to feel
-the pain if these are not resolved.
+Owner-side decisions and credentials that affect the internal alpha track.
 
 ## Signing and identity
 
@@ -14,29 +12,29 @@ the pain if these are not resolved.
   Developer Program (Individual). Signing Certificate: Development.
 - [x] **Confirm bundle ID `ai.tael.macagent` is acceptable long-term.**
   Confirmed 2026-04-26. Used as the stable TCC identity.
+- [ ] **Install Developer ID Application certificate.**
+  Required before `scripts/package-alpha-dmg.sh` can produce a notarized
+  internal alpha DMG. Current local keychain inspection showed Apple
+  Development only.
+- [ ] **Create a `notarytool` keychain profile.**
+  Recommended profile name: `tael-notary`.
+  Run `xcrun notarytool store-credentials tael-notary` locally.
 
 ## Repo and naming
 
 - [x] **Confirm repo name `tael-ai` should remain.**
   Confirmed 2026-04-26. Keeping `tael-ai`.
-- [ ] **Confirm GitHub Issues should be created manually or via CLI.**
-  Maestro Claude does not have `gh` access and does not auto-open
-  Issues from this run. Week 1 ticket checklist lives in
-  [`docs/Week1Heartbeat.md`](docs/Week1Heartbeat.md). If you want a
-  one-issue-per-ticket layout, tell Claude/Codex on the next run and
-  it can be created via the GitHub MCP server.
+- [x] **Confirm GitHub Issues should be created manually or via CLI.**
+  Week 1 issues were created via CLI and are reconciled as part of the
+  SDLC stabilization pass.
 
 ## Branches
 
-- [ ] **Confirm branch model.** The plan says:
-  - `main` — frozen plan + scaffold
-  - `dev-claude` — Maestro Claude
-  - `dev-codex` — Codex
-  
-  This run created `dev-claude` from `main` and developed there.
-  PR is opened against `main` as a draft per repo policy.
+- [x] **Confirm branch model.**
+  Active flow: `feature/*` or `codex/*` → `develop` → `main`.
+  Claude remains a review checkpoint; Codex can lead scoped execution.
 
-## Build / test status from PR 1
+## Build / test status
 
 - [x] **Run `xcodebuild` locally.**
   Verified 2026-04-26. Clean build succeeds. All 11 tests pass
@@ -44,18 +42,23 @@ the pain if these are not resolved.
   App launches as menubar utility. Permission gate HUD confirmed
   working. Quit menu works. Required fix: set
   `GENERATE_INFOPLIST_FILE = YES` on TAELMacAgentTests target.
+- [x] **Fix signing source drift for test host.**
+  Verified 2026-04-30. `project.yml` now carries Team `4X8U3NCLQ8`,
+  Apple Development debug signing, and generated test target Info.plist
+  settings so `make xcodeproj` does not reintroduce ad-hoc test signing.
+  `make test` passes with 20 tests.
 
 ## Future, intentionally deferred
 
-These are *not* PR 1 problems but Ozzy-side decisions that will land soon:
+These are not blockers for the current internal alpha stabilization pass:
 
-- [ ] Decide product name. v0.3 is explicit: do this **after** the
-  Week 1 heartbeat works.
-- [ ] Decide release signing model (Developer ID + notarization).
-- [ ] Decide on KeyboardShortcuts package source (sindresorhus/KeyboardShortcuts)
-  vs hand-rolled. PR 2 will need to add it via SPM.
-- [ ] Decide on a HUD design language. PR 1 ships an intentionally
-  ugly placeholder.
+- [ ] Decide product name. Internal alpha remains TAEL / TAELMacAgent.
+- [x] Decide release signing model.
+  Internal alpha uses manual Developer ID DMG plus notarization.
+- [x] Decide on KeyboardShortcuts package source.
+  `sindresorhus/KeyboardShortcuts` is active via SPM.
+- [ ] Decide on a HUD design language. The current HUD is functional
+  but intentionally plain.
 
 ## PR-3 follow-up items from PR #18 review
 
@@ -64,13 +67,13 @@ deliberately not bundled into PR 2 because each one either
 exceeds Week 1 scope, touches behavior the v0.3 §23.4 acceptance
 test does not require, or is a test-quality improvement that
 adds value without blocking the heartbeat. Pick them up in PR 3
-or as small follow-ups — none of them are urgent in isolation.
+or as small follow-ups. None of them are urgent in isolation.
 
 - [x] **User-facing error HUD on capture failure.**
   Shipped 2026-04-26 in PR-3 (Task 6). `HUDErrorView` + a `presentError`
   closure on `HotkeyInvocationHandler`, wired through `HUDPanelController`
   and `AppDelegate`. Permission-error path intentionally does not call
-  `presentError` — `PermissionsGate` already shows the gate UI.
+  `presentError`; `PermissionsGate` already shows the gate UI.
 - [x] **Hotkey closure teardown race.**
   Shipped 2026-04-26 in PR-3 (Task 4). `AppDelegate.log` is now
   `private static let` so the guard's `else` clause can log
@@ -89,7 +92,7 @@ or as small follow-ups — none of them are urgent in isolation.
   failure test asserts 50ms gate latency is retained across the failure.
 - [x] **Test: `.notImplemented` → `.restricted` mapping.**
   Shipped 2026-04-26 in PR-3 (Task 2). `HotkeyInvocationHandler` accepts
-  a `kind: PermissionKind` init parameter (default `.screenRecording` —
-  no production behavior change). New test passes `.accessibility` (whose
-  `isImplemented` returns false in Week 1) and asserts the gate throws
+  a `kind: PermissionKind` init parameter (default `.screenRecording`;
+  no production behavior change). New test passes `.microphone` (which
+  remains unimplemented) and asserts the gate throws
   `.notImplemented`, the handler logs `.restricted`, and no UI is shown.

--- a/TODO_FOR_OZZY.md
+++ b/TODO_FOR_OZZY.md
@@ -6,28 +6,19 @@ the pain if these are not resolved.
 
 ## Signing and identity
 
-- [ ] **Set Apple Developer Team ID in Xcode.**
-  The project ships with `DEVELOPMENT_TEAM` left blank. Open
-  `TAELMacAgent/TAELMacAgent.xcodeproj` → project → `TAELMacAgent` target →
-  Signing & Capabilities → set Team. Do **not** select "Sign to Run Locally"
-  (ad-hoc) for daily dev — TCC permissions are keyed to bundle identity
-  and signing requirements; ad-hoc signing makes Screen Recording /
-  Accessibility / Microphone debugging noisy and irreproducible.
-- [ ] **Choose preferred local signing identity.**
-  Apple Development is correct for Debug builds. Confirm which
-  developer account / identity is used so the team can avoid
-  flapping TCC entries. Document it in `docs/PermissionNotes.md`
-  once chosen.
-- [ ] **Confirm bundle ID `ai.tael.macagent` is acceptable long-term.**
-  Used as the stable TCC identity. Changing it later resets all
-  granted permissions on every dev machine.
+- [x] **Set Apple Developer Team ID in Xcode.**
+  Set 2026-04-26. Team: OMER FARUK AKBEN, Team ID: 4X8U3NCLQ8.
+  Automatic signing enabled, Development certificate.
+- [x] **Choose preferred local signing identity.**
+  Confirmed 2026-04-26. Apple Development (automatic), paid Apple
+  Developer Program (Individual). Signing Certificate: Development.
+- [x] **Confirm bundle ID `ai.tael.macagent` is acceptable long-term.**
+  Confirmed 2026-04-26. Used as the stable TCC identity.
 
 ## Repo and naming
 
-- [ ] **Confirm repo name `tael-ai` should remain, or move to
-  `tael-mac-agent` later.** The macOS app is `TAELMacAgent` regardless,
-  but the repo name is flexible until the wider TAEL surface area
-  (`tuel-ai`, `toel-ai`) starts existing.
+- [x] **Confirm repo name `tael-ai` should remain.**
+  Confirmed 2026-04-26. Keeping `tael-ai`.
 - [ ] **Confirm GitHub Issues should be created manually or via CLI.**
   Maestro Claude does not have `gh` access and does not auto-open
   Issues from this run. Week 1 ticket checklist lives in
@@ -47,27 +38,12 @@ the pain if these are not resolved.
 
 ## Build / test status from PR 1
 
-- [ ] **Run `xcodebuild` locally.**
-  This run was performed in a Linux container with no Xcode toolchain.
-  `xcodebuild`, `swift build`, and `swiftformat` were not available, so
-  the project was not compiled here. Source files follow the v0.3 layout
-  and the `PermissionsGate` tokenized pattern, but a real Xcode build
-  on macOS 14.0+ is the only ground truth. To verify:
-
-  ```bash
-  xcodebuild -project TAELMacAgent/TAELMacAgent.xcodeproj \
-             -scheme TAELMacAgent \
-             -configuration Debug \
-             -destination 'platform=macOS' \
-             clean build
-  xcodebuild -project TAELMacAgent/TAELMacAgent.xcodeproj \
-             -scheme TAELMacAgent \
-             -destination 'platform=macOS' \
-             test
-  ```
-
-  Expected: clean build, all `TAELMacAgentTests` pass, app launches as a
-  menubar utility, Quit menu works.
+- [x] **Run `xcodebuild` locally.**
+  Verified 2026-04-26. Clean build succeeds. All 11 tests pass
+  (3 HotkeyHandler, 3 LocalLogService, 5 PermissionsGate).
+  App launches as menubar utility. Permission gate HUD confirmed
+  working. Quit menu works. Required fix: set
+  `GENERATE_INFOPLIST_FILE = YES` on TAELMacAgentTests target.
 
 ## Future, intentionally deferred
 

--- a/docs/AlphaReleaseChecklist.md
+++ b/docs/AlphaReleaseChecklist.md
@@ -1,0 +1,60 @@
+# Alpha release checklist
+
+This checklist is for the internal alpha DMG only. It is not the public
+launch process.
+
+## Prerequisites
+
+- Apple Developer Program account has a Developer ID Application certificate.
+- The certificate is installed in the local login keychain.
+- A notary profile exists:
+
+```bash
+xcrun notarytool store-credentials tael-notary
+```
+
+- `security find-identity -v -p codesigning` shows the Developer ID identity.
+- Screen Recording and Accessibility flows have passed the manual checklist.
+
+## Build and package
+
+```bash
+DEVELOPER_ID_APPLICATION="Developer ID Application: OMER FARUK AKBEN (...)" \
+NOTARYTOOL_PROFILE="tael-notary" \
+VERSION="0.1.0-alpha.1" \
+./scripts/package-alpha-dmg.sh
+```
+
+The script archives the Release app, signs with Developer ID, notarizes and
+staples the app, creates a DMG, notarizes and staples the DMG, and runs
+Gatekeeper checks.
+
+## Required validation
+
+- `git diff --check`
+- `make xcodeproj`
+- `make test`
+- `make build`
+- `codesign --verify --deep --strict --verbose=2 <path>/TAELMacAgent.app`
+- `xcrun stapler validate <path>/TAELMacAgent-<version>.dmg`
+- `spctl -a -vvv <path>/TAELMacAgent.app`
+- `spctl -a -vvv --type open <path>/TAELMacAgent-<version>.dmg`
+
+## Manual install smoke test
+
+- Open the DMG from a clean user account or fresh Mac.
+- Drag `TAELMacAgent.app` to Applications.
+- Launch the app and confirm the menubar item appears.
+- Press `Command-Shift-T` from Terminal or VS Code.
+- Grant Screen Recording, quit and relaunch, then verify screenshot HUD.
+- Grant Accessibility and verify focused-window app/title metadata appears.
+- Revoke Screen Recording and verify TAEL shows the permission gate.
+- Confirm no screenshots or AX context files are written to disk.
+
+## Known alpha constraints
+
+- Manual DMG only. Sparkle auto-update is deferred.
+- App Sandbox remains off for alpha while ScreenCaptureKit, hotkey, and AX
+  behavior are still being proven together.
+- Developer ID certificate and notary credentials are local machine
+  prerequisites and are not committed to the repo.

--- a/docs/Architecture.md
+++ b/docs/Architecture.md
@@ -7,7 +7,7 @@ sections 8 and 13.
 
 ## What exists today
 
-```
+```text
 TAELMacAgent (menubar app, native macOS)
 ├── App
 │   ├── TAELMacAgentApp.swift     SwiftUI App entry
@@ -73,7 +73,7 @@ boundary**, not a polite convention.
 
 ## Week 1 heartbeat (target, not yet wired)
 
-```
+```text
 global hotkey                                                (HotkeyManager)
   → PermissionsGate.withPermission(.screenRecording) { grant in
       → SCScreenshotManager.captureImage(contentFilter:configuration:)

--- a/docs/Architecture.md
+++ b/docs/Architecture.md
@@ -1,4 +1,4 @@
-# TAEL macOS agent — Architecture (PR 1)
+# TAEL macOS agent architecture
 
 This document tracks the *current* architecture, not the eventual one.
 The eventual architecture is described in
@@ -10,21 +10,22 @@ sections 8 and 13.
 ```text
 TAELMacAgent (menubar app, native macOS)
 ├── App
-│   ├── TAELMacAgentApp.swift     SwiftUI App entry
-│   ├── AppDelegate.swift          Menubar lifecycle, NSStatusItem
+│   ├── TAELMacAgentApp.swift      SwiftUI App entry
+│   ├── AppDelegate.swift          Menubar lifecycle and dependency wiring
+│   ├── HotkeyInvocationHandler.swift
+│   │                              gate → capture → focused-window metadata → HUD + log
 │   └── MenuBarController.swift    Menubar menu (Show HUD, Quit)
 ├── Hotkey
-│   └── HotkeyManager.swift        Stub. Registers a callback. No real
-│                                  global hotkey until KeyboardShortcuts
-│                                  package is added (PR 2, ticket 6).
+│   ├── HotkeyManager.swift        KeyboardShortcuts-backed global hotkey
+│   └── HotkeyName.swift           Command-Shift-T binding name
 ├── Permissions
 │   ├── PermissionKind.swift       Enum: screenRecording, accessibility,
 │   │                              microphone, appleEvents, inputMonitoring
 │   ├── PermissionStatus.swift     Enum: notDetermined, denied, granted,
 │   │                              restricted
 │   ├── PermissionError.swift      Errors thrown by PermissionsGate
-│   ├── PermissionsChecker.swift   Reads current OS permission state.
-│   │                              v0: Screen Recording only.
+│   ├── PermissionsChecker.swift   Reads current OS permission state for
+│   │                              Screen Recording and Accessibility.
 │   └── PermissionsGate.swift      The architectural boundary. Every
 │                                  protected call goes through here.
 │                                  Also defines `PermissionGrant` so
@@ -33,19 +34,22 @@ TAELMacAgent (menubar app, native macOS)
 ├── HUD
 │   ├── HUDPanelController.swift   Non-activating NSPanel host.
 │   ├── HUDView.swift              SwiftUI placeholder content.
-│   └── PermissionGateView.swift   "Open System Settings" sheet for
-│                                  missing permissions.
+│   ├── HUDScreenshotView.swift    Screenshot rendering.
+│   ├── HUDContextBundleView.swift Screenshot plus focused-window metadata.
+│   ├── HUDErrorView.swift         Capture failure surface.
+│   └── PermissionGateView.swift   "Open System Settings" sheet.
 ├── Capture
 │   ├── ScreenshotTarget.swift     displayContainingCursor / mainDisplay
 │   ├── CapturedScreenshot.swift   Screenshot value type + metadata
-│   └── ScreenCaptureService.swift Stub. Real SCScreenshotManager call
-│                                  lands in PR 2, ticket 8. Requires a
-│                                  PermissionGrant of kind .screenRecording.
+│   ├── ScreenCaptureService.swift ScreenCaptureKit screenshot service.
+│   ├── FocusedWindowMetadata.swift
+│   ├── ContextBundle.swift        Per-invocation screenshot + AX metadata.
+│   └── AXService.swift            Focused-window metadata through AX APIs.
 ├── Logging
 │   ├── InvocationLog.swift        Value type: hotkey ts, gate result,
 │   │                              capture timing, target metadata.
 │   └── LocalLogService.swift      Local-only logger. Does not touch disk
-│                                  in PR 1; in-memory ring buffer.
+│                                  in the alpha track; in-memory ring buffer.
 └── Resources
     └── Assets.xcassets            App icon placeholder.
 ```
@@ -71,7 +75,7 @@ accept the grant and assert their expected kind via `precondition`.
 This makes the boundary **a code-review-visible, type-system-visible
 boundary**, not a polite convention.
 
-## Week 1 heartbeat (target, not yet wired)
+## Invocation flow
 
 ```text
 global hotkey                                                (HotkeyManager)
@@ -80,26 +84,36 @@ global hotkey                                                (HotkeyManager)
         (display containing cursor, fallback to main display)
                                                            (ScreenCaptureService)
     }
-  → HUDPanelController shows non-activating NSPanel with PNG     (HUD)
+  → PermissionsGate.withPermission(.accessibility, showMissingUI: false) { grant in
+      → read frontmost app and focused-window title / role       (AXService)
+    }
+  → HUDPanelController shows non-activating NSPanel              (HUD)
   → InvocationLog written locally                               (Logging)
 ```
 
+Accessibility metadata is optional. Missing or revoked Accessibility permission
+must not break the screenshot heartbeat or show a second permission gate during
+the hotkey flow.
+
 ## Folder layout reference
 
-The Week 1 layout in this repo is intentionally a strict subset of the
-section-13 "Recommended initial structure" in v0.3. Folders that have no
-PR 1 implementation (`Voice/`, `Planner/`, `Skills/`, `Executor/`,
-`Settings/`) are not created here. They will be added in their own PRs.
+The current layout is still a subset of the section-13 "Recommended initial
+structure" in v0.3. Folders that have no implementation yet (`Voice/`,
+`Planner/`, `Skills/`, `Executor/`, `Settings/`) are not created here. They
+will be added in their own milestones.
 
 ## Third-party packages
 
-PR 1: none.
-
-Planned (do not add yet):
+Active:
 
 | Package | Purpose | Ticket |
 |---|---|---|
-| `sindresorhus/KeyboardShortcuts` | global hotkey + user-configurable | Week 1 ticket 6 |
+| `sindresorhus/KeyboardShortcuts` | global hotkey | Week 1 ticket 6 |
+
+Planned, not yet added:
+
+| Package | Purpose | Milestone |
+|---|---|---|
 | `argmaxinc/WhisperKit` | local STT, isolated behind `TranscriptionService` | Week 3 |
 
 ## Concurrency model
@@ -112,13 +126,14 @@ Planned (do not add yet):
 
 ## Logging
 
-`LocalLogService` keeps an in-memory ring buffer of `InvocationLog` rows
-in PR 1. PR 1 does **not** persist logs to disk. Disk persistence (with
-size cap and daily rotation) lands when the executor lands.
+`LocalLogService` keeps an in-memory ring buffer of `InvocationLog` rows.
+The app does **not** persist screenshots, AX metadata, audio, transcripts, or
+invocation logs to disk in the current alpha track. Disk persistence with size
+cap and rotation lands only when the executor milestone needs it.
 
 ## Test layout
 
-- `TAELMacAgentTests/PermissionsGateTests.swift` — verifies that
-  `withPermission` short-circuits on denied status, that the operation
-  is invoked exactly once on granted, and that the closure receives a
-  grant of the requested kind.
+- `TAELMacAgentTests/PermissionsGateTests.swift` verifies the tokenized gate.
+- `TAELMacAgentTests/HotkeyHandlerTests.swift` verifies screenshot success,
+  capture failure, missing permissions, and optional AX metadata degradation.
+- `TAELMacAgentTests/ContextBundleTests.swift` verifies context value behavior.

--- a/docs/ManualTestChecklist.md
+++ b/docs/ManualTestChecklist.md
@@ -3,9 +3,9 @@
 PR-by-PR, run the rows that apply. Anything new and risky should add a
 row here.
 
-Legend: ✅ pass · ⚠️ pass with note · ❌ fail · — not applicable to this PR
+Legend: pass, pass with note, fail, not applicable
 
-## PR 1 — scaffold only
+## PR 1 scaffold only
 
 | # | Check | Expected | Result |
 |---|---|---|---|
@@ -19,10 +19,9 @@ Legend: ✅ pass · ⚠️ pass with note · ❌ fail · — not applicable to t
 | 8 | Inspect `Info.plist` | `LSUIElement = YES`, `LSMinimumSystemVersion = 14.0`, `CFBundleIdentifier = ai.tael.macagent` | |
 | 9 | Confirm no Screen Recording prompt appears on launch | We do not call any protected API on launch | |
 
-## Week 1 (lands in PR 2 — `hotkey → screenshot → HUD`)
+## Week 1 heartbeat, shipped in PR 2
 
-These are not expected to pass on PR 1. Listed here so they are ready
-when PR 2 lands.
+These are retained as the baseline heartbeat checks.
 
 | # | Check | Expected |
 |---|---|---|
@@ -39,7 +38,7 @@ when PR 2 lands.
 | W1.11 | Press hotkey with cursor on a Cursor / VS Code window | Screenshot includes that window |
 | W1.12 | Inspect `LocalLogService` after several invocations | Each invocation has a row with hotkey ts, gate result, capture timing, target display metadata |
 
-## PR 2 — Week 1 heartbeat manual cases
+## PR 2 Week 1 heartbeat manual cases
 
 ### PR-2.1 First-launch Screen Recording prompt
 
@@ -58,16 +57,16 @@ when PR 2 lands.
 
 - Click "Open System Settings" in the gate, grant Screen Recording for TAELMacAgent, quit/relaunch TAEL.
 - Press ⌘⇧T.
-- Expected: HUD appears within ~500ms showing the cursor display's screenshot at max 720x480 with caption "Captured WIDTHxHEIGHT — cursor display".
+- Expected: HUD appears within ~500ms showing the cursor display's screenshot at max 720x480 with caption "Captured WIDTHxHEIGHT - cursor display".
 - Expected: HUD does not steal focus from Terminal/VS Code/Cursor.
 
-### PR-2.4 Multi-monitor — cursor display selection
+### PR-2.4 Multi-monitor cursor display selection
 
 - With two displays, move the cursor to the secondary display.
 - Press ⌘⇧T.
 - Expected: HUD shows the secondary display's content, caption says "cursor display".
 
-### PR-2.5 Multi-monitor — main display fallback
+### PR-2.5 Multi-monitor main display fallback
 
 - Disconnect or disable the secondary display while the cursor was on it (edge case; requires a hotplug or display-arrangement change).
 - Press ⌘⇧T.
@@ -90,6 +89,29 @@ when PR 2 lands.
 - Expected: each row has hotkeyTimestamp, gateOutcome, gateLatencyMs, captureLatencyMs, targetDescription. Granted-path rows have all four numeric fields populated.
 
 ## TCC reset for clean re-test
+
+## PR 5 focused-window metadata
+
+| # | Check | Expected |
+|---|---|---|
+| PR-5.1 | Grant Screen Recording, do not grant Accessibility, press `Command-Shift-T` from Terminal | Screenshot HUD appears; focused-window area says metadata is unavailable; no Accessibility gate interrupts the heartbeat |
+| PR-5.2 | Grant Screen Recording and Accessibility, press `Command-Shift-T` from Terminal | HUD shows screenshot plus Terminal app name and focused-window title when available |
+| PR-5.3 | Press `Command-Shift-T` from VS Code or Cursor | HUD shows screenshot plus app name and a best-effort focused-window title |
+| PR-5.4 | Press `Command-Shift-T` from Safari or another sandboxed app | HUD still appears; metadata may be partial but app must not crash |
+| PR-5.5 | Press `Command-Shift-T` from a full-screen app | HUD appears without stealing focus; metadata degrades gracefully |
+| PR-5.6 | Revoke Accessibility while app is running, then press `Command-Shift-T` | Screenshot still appears; focused-window metadata is omitted |
+| PR-5.7 | Inspect project root and `~/Library/Application Support/TAELMacAgent/` | No screenshot or AX context files are created |
+
+## Alpha DMG smoke test
+
+| # | Check | Expected |
+|---|---|---|
+| A.1 | Run `./scripts/package-alpha-dmg.sh` without required env vars | Script exits with a clear prerequisite error |
+| A.2 | Package with Developer ID identity and notary profile | DMG is created, notarized, stapled, and Gatekeeper-checked |
+| A.3 | Install from the DMG on a clean user or fresh Mac | App launches as a menubar utility |
+| A.4 | Grant Screen Recording and invoke the hotkey | Screenshot HUD appears |
+| A.5 | Grant Accessibility and invoke the hotkey | Focused-window metadata appears when available |
+| A.6 | Quit from menubar | App exits cleanly |
 
 ```bash
 ./scripts/reset-tcc-dev.sh

--- a/docs/ManualTestChecklist.md
+++ b/docs/ManualTestChecklist.md
@@ -41,43 +41,51 @@ when PR 2 lands.
 
 ## PR 2 — Week 1 heartbeat manual cases
 
-PR-2.1 First-launch Screen Recording prompt
+### PR-2.1 First-launch Screen Recording prompt
+
 - Quit TAEL if running.
 - `make tcc-reset` to clear ai.tael.macagent's TCC entries.
 - `make run`.
 - Press ⌘⇧T while Terminal is focused.
 - Expected: PermissionGateView appears with "TAEL needs Screen Recording permission" and "Open System Settings" / "Cancel" buttons.
 
-PR-2.2 Cancel button dismisses the gate
+### PR-2.2 Cancel button dismisses the gate
+
 - From PR-2.1's gate, click "Cancel".
 - Expected: panel disappears within ~100ms, no crash.
 
-PR-2.3 Granted path captures and renders
+### PR-2.3 Granted path captures and renders
+
 - Click "Open System Settings" in the gate, grant Screen Recording for TAELMacAgent, quit/relaunch TAEL.
 - Press ⌘⇧T.
 - Expected: HUD appears within ~500ms showing the cursor display's screenshot at max 720x480 with caption "Captured WIDTHxHEIGHT — cursor display".
 - Expected: HUD does not steal focus from Terminal/VS Code/Cursor.
 
-PR-2.4 Multi-monitor — cursor display selection
+### PR-2.4 Multi-monitor — cursor display selection
+
 - With two displays, move the cursor to the secondary display.
 - Press ⌘⇧T.
 - Expected: HUD shows the secondary display's content, caption says "cursor display".
 
-PR-2.5 Multi-monitor — main display fallback
+### PR-2.5 Multi-monitor — main display fallback
+
 - Disconnect or disable the secondary display while the cursor was on it (edge case; requires a hotplug or display-arrangement change).
 - Press ⌘⇧T.
 - Expected: HUD shows the main display, caption says "main display (fallback)".
 
-PR-2.6 Full-screen app
+### PR-2.6 Full-screen app
+
 - Make a Terminal or VS Code window full-screen.
 - Press ⌘⇧T.
 - Expected: HUD appears as an overlay; full-screen app stays focused; HUD shows the captured screenshot.
 
-PR-2.7 No screenshot persistence
+### PR-2.7 No screenshot persistence
+
 - After PR-2.3, check `~/Library/Application Support/TAELMacAgent/` and the project root.
 - Expected: no PNG/JPEG files created. Screenshots are in-memory only.
 
-PR-2.8 Invocation log fields
+### PR-2.8 Invocation log fields
+
 - After several invocations, attach a debugger to TAELMacAgent and inspect `LocalLogService.recent()`.
 - Expected: each row has hotkeyTimestamp, gateOutcome, gateLatencyMs, captureLatencyMs, targetDescription. Granted-path rows have all four numeric fields populated.
 

--- a/docs/ManualTestChecklist.md
+++ b/docs/ManualTestChecklist.md
@@ -44,8 +44,8 @@ when PR 2 lands.
 ### PR-2.1 First-launch Screen Recording prompt
 
 - Quit TAEL if running.
-- `make tcc-reset` to clear ai.tael.macagent's TCC entries.
-- `make run`.
+- `scripts/reset-tcc-dev.sh` to clear ai.tael.macagent's TCC entries.
+- Open `TAELMacAgent/TAELMacAgent.xcodeproj` in Xcode and Run, or `xcodebuild -project TAELMacAgent/TAELMacAgent.xcodeproj -scheme TAELMacAgent -configuration Debug -destination 'platform=macOS' CODE_SIGNING_ALLOWED=NO build` then launch the built `.app`.
 - Press ⌘⇧T while Terminal is focused.
 - Expected: PermissionGateView appears with "TAEL needs Screen Recording permission" and "Open System Settings" / "Cancel" buttons.
 

--- a/docs/ManualTestChecklist.md
+++ b/docs/ManualTestChecklist.md
@@ -90,6 +90,14 @@ These are retained as the baseline heartbeat checks.
 
 ## TCC reset for clean re-test
 
+```bash
+./scripts/reset-tcc-dev.sh
+```
+
+After running, **quit the app and relaunch** before re-testing
+W1.3-W1.5. Some macOS 14 builds need a quit+relaunch for the new
+state to take effect.
+
 ## PR 5 focused-window metadata
 
 | # | Check | Expected |
@@ -112,11 +120,3 @@ These are retained as the baseline heartbeat checks.
 | A.4 | Grant Screen Recording and invoke the hotkey | Screenshot HUD appears |
 | A.5 | Grant Accessibility and invoke the hotkey | Focused-window metadata appears when available |
 | A.6 | Quit from menubar | App exits cleanly |
-
-```bash
-./scripts/reset-tcc-dev.sh
-```
-
-After running, **quit the app and relaunch** before re-testing
-W1.3–W1.5. Some macOS 14 builds need a quit+relaunch for the new
-state to take effect.

--- a/docs/ManualTestChecklist.md
+++ b/docs/ManualTestChecklist.md
@@ -39,6 +39,48 @@ when PR 2 lands.
 | W1.11 | Press hotkey with cursor on a Cursor / VS Code window | Screenshot includes that window |
 | W1.12 | Inspect `LocalLogService` after several invocations | Each invocation has a row with hotkey ts, gate result, capture timing, target display metadata |
 
+## PR 2 — Week 1 heartbeat manual cases
+
+PR-2.1 First-launch Screen Recording prompt
+- Quit TAEL if running.
+- `make tcc-reset` to clear ai.tael.macagent's TCC entries.
+- `make run`.
+- Press ⌘⇧T while Terminal is focused.
+- Expected: PermissionGateView appears with "TAEL needs Screen Recording permission" and "Open System Settings" / "Cancel" buttons.
+
+PR-2.2 Cancel button dismisses the gate
+- From PR-2.1's gate, click "Cancel".
+- Expected: panel disappears within ~100ms, no crash.
+
+PR-2.3 Granted path captures and renders
+- Click "Open System Settings" in the gate, grant Screen Recording for TAELMacAgent, quit/relaunch TAEL.
+- Press ⌘⇧T.
+- Expected: HUD appears within ~500ms showing the cursor display's screenshot at max 720x480 with caption "Captured WIDTHxHEIGHT — cursor display".
+- Expected: HUD does not steal focus from Terminal/VS Code/Cursor.
+
+PR-2.4 Multi-monitor — cursor display selection
+- With two displays, move the cursor to the secondary display.
+- Press ⌘⇧T.
+- Expected: HUD shows the secondary display's content, caption says "cursor display".
+
+PR-2.5 Multi-monitor — main display fallback
+- Disconnect or disable the secondary display while the cursor was on it (edge case; requires a hotplug or display-arrangement change).
+- Press ⌘⇧T.
+- Expected: HUD shows the main display, caption says "main display (fallback)".
+
+PR-2.6 Full-screen app
+- Make a Terminal or VS Code window full-screen.
+- Press ⌘⇧T.
+- Expected: HUD appears as an overlay; full-screen app stays focused; HUD shows the captured screenshot.
+
+PR-2.7 No screenshot persistence
+- After PR-2.3, check `~/Library/Application Support/TAELMacAgent/` and the project root.
+- Expected: no PNG/JPEG files created. Screenshots are in-memory only.
+
+PR-2.8 Invocation log fields
+- After several invocations, attach a debugger to TAELMacAgent and inspect `LocalLogService.recent()`.
+- Expected: each row has hotkeyTimestamp, gateOutcome, gateLatencyMs, captureLatencyMs, targetDescription. Granted-path rows have all four numeric fields populated.
+
 ## TCC reset for clean re-test
 
 ```bash

--- a/docs/PermissionNotes.md
+++ b/docs/PermissionNotes.md
@@ -60,15 +60,22 @@ is "Open System Settings" only.
 This wraps `tccutil reset ScreenCapture ai.tael.macagent`. See the
 script for what it does and how to dry-run it.
 
-## Future permissions (placeholders only in PR 1)
+## Active permissions
 
-### Accessibility
+### Accessibility (PR 4)
 
-- Required for AX tree reads and for `CGEvent` synthesis on Apple
-  Silicon under modern macOS.
-- Use `AXIsProcessTrustedWithOptions` to check; pass
-  `kAXTrustedCheckOptionPrompt` to prompt.
-- Quit-and-relaunch behavior: similar to Screen Recording.
+- Required for AX tree reads (PR 5+) and for `CGEvent` synthesis on
+  Apple Silicon under modern macOS.
+- `PermissionsChecker.accessibilityStatus()` calls `AXIsProcessTrusted()`
+  — the no-prompt variant. The prompting variant
+  (`AXIsProcessTrustedWithOptions([kAXTrustedCheckOptionPrompt: true])`)
+  is intentionally not used; `PermissionGateView` owns the prompt path
+  so the user lands in the same flow as Screen Recording.
+- Quit-and-relaunch behavior: similar to Screen Recording. After
+  granting AX in System Settings → Privacy & Security → Accessibility,
+  the app must be relaunched for the trust state to flip.
+
+## Future permissions (placeholders only)
 
 ### Microphone
 

--- a/docs/PermissionNotes.md
+++ b/docs/PermissionNotes.md
@@ -17,7 +17,7 @@ If you hit a TCC weirdness, write it down here.
   requirement, and ad-hoc identities flap, which causes the OS to
   re-prompt or silently drop grants.
 
-## Week 1 active permission: Screen Recording
+## Active permission: Screen Recording
 
 ### Behavior
 
@@ -37,19 +37,16 @@ If you hit a TCC weirdness, write it down here.
 We use `CGPreflightScreenCaptureAccess()` to read the current
 state without triggering the prompt.
 
-PR 1's `PermissionGateView` does **not** call
-`CGRequestScreenCaptureAccess()`; it only links the user to System
-Settings → Privacy & Security → Screen Recording. The first system
-prompt for Screen Recording is therefore triggered as a side effect of
-the first real ScreenCaptureKit call (which lands in PR 2). If we add
-an explicit "Request access" button in the gate later, it will route
-through `CGRequestScreenCaptureAccess()` — but until then, the gate
-is "Open System Settings" only.
+`PermissionGateView` does **not** call `CGRequestScreenCaptureAccess()`;
+it links the user to System Settings → Privacy & Security → Screen
+Recording. If we add an explicit "Request access" button later, it will
+route through `CGRequestScreenCaptureAccess()`. Until then, the gate is
+"Open System Settings" only.
 
 > Note: in some macOS 14 minor versions, `CGPreflightScreenCaptureAccess`
 > can return `true` even when ScreenCaptureKit later fails. The gate
 > should consider both preflight and an actual `SCShareableContent` probe.
-> This is an open item — see ticket 4 in `Week1Heartbeat.md`.
+> This remains a known macOS edge case to watch during manual QA.
 
 ### Reset for development
 
@@ -62,18 +59,21 @@ script for what it does and how to dry-run it.
 
 ## Active permissions
 
-### Accessibility (PR 4)
+### Accessibility
 
-- Required for AX tree reads (PR 5+) and for `CGEvent` synthesis on
-  Apple Silicon under modern macOS.
+- Required for focused-window metadata and for future AX tree reads.
+- `AXService` consumes a `.accessibility` grant to read frontmost app,
+  focused-window title, and focused-window role.
 - `PermissionsChecker.accessibilityStatus()` calls `AXIsProcessTrusted()`
-  — the no-prompt variant. The prompting variant
+  - the no-prompt variant. The prompting variant
   (`AXIsProcessTrustedWithOptions([kAXTrustedCheckOptionPrompt: true])`)
   is intentionally not used; `PermissionGateView` owns the prompt path
   so the user lands in the same flow as Screen Recording.
 - Quit-and-relaunch behavior: similar to Screen Recording. After
   granting AX in System Settings → Privacy & Security → Accessibility,
   the app must be relaunched for the trust state to flip.
+- During a normal hotkey invocation, Accessibility is optional context:
+  missing AX permission must not interrupt the screenshot heartbeat.
 
 ## Future permissions (placeholders only)
 
@@ -86,19 +86,18 @@ script for what it does and how to dry-run it.
 
 - Per-target. Sending an event to e.g. Terminal prompts a per-app
   grant. There is no global "Apple Events on" toggle.
-- We will not request these in PR 1.
+- We will not request these before the planner/executor milestone.
 
 ### Input Monitoring
 
 - Required if we ever use a low-level `CGEventTap` for global hotkey
-  capture. We avoid this in PR 1 by using KeyboardShortcuts (which
-  uses Carbon HotKey APIs and does not require Input Monitoring).
+  capture. We avoid this by using KeyboardShortcuts, which uses Carbon
+  HotKey APIs and does not require Input Monitoring.
 
 ## Logs
 
-`LocalLogService` keeps an in-memory ring buffer of `InvocationLog`
-rows in PR 1. To inspect after a session, use the menubar "Show recent
-invocations" item (planned for PR 2). For now, attach a debugger.
+`LocalLogService` keeps an in-memory ring buffer of `InvocationLog` rows.
+To inspect after a session, attach a debugger and call `recent()`.
 
 ## Things we have not yet observed but expect
 

--- a/docs/ProtectedAPICallPolicy.md
+++ b/docs/ProtectedAPICallPolicy.md
@@ -8,17 +8,20 @@ This is an **architectural rule**, not a guideline.
 
 ## What is a "protected API call"?
 
-| Surface | Examples | TCC permission | Status in PR 1 |
+| Surface | Examples | TCC permission | Current status |
 |---|---|---|---|
-| Screen capture | `SCScreenshotManager`, `CGDisplayStream`, `CGWindowListCreateImage` | Screen Recording | **Active** — gated through `PermissionsGate` with `.screenRecording`. |
-| Accessibility tree | `AXUIElement*`, `AXObserver*` | Accessibility | **Active (PR 4)** — gated through `PermissionsGate` with `.accessibility`. PR 4 lands the permission check (`AXIsProcessTrusted`); the actual AX tree read lands in PR 5. |
+| Screen capture | `SCScreenshotManager`, `CGDisplayStream`, `CGWindowListCreateImage` | Screen Recording | **Active**. Gated through `PermissionsGate` with `.screenRecording`. |
+| Focused-window metadata | `AXUIElement*`, `AXObserver*` | Accessibility | **Active**. `AXService` consumes a `.accessibility` grant for frontmost app and focused-window metadata. |
 | Microphone | `AVAudioEngine`, `AVCaptureDevice` (audio) | Microphone | Future. Enum placeholder only. |
 | Apple Events / scripting | `NSAppleScript`, `OSAScript`, `appleScriptObjectSpecifier` | Apple Events / Automation | Future. Enum placeholder only. |
 | Keyboard/mouse synthesis | `CGEvent.post`, `CGEventTapCreate` | Input Monitoring / Accessibility | Future. Enum placeholder only. |
-| Subprocess execution | `Process()`, `posix_spawn`, `system()` | n/a (but treated as protected by `SafetyPolicy`) | Future. Not in PR 1. Will go through `SafeExecutor`. |
-| Clipboard write | `NSPasteboard.general.set*` | n/a (but treated as protected by `SafetyPolicy`) | Future. Not in PR 1. Will go through `ClipboardExecutor`. |
+| Subprocess execution | `Process()`, `posix_spawn`, `system()` | n/a (but treated as protected by `SafetyPolicy`) | Future. Will go through `SafeExecutor`. |
+| Clipboard write | `NSPasteboard.general.set*` | n/a (but treated as protected by `SafetyPolicy`) | Future. Will go through `ClipboardExecutor`. |
 
-For PR 4, Screen Recording and Accessibility are active. Microphone, Apple Events, and Input Monitoring remain future policy entries — their enum cases exist (so the gate has a complete vocabulary) but `PermissionsChecker` does not query them, and no service consumes their grants yet.
+Screen Recording and Accessibility are active. Microphone, Apple Events, and
+Input Monitoring remain future policy entries. Their enum cases exist so the
+gate has a complete vocabulary, but `PermissionsChecker` does not query them
+and no service consumes their grants yet.
 
 ## How the gate works
 
@@ -34,12 +37,15 @@ struct PermissionGrant {
 final class PermissionsGate {
     func withPermission<T>(
         _ kind: PermissionKind,
+        showMissingUI: Bool = true,
         operation: (PermissionGrant) async throws -> T
     ) async throws -> T {
         let status = await checker.status(for: kind)
 
         guard status == .granted else {
-            await permissionUI.showGate(for: kind)
+            if showMissingUI {
+                await permissionUI.showGate(for: kind)
+            }
             throw PermissionError.missing(kind)
         }
 
@@ -58,9 +64,10 @@ Two properties:
    without going through the gate, because the closure body
    `PermissionsGate.withPermission` runs is the only place a grant
    exists.
-2. **Single source of permission UI.** Missing permission always shows
-   the same `PermissionGateView`. There is no per-feature ad-hoc
-   "did you grant…" sheet.
+2. **Single source of permission UI.** Required missing permissions show
+   the same `PermissionGateView`. Optional context reads may pass
+   `showMissingUI: false` but still receive a grant only through the gate.
+   There is no per-feature ad-hoc "did you grant..." sheet.
 
 ## Required usage pattern
 

--- a/docs/ProtectedAPICallPolicy.md
+++ b/docs/ProtectedAPICallPolicy.md
@@ -11,17 +11,14 @@ This is an **architectural rule**, not a guideline.
 | Surface | Examples | TCC permission | Status in PR 1 |
 |---|---|---|---|
 | Screen capture | `SCScreenshotManager`, `CGDisplayStream`, `CGWindowListCreateImage` | Screen Recording | **Active** — gated through `PermissionsGate` with `.screenRecording`. |
-| Accessibility tree | `AXUIElement*`, `AXObserver*` | Accessibility | Future. Enum placeholder only; no real check yet. |
+| Accessibility tree | `AXUIElement*`, `AXObserver*` | Accessibility | **Active (PR 4)** — gated through `PermissionsGate` with `.accessibility`. PR 4 lands the permission check (`AXIsProcessTrusted`); the actual AX tree read lands in PR 5. |
 | Microphone | `AVAudioEngine`, `AVCaptureDevice` (audio) | Microphone | Future. Enum placeholder only. |
 | Apple Events / scripting | `NSAppleScript`, `OSAScript`, `appleScriptObjectSpecifier` | Apple Events / Automation | Future. Enum placeholder only. |
 | Keyboard/mouse synthesis | `CGEvent.post`, `CGEventTapCreate` | Input Monitoring / Accessibility | Future. Enum placeholder only. |
 | Subprocess execution | `Process()`, `posix_spawn`, `system()` | n/a (but treated as protected by `SafetyPolicy`) | Future. Not in PR 1. Will go through `SafeExecutor`. |
 | Clipboard write | `NSPasteboard.general.set*` | n/a (but treated as protected by `SafetyPolicy`) | Future. Not in PR 1. Will go through `ClipboardExecutor`. |
 
-For PR 1, only Screen Recording is active. The rest are future policy
-entries — their enum cases exist (so the gate has a complete vocabulary)
-but `PermissionsChecker` does not query them, and no service consumes
-their grants yet.
+For PR 4, Screen Recording and Accessibility are active. Microphone, Apple Events, and Input Monitoring remain future policy entries — their enum cases exist (so the gate has a complete vocabulary) but `PermissionsChecker` does not query them, and no service consumes their grants yet.
 
 ## How the gate works
 

--- a/docs/Week1Heartbeat.md
+++ b/docs/Week1Heartbeat.md
@@ -4,7 +4,7 @@
 
 The Week 1 heartbeat is the **only thing** Week 1 has to prove.
 
-```
+```text
 global hotkey
   → PermissionsGate
   → SCScreenshotManager.captureImage(contentFilter:configuration:)
@@ -102,7 +102,7 @@ AX work and starts in Week 2.
 
 The capture path **must** use:
 
-```
+```swift
 SCScreenshotManager.captureImage(contentFilter:configuration:)
 ```
 
@@ -111,7 +111,7 @@ overload is macOS 15.2+, and our deployment target is macOS 14.0+.
 
 ## What Week 1 explicitly excludes
 
-```
+```text
 No AI planner.
 No speech capture.
 No WhisperKit.

--- a/docs/Week1Heartbeat.md
+++ b/docs/Week1Heartbeat.md
@@ -1,5 +1,7 @@
 # Week 1 heartbeat
 
+> **Status (2026-04-26): heartbeat shipped in PR 2.** Hotkey ⌘⇧T → PermissionsGate.withPermission(.screenRecording) → SCScreenshotManager.captureImage → non-activating NSPanel HUD with the captured CGImage. See `docs/ManualTestChecklist.md` PR-2.* cases for verification.
+
 The Week 1 heartbeat is the **only thing** Week 1 has to prove.
 
 ```

--- a/docs/superpowers/plans/2026-04-25-pr1-cleanup.md
+++ b/docs/superpowers/plans/2026-04-25-pr1-cleanup.md
@@ -23,10 +23,12 @@
 - [ ] **Step 1: Verify the merge happened**
 
 Run:
+
 ```bash
 git fetch origin
 git log origin/develop --oneline | head -5
 ```
+
 Expected: the most recent commit on `origin/develop` is the merge commit from PR #14 (`Merge pull request #14 from ...`) sitting on top of the `0cc890b` review-addendum commit.
 
 - [ ] **Step 2: If not merged, stop and ask Ozzy to merge**
@@ -44,26 +46,32 @@ PR #14 must merge to `develop` before this cleanup PR makes sense — the cleanu
 - [ ] **Step 1: Switch to develop and pull**
 
 Run:
+
 ```bash
 git checkout develop
 git pull origin develop
 ```
+
 Expected: working tree clean, branch up to date.
 
 - [ ] **Step 2: Create the cleanup branch**
 
 Run:
+
 ```bash
 git checkout -b feature/pr1-cleanup
 ```
+
 Expected: `Switched to a new branch 'feature/pr1-cleanup'`.
 
 - [ ] **Step 3: Push the branch to set upstream**
 
 Run:
+
 ```bash
 git push -u origin feature/pr1-cleanup
 ```
+
 Expected: branch tracks `origin/feature/pr1-cleanup`.
 
 ---
@@ -73,6 +81,7 @@ Expected: branch tracks `origin/feature/pr1-cleanup`.
 ### Task 2: Rename `PermissionsCheckerProtocol` → `PermissionChecking`
 
 **Files:**
+
 - Modify: `TAELMacAgent/TAELMacAgent/Permissions/PermissionsChecker.swift`
 - Modify: `TAELMacAgent/TAELMacAgent/Permissions/PermissionsGate.swift`
 - Modify: `TAELMacAgent/TAELMacAgentTests/PermissionsGateTests.swift`
@@ -85,6 +94,7 @@ Expected: branch tracks `origin/feature/pr1-cleanup`.
 In `TAELMacAgent/TAELMacAgent/Permissions/PermissionsChecker.swift`:
 
 Replace:
+
 ```swift
 public protocol PermissionsCheckerProtocol: Sendable {
     func status(for kind: PermissionKind) async -> PermissionStatus
@@ -94,6 +104,7 @@ public final class PermissionsChecker: PermissionsCheckerProtocol {
 ```
 
 With:
+
 ```swift
 public protocol PermissionChecking: Sendable {
     func status(for kind: PermissionKind) async -> PermissionStatus
@@ -107,6 +118,7 @@ public final class PermissionsChecker: PermissionChecking {
 In `TAELMacAgent/TAELMacAgent/Permissions/PermissionsGate.swift`:
 
 Replace:
+
 ```swift
     private let checker: PermissionsCheckerProtocol
     private let permissionUI: PermissionGateUI
@@ -116,6 +128,7 @@ Replace:
 ```
 
 With:
+
 ```swift
     private let checker: PermissionChecking
     private let permissionUI: PermissionGateUI
@@ -129,11 +142,13 @@ With:
 In `TAELMacAgent/TAELMacAgentTests/PermissionsGateTests.swift`:
 
 Replace:
+
 ```swift
     private actor StubChecker: PermissionsCheckerProtocol {
 ```
 
 With:
+
 ```swift
     private actor StubChecker: PermissionChecking {
 ```
@@ -141,19 +156,23 @@ With:
 - [ ] **Step 4: Search for any straggling references**
 
 Run:
+
 ```bash
 grep -rn "PermissionsCheckerProtocol" TAELMacAgent/ docs/
 ```
+
 Expected: zero matches.
 
 - [ ] **Step 5: Build and test**
 
 Run:
+
 ```bash
 xcodebuild -project TAELMacAgent/TAELMacAgent.xcodeproj \
   -scheme TAELMacAgent -configuration Debug \
   -destination 'platform=macOS' CODE_SIGNING_ALLOWED=NO test
 ```
+
 Expected: BUILD SUCCEEDED, all 4 PermissionsGateTests pass.
 
 - [ ] **Step 6: Commit**
@@ -171,6 +190,7 @@ Ported from PR #15 dev-codex; mechanical refactor, no behavior change."
 ### Task 3: Rename `PermissionGateUI` → `PermissionGatePresenting` and `NoopPermissionGateUI` → `NoopPermissionGatePresenter`
 
 **Files:**
+
 - Modify: `TAELMacAgent/TAELMacAgent/Permissions/PermissionsGate.swift`
 - Modify: `TAELMacAgent/TAELMacAgent/HUD/HUDPanelController.swift`
 - Modify: `TAELMacAgent/TAELMacAgentTests/PermissionsGateTests.swift`
@@ -182,6 +202,7 @@ Ported from PR #15 dev-codex; mechanical refactor, no behavior change."
 In `TAELMacAgent/TAELMacAgent/Permissions/PermissionsGate.swift`:
 
 Replace:
+
 ```swift
 public protocol PermissionGateUI: Sendable {
     func showGate(for kind: PermissionKind) async
@@ -195,6 +216,7 @@ public struct NoopPermissionGateUI: PermissionGateUI {
 ```
 
 With:
+
 ```swift
 public protocol PermissionGatePresenting: Sendable {
     func showGate(for kind: PermissionKind) async
@@ -208,6 +230,7 @@ public struct NoopPermissionGatePresenter: PermissionGatePresenting {
 ```
 
 Then in the same file, replace:
+
 ```swift
     private let permissionUI: PermissionGateUI
 
@@ -218,6 +241,7 @@ Then in the same file, replace:
 ```
 
 With:
+
 ```swift
     private let permissionUI: PermissionGatePresenting
 
@@ -232,11 +256,13 @@ With:
 In `TAELMacAgent/TAELMacAgent/HUD/HUDPanelController.swift`:
 
 Replace:
+
 ```swift
 final class HUDPanelController: NSObject, PermissionGateUI {
 ```
 
 With:
+
 ```swift
 final class HUDPanelController: NSObject, PermissionGatePresenting {
 ```
@@ -244,6 +270,7 @@ final class HUDPanelController: NSObject, PermissionGatePresenting {
 Also update the doc comment header on the same file:
 
 Replace:
+
 ```swift
 //  Owns the non-activating NSPanel that hosts the HUD. Implements
 //  `PermissionGateUI` so `PermissionsGate` can route missing-permission
@@ -251,6 +278,7 @@ Replace:
 ```
 
 With:
+
 ```swift
 //  Owns the non-activating NSPanel that hosts the HUD. Implements
 //  `PermissionGatePresenting` so `PermissionsGate` can route missing-
@@ -262,11 +290,13 @@ With:
 In `TAELMacAgent/TAELMacAgentTests/PermissionsGateTests.swift`:
 
 Replace:
+
 ```swift
     private actor SpyUI: PermissionGateUI {
 ```
 
 With:
+
 ```swift
     private actor SpyUI: PermissionGatePresenting {
 ```
@@ -274,9 +304,11 @@ With:
 - [ ] **Step 4: Search for stragglers**
 
 Run:
+
 ```bash
 grep -rn "PermissionGateUI\|NoopPermissionGateUI" TAELMacAgent/ docs/
 ```
+
 Expected: zero matches.
 
 - [ ] **Step 5: Build and test**
@@ -286,6 +318,7 @@ xcodebuild -project TAELMacAgent/TAELMacAgent.xcodeproj \
   -scheme TAELMacAgent -configuration Debug \
   -destination 'platform=macOS' CODE_SIGNING_ALLOWED=NO test
 ```
+
 Expected: BUILD SUCCEEDED, all 4 PermissionsGateTests pass.
 
 - [ ] **Step 6: Commit**
@@ -306,6 +339,7 @@ naming symmetry. Ported from PR #15 dev-codex."
 ### Task 4: `PermissionsChecker` returns `.notDetermined` instead of `.denied` when preflight is false
 
 **Files:**
+
 - Modify: `TAELMacAgent/TAELMacAgent/Permissions/PermissionsChecker.swift`
 - Modify: `TAELMacAgent/TAELMacAgentTests/PermissionsGateTests.swift` (only if test names imply `.denied` semantics)
 
@@ -316,6 +350,7 @@ naming symmetry. Ported from PR #15 dev-codex."
 In `TAELMacAgent/TAELMacAgent/Permissions/PermissionsChecker.swift`:
 
 Replace:
+
 ```swift
     private func screenRecordingStatus() -> PermissionStatus {
         #if os(macOS)
@@ -339,6 +374,7 @@ Replace:
 ```
 
 With:
+
 ```swift
     private func screenRecordingStatus() -> PermissionStatus {
         #if os(macOS)
@@ -369,6 +405,7 @@ xcodebuild -project TAELMacAgent/TAELMacAgent.xcodeproj \
   -scheme TAELMacAgent -configuration Debug \
   -destination 'platform=macOS' CODE_SIGNING_ALLOWED=NO test
 ```
+
 Expected: BUILD SUCCEEDED, all 4 PermissionsGateTests pass. The `whenNotDetermined` test still exercises the new return value's gate path; the `whenDenied` test still uses an explicit `.denied` injection from the stub, so it continues to test the gate's `guard status == .granted` correctly.
 
 - [ ] **Step 3: Commit**
@@ -390,6 +427,7 @@ PR #15 dev-codex (semantic fix only, naming stays this PR's)."
 ### Task 5: Drop `PermissionGrant: Hashable` → `Equatable`
 
 **Files:**
+
 - Modify: `TAELMacAgent/TAELMacAgent/Permissions/PermissionsGate.swift`
 
 **Why:** Type-design-analyzer flagged: `Hashable` invites a `Set<PermissionGrant>` caching anti-pattern that the policy doc explicitly bans (don't "remember" grants). `Equatable` is enough for tests and error comparisons.
@@ -399,6 +437,7 @@ PR #15 dev-codex (semantic fix only, naming stays this PR's)."
 In `TAELMacAgent/TAELMacAgent/Permissions/PermissionsGate.swift`:
 
 Replace:
+
 ```swift
 public struct PermissionGrant: Sendable, Hashable {
     public let kind: PermissionKind
@@ -410,6 +449,7 @@ public struct PermissionGrant: Sendable, Hashable {
 ```
 
 With:
+
 ```swift
 public struct PermissionGrant: Sendable, Equatable {
     public let kind: PermissionKind
@@ -427,6 +467,7 @@ xcodebuild -project TAELMacAgent/TAELMacAgent.xcodeproj \
   -scheme TAELMacAgent -configuration Debug \
   -destination 'platform=macOS' CODE_SIGNING_ALLOWED=NO test
 ```
+
 Expected: BUILD SUCCEEDED, all tests pass. If a consumer relied on `Hashable`, the build will fail and the offending consumer should be reviewed (likely an unintentional `Set<PermissionGrant>`).
 
 - [ ] **Step 3: Commit**
@@ -447,6 +488,7 @@ sufficient for tests and PermissionError equality."
 ### Task 6: Throw `PermissionError.notImplemented(kind)` for unimplemented kinds (TDD)
 
 **Files:**
+
 - Modify: `TAELMacAgent/TAELMacAgent/Permissions/PermissionsGate.swift`
 - Modify: `TAELMacAgent/TAELMacAgentTests/PermissionsGateTests.swift`
 
@@ -487,6 +529,7 @@ In `TAELMacAgent/TAELMacAgentTests/PermissionsGateTests.swift`, add a new test m
 - [ ] **Step 2: Run the test and confirm it fails**
 
 Run:
+
 ```bash
 xcodebuild test \
   -project TAELMacAgent/TAELMacAgent.xcodeproj \
@@ -495,6 +538,7 @@ xcodebuild test \
   CODE_SIGNING_ALLOWED=NO \
   -only-testing:TAELMacAgentTests/PermissionsGateTests/test_withPermission_whenKindNotImplemented_throwsNotImplemented_andDoesNotShowGate
 ```
+
 Expected: FAIL — current code throws `.missing(.microphone)` and shows the gate UI, not `.notImplemented`.
 
 - [ ] **Step 3: Update `withPermission` to short-circuit unimplemented kinds**
@@ -502,6 +546,7 @@ Expected: FAIL — current code throws `.missing(.microphone)` and shows the gat
 In `TAELMacAgent/TAELMacAgent/Permissions/PermissionsGate.swift`:
 
 Replace:
+
 ```swift
     @discardableResult
     public func withPermission<T>(
@@ -520,6 +565,7 @@ Replace:
 ```
 
 With:
+
 ```swift
     @discardableResult
     public func withPermission<T>(
@@ -557,6 +603,7 @@ xcodebuild -project TAELMacAgent/TAELMacAgent.xcodeproj \
   -scheme TAELMacAgent -configuration Debug \
   -destination 'platform=macOS' CODE_SIGNING_ALLOWED=NO test
 ```
+
 Expected: BUILD SUCCEEDED, 5 PermissionsGateTests pass (4 existing + 1 new).
 
 - [ ] **Step 6: Commit**
@@ -579,6 +626,7 @@ case already existed in PermissionError but was unreachable."
 ### Task 7: Wire `PermissionGateView` Cancel button to `HUDPanelController.tearDown()`
 
 **Files:**
+
 - Modify: `TAELMacAgent/TAELMacAgent/HUD/PermissionGateView.swift`
 - Modify: `TAELMacAgent/TAELMacAgent/HUD/HUDPanelController.swift`
 
@@ -589,6 +637,7 @@ case already existed in PermissionError but was unreachable."
 In `TAELMacAgent/TAELMacAgent/HUD/PermissionGateView.swift`:
 
 Replace:
+
 ```swift
 struct PermissionGateView: View {
     let kind: PermissionKind
@@ -597,6 +646,7 @@ struct PermissionGateView: View {
 ```
 
 With:
+
 ```swift
 struct PermissionGateView: View {
     let kind: PermissionKind
@@ -606,6 +656,7 @@ struct PermissionGateView: View {
 ```
 
 Then replace:
+
 ```swift
                 Button("Cancel") {
                     NSApp.keyWindow?.close()
@@ -613,6 +664,7 @@ Then replace:
 ```
 
 With:
+
 ```swift
                 Button("Cancel") {
                     onCancel()
@@ -624,6 +676,7 @@ With:
 In `TAELMacAgent/TAELMacAgent/HUD/HUDPanelController.swift`:
 
 Replace:
+
 ```swift
     nonisolated func showGate(for kind: PermissionKind) async {
         await MainActor.run {
@@ -633,6 +686,7 @@ Replace:
 ```
 
 With:
+
 ```swift
     nonisolated func showGate(for kind: PermissionKind) async {
         await MainActor.run {
@@ -650,6 +704,7 @@ xcodebuild -project TAELMacAgent/TAELMacAgent.xcodeproj \
   -scheme TAELMacAgent -configuration Debug \
   -destination 'platform=macOS' CODE_SIGNING_ALLOWED=NO build
 ```
+
 Expected: BUILD SUCCEEDED.
 
 The "Show HUD (placeholder)" menu calls `showPlaceholder()` which uses `HUDView()`, not `PermissionGateView`, so no other call sites need updating.
@@ -661,6 +716,7 @@ xcodebuild -project TAELMacAgent/TAELMacAgent.xcodeproj \
   -scheme TAELMacAgent -configuration Debug \
   -destination 'platform=macOS' CODE_SIGNING_ALLOWED=NO test
 ```
+
 Expected: BUILD SUCCEEDED, all tests pass (no test for the SwiftUI button itself; manual verification follows in PR review).
 
 - [ ] **Step 5: Commit**
@@ -681,6 +737,7 @@ path through the controller's lifecycle."
 ### Task 8: Panel style mask back to v0.3 §23.11 spec
 
 **Files:**
+
 - Modify: `TAELMacAgent/TAELMacAgent/HUD/HUDPanelController.swift`
 
 **Why:** Comment-analyzer flagged: code uses `[.titled, .closable, .nonactivatingPanel, .utilityWindow, .hudWindow]` but v0.3 §23.11 mandates `[.nonactivatingPanel, .borderless]` plus explicit `isReleasedWhenClosed = false` and `collectionBehavior = [.canJoinAllSpaces, .fullScreenAuxiliary, .transient]`. Bring back to spec; the existing `.titled, .closable` was added presumably for the (now-broken) Cancel-button-via-titlebar path that Task 7 already fixed properly.
@@ -690,6 +747,7 @@ path through the controller's lifecycle."
 In `TAELMacAgent/TAELMacAgent/HUD/HUDPanelController.swift`:
 
 Replace:
+
 ```swift
     private func makePanel<Content: View>(content: Content) -> NSPanel {
         let host = NSHostingController(rootView: AnyView(content))
@@ -713,6 +771,7 @@ Replace:
 ```
 
 With:
+
 ```swift
     private func makePanel<Content: View>(content: Content) -> NSPanel {
         let host = NSHostingController(rootView: AnyView(content))
@@ -747,6 +806,7 @@ xcodebuild -project TAELMacAgent/TAELMacAgent.xcodeproj \
   -scheme TAELMacAgent -configuration Debug \
   -destination 'platform=macOS' CODE_SIGNING_ALLOWED=NO build
 ```
+
 Expected: BUILD SUCCEEDED. (No `.title` setter line because borderless panels don't render a titlebar.)
 
 - [ ] **Step 3: Run tests**
@@ -756,6 +816,7 @@ xcodebuild -project TAELMacAgent/TAELMacAgent.xcodeproj \
   -scheme TAELMacAgent -configuration Debug \
   -destination 'platform=macOS' CODE_SIGNING_ALLOWED=NO test
 ```
+
 Expected: all tests pass.
 
 - [ ] **Step 4: Commit**
@@ -778,6 +839,7 @@ the broken titlebar-Cancel path that Task 7 fixed properly."
 ### Task 9: `LocalLogService` overflow signal (TDD)
 
 **Files:**
+
 - Modify: `TAELMacAgent/TAELMacAgent/Logging/LocalLogService.swift`
 - Create: `TAELMacAgent/TAELMacAgentTests/LocalLogServiceTests.swift`
 
@@ -858,6 +920,7 @@ xcodebuild test \
   CODE_SIGNING_ALLOWED=NO \
   -only-testing:TAELMacAgentTests/LocalLogServiceTests
 ```
+
 Expected: FAIL — `droppedCount` doesn't exist on `LocalLogService`.
 
 - [ ] **Step 3: Update `LocalLogService` with `droppedCount` and `os_log` signal**
@@ -933,6 +996,7 @@ xcodebuild -project TAELMacAgent/TAELMacAgent.xcodeproj \
   -scheme TAELMacAgent -configuration Debug \
   -destination 'platform=macOS' CODE_SIGNING_ALLOWED=NO test
 ```
+
 Expected: BUILD SUCCEEDED, all tests pass (existing 5 + new 3 = 8 total).
 
 - [ ] **Step 6: Commit**
@@ -956,6 +1020,7 @@ clear() does NOT reset droppedCount; it's a session metric."
 ### Task 10: Fix `reset-tcc-dev.sh` `set -e` interaction with command substitution
 
 **Files:**
+
 - Modify: `scripts/reset-tcc-dev.sh`
 
 **Why:** Code-reviewer + silent-failure-hunter both flagged: with `set -euo pipefail`, the script aborts on the FIRST `tccutil` non-zero exit because `output=$("${cmd[@]}" 2>&1)` triggers `set -e`. Lines 73-87 (the benign-vs-real distinguishing logic) are dead code; the `Done.` on line 97 never prints either.
@@ -965,6 +1030,7 @@ clear() does NOT reset droppedCount; it's a session metric."
 In `scripts/reset-tcc-dev.sh`, find the loop body (around lines 67-87):
 
 Replace:
+
 ```bash
   echo "running:   ${cmd[*]}"
   # We capture combined output and the exit code so we can distinguish
@@ -990,6 +1056,7 @@ Replace:
 ```
 
 With:
+
 ```bash
   echo "running:   ${cmd[*]}"
   # We capture combined output and the exit code so we can distinguish
@@ -1020,17 +1087,21 @@ With:
 - [ ] **Step 2: Verify the script syntax**
 
 Run:
+
 ```bash
 bash -n scripts/reset-tcc-dev.sh && echo OK
 ```
+
 Expected: `OK` (no syntax errors).
 
 - [ ] **Step 3: Dry-run to confirm the loop iterates all services**
 
 Run:
+
 ```bash
 ./scripts/reset-tcc-dev.sh --dry-run
 ```
+
 Expected: prints "would run: ..." for all 5 services, no early exit.
 
 - [ ] **Step 4: Commit**
@@ -1055,6 +1126,7 @@ Found by pr-review-toolkit code-reviewer pass on PR #14."
 ### Task 11: Sync `ProtectedAPICallPolicy.md` and `Week1Heartbeat.md` snippets to current closure shape
 
 **Files:**
+
 - Modify: `docs/ProtectedAPICallPolicy.md`
 - Modify: `docs/Week1Heartbeat.md`
 
@@ -1063,9 +1135,11 @@ Found by pr-review-toolkit code-reviewer pass on PR #14."
 - [ ] **Step 1: Read both docs to find the stale snippets**
 
 Run:
+
 ```bash
 grep -n "@escaping\|CGImage" docs/ProtectedAPICallPolicy.md docs/Week1Heartbeat.md
 ```
+
 Expected: a handful of matches in each file.
 
 - [ ] **Step 2: Update `docs/ProtectedAPICallPolicy.md`**
@@ -1088,6 +1162,7 @@ Same pattern as Step 2: walk every code block and bring it in sync with the curr
 grep -n "@escaping\|CGImage\|PermissionsCheckerProtocol\|PermissionGateUI\|NoopPermissionGateUI" \
   docs/ProtectedAPICallPolicy.md docs/Week1Heartbeat.md docs/Architecture.md docs/PermissionNotes.md
 ```
+
 Expected: zero matches.
 
 - [ ] **Step 5: Commit**
@@ -1120,6 +1195,7 @@ xcodebuild -project TAELMacAgent/TAELMacAgent.xcodeproj \
   -scheme TAELMacAgent -configuration Debug \
   -destination 'platform=macOS' CODE_SIGNING_ALLOWED=NO clean test
 ```
+
 Expected: BUILD SUCCEEDED, all 8 tests pass (5 PermissionsGateTests + 3 LocalLogServiceTests).
 
 - [ ] **Step 2: Confirm the branch is ahead of develop with one commit per task**
@@ -1127,6 +1203,7 @@ Expected: BUILD SUCCEEDED, all 8 tests pass (5 PermissionsGateTests + 3 LocalLog
 ```bash
 git log origin/develop..HEAD --oneline
 ```
+
 Expected: 10 commits (Tasks 2–11), in order, conventional-commit format.
 
 - [ ] **Step 3: Push the branch**
@@ -1178,6 +1255,7 @@ Applies the 11 items from the pr-review-toolkit pass on PR #14 (see \`docs/PR1_r
 EOF
 )"
 ```
+
 Expected: PR URL printed.
 
 - [ ] **Step 5: Notify Ozzy in chat**

--- a/docs/superpowers/plans/2026-04-26-pr2-week1-heartbeat.md
+++ b/docs/superpowers/plans/2026-04-26-pr2-week1-heartbeat.md
@@ -25,6 +25,7 @@ git checkout develop && git pull origin develop && \
   git checkout -b feature/pr2-week1-heartbeat && \
   git push -u origin feature/pr2-week1-heartbeat
 ```
+
 Expected: `Switched to a new branch 'feature/pr2-week1-heartbeat'`, branch tracks origin.
 
 ---
@@ -34,6 +35,7 @@ Expected: `Switched to a new branch 'feature/pr2-week1-heartbeat'`, branch track
 ### Task 1: Add `KeyboardShortcuts` SPM dependency via XcodeGen
 
 **Files:**
+
 - Modify: `TAELMacAgent/project.yml`
 - Modify (regenerated): `TAELMacAgent/TAELMacAgent.xcodeproj/project.pbxproj`
 - Modify (created by Xcode/SPM resolve): `TAELMacAgent/TAELMacAgent.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved`
@@ -72,6 +74,7 @@ Then in the `targets.TAELMacAgent` block, add a `dependencies` key:
 ```bash
 command -v xcodegen >/dev/null && echo OK || brew install xcodegen
 ```
+
 Expected: `OK`, or `xcodegen` installed via Homebrew.
 
 - [ ] **Step 3: Regenerate `.xcodeproj`**
@@ -79,6 +82,7 @@ Expected: `OK`, or `xcodegen` installed via Homebrew.
 ```bash
 make xcodeproj
 ```
+
 Expected: XcodeGen prints `Created project at ...TAELMacAgent.xcodeproj`. The pbxproj will now include the package reference, product dependency, and Frameworks build phase entry.
 
 - [ ] **Step 4: Resolve SPM dependencies**
@@ -86,6 +90,7 @@ Expected: XcodeGen prints `Created project at ...TAELMacAgent.xcodeproj`. The pb
 ```bash
 xcodebuild -project TAELMacAgent/TAELMacAgent.xcodeproj -resolvePackageDependencies
 ```
+
 Expected: `Resolved source packages`. Creates/updates `Package.resolved`.
 
 - [ ] **Step 5: Build to confirm KeyboardShortcuts links cleanly**
@@ -95,6 +100,7 @@ xcodebuild -project TAELMacAgent/TAELMacAgent.xcodeproj \
   -scheme TAELMacAgent -configuration Debug \
   -destination 'platform=macOS' CODE_SIGNING_ALLOWED=NO build
 ```
+
 Expected: BUILD SUCCEEDED. No source code uses `KeyboardShortcuts` yet, but the link should succeed.
 
 - [ ] **Step 6: Commit**
@@ -119,6 +125,7 @@ Regenerated pbxproj via 'make xcodeproj' (XcodeGen)."
 ### Task 2: Define `DisplayScreenshotCapturing` protocol and conform `ScreenCaptureService`
 
 **Files:**
+
 - Modify: `TAELMacAgent/TAELMacAgent/Capture/ScreenCaptureService.swift`
 
 **Why:** the hotkey wire-up in Task 6 needs to be unit-testable, but the real `ScreenCaptureService` requires TCC Screen Recording grant. A thin protocol lets Task 7's tests inject a mock without touching ScreenCaptureKit. **Do NOT pull the type into a separate file** — keep it co-located with the service per the same file-locality principle that protects `PermissionGrant` from forgery (the protocol+default is the public surface; the implementation stays one read away).
@@ -180,6 +187,7 @@ xcodebuild -project TAELMacAgent/TAELMacAgent.xcodeproj \
   -scheme TAELMacAgent -configuration Debug \
   -destination 'platform=macOS' CODE_SIGNING_ALLOWED=NO test
 ```
+
 Expected: BUILD SUCCEEDED, all 8 existing tests still pass. The protocol extraction is a refactor — behavior is unchanged.
 
 - [ ] **Step 4: Commit**
@@ -201,6 +209,7 @@ Type stays co-located with the service per file-locality discipline."
 ### Task 3: Replace `notImplemented` stub with real `SCScreenshotManager` capture
 
 **Files:**
+
 - Modify: `TAELMacAgent/TAELMacAgent/Capture/ScreenCaptureService.swift`
 
 **Why:** ticket 8. Replace the stub body. The PR 2 outline comment in the file already describes the shape; this task fills it in.
@@ -349,6 +358,7 @@ xcodebuild -project TAELMacAgent/TAELMacAgent.xcodeproj \
   -scheme TAELMacAgent -configuration Debug \
   -destination 'platform=macOS' CODE_SIGNING_ALLOWED=NO test
 ```
+
 Expected: BUILD SUCCEEDED, all 8 existing tests still pass. The body change is not exercised by any current test (it's the production capture path).
 
 - [ ] **Step 6: Commit**
@@ -376,6 +386,7 @@ Manual verification via 'make run' after Task 6 wires the hotkey."
 ### Task 4: Add `KeyboardShortcuts.Name` extension
 
 **Files:**
+
 - Create: `TAELMacAgent/TAELMacAgent/Hotkey/HotkeyName.swift`
 
 **Why:** the KeyboardShortcuts API requires shortcut names declared as `KeyboardShortcuts.Name` static properties. Co-locate the name in its own small file under `Hotkey/` so it's findable.
@@ -423,6 +434,7 @@ xcodebuild -project TAELMacAgent/TAELMacAgent.xcodeproj \
   -scheme TAELMacAgent -configuration Debug \
   -destination 'platform=macOS' CODE_SIGNING_ALLOWED=NO build
 ```
+
 Expected: BUILD SUCCEEDED.
 
 - [ ] **Step 4: Commit**
@@ -441,6 +453,7 @@ via KeyboardShortcuts.onKeyDown."
 ### Task 5: Replace `HotkeyManager` placeholder with real registration
 
 **Files:**
+
 - Modify: `TAELMacAgent/TAELMacAgent/Hotkey/HotkeyManager.swift`
 
 **Why:** ticket 6. Currently `installPlaceholderBinding()` is a no-op; PR 2 wires it through `KeyboardShortcuts.onKeyDown(for:)`.
@@ -490,6 +503,7 @@ xcodebuild -project TAELMacAgent/TAELMacAgent.xcodeproj \
   -scheme TAELMacAgent -configuration Debug \
   -destination 'platform=macOS' CODE_SIGNING_ALLOWED=NO build
 ```
+
 Expected: BUILD SUCCEEDED. There's still a call site in `AppDelegate` to `installPlaceholderBinding()` that no longer exists — Task 6 fixes it. If you want a passing build between tasks, temporarily rename the call site too; otherwise commit Task 5 + Task 6 together.
 
 **Decision:** for cleaner per-task commits, keep `installPlaceholderBinding` as a deprecated alias that just calls `installBinding`. Replace Step 1's file with this version instead:
@@ -545,6 +559,7 @@ xcodebuild -project TAELMacAgent/TAELMacAgent.xcodeproj \
   -scheme TAELMacAgent -configuration Debug \
   -destination 'platform=macOS' CODE_SIGNING_ALLOWED=NO test
 ```
+
 Expected: 8 tests pass.
 
 - [ ] **Step 4: Commit**
@@ -568,6 +583,7 @@ commit's build green; removed when AppDelegate updates in Task 6."
 ### Task 6: Wire `AppDelegate` — hotkey → gate → capture → HUD + log
 
 **Files:**
+
 - Modify: `TAELMacAgent/TAELMacAgent/App/AppDelegate.swift`
 
 **Why:** ticket 9. This is the heartbeat itself. The closure assigned to `hotkeyManager.onTrigger` runs the gate, captures, presents to HUD, records a log row.
@@ -705,6 +721,7 @@ xcodebuild -project TAELMacAgent/TAELMacAgent.xcodeproj \
   -scheme TAELMacAgent -configuration Debug \
   -destination 'platform=macOS' CODE_SIGNING_ALLOWED=NO build
 ```
+
 Expected: BUILD SUCCEEDED, no deprecation warning. The change references `installBinding()` (Task 5) and a new `hudController.present(screenshot:)` method (added in Task 7).
 
 **Will fail at this point** — `HUDPanelController.present(screenshot:)` doesn't exist yet. That's expected; the next task adds it. **Do not commit Task 6 alone.** Commit Task 6 + Task 7 together OR add a stub `present(screenshot:)` to HUDPanelController in this commit and flesh it out in Task 7.
@@ -730,6 +747,7 @@ xcodebuild -project TAELMacAgent/TAELMacAgent.xcodeproj \
   -scheme TAELMacAgent -configuration Debug \
   -destination 'platform=macOS' CODE_SIGNING_ALLOWED=NO test
 ```
+
 Expected: 8 tests pass.
 
 - [ ] **Step 4: Commit**
@@ -759,6 +777,7 @@ as a stub; Task 7 fleshes out the real screenshot rendering."
 ### Task 7: HUD screenshot rendering
 
 **Files:**
+
 - Create: `TAELMacAgent/TAELMacAgent/HUD/HUDScreenshotView.swift`
 - Modify: `TAELMacAgent/TAELMacAgent/HUD/HUDPanelController.swift`
 
@@ -830,6 +849,7 @@ xcodebuild -project TAELMacAgent/TAELMacAgent.xcodeproj \
   -scheme TAELMacAgent -configuration Debug \
   -destination 'platform=macOS' CODE_SIGNING_ALLOWED=NO build
 ```
+
 Expected: BUILD SUCCEEDED.
 
 - [ ] **Step 4: Run tests**
@@ -839,6 +859,7 @@ xcodebuild -project TAELMacAgent/TAELMacAgent.xcodeproj \
   -scheme TAELMacAgent -configuration Debug \
   -destination 'platform=macOS' CODE_SIGNING_ALLOWED=NO test
 ```
+
 Expected: 8 tests pass.
 
 - [ ] **Step 5: Commit**
@@ -863,11 +884,13 @@ HUDPanelController.present(screenshot:) replaces the Task 6 stub."
 ### Task 8: Wire-up tests via `DisplayScreenshotCapturing` mock (TDD)
 
 **Files:**
+
 - Create: `TAELMacAgent/TAELMacAgentTests/HotkeyHandlerTests.swift`
 
 **Why:** the hotkey path orchestrates four collaborators (gate, capture service, HUD, log). Without tests, regressions in the wire-up only surface in manual testing. The `DisplayScreenshotCapturing` protocol from Task 2 makes this mockable. Tests live in their own file because they exercise a different surface than `PermissionsGateTests`.
 
 **Caveat:** `AppDelegate.handleHotkeyInvocation` is `private`. Two options:
+
 1. Make it `internal` and `@testable import` — simpler but expands the API.
 2. Extract the body into a free function or a small `HotkeyInvocationHandler` type that AppDelegate composes — testable in isolation, no privacy widening.
 
@@ -1148,6 +1171,7 @@ xcodebuild test \
   CODE_SIGNING_ALLOWED=NO \
   -only-testing:TAELMacAgentTests/HotkeyHandlerTests
 ```
+
 Expected: 3 tests pass.
 
 - [ ] **Step 5: Run the full suite**
@@ -1157,6 +1181,7 @@ xcodebuild -project TAELMacAgent/TAELMacAgent.xcodeproj \
   -scheme TAELMacAgent -configuration Debug \
   -destination 'platform=macOS' CODE_SIGNING_ALLOWED=NO test
 ```
+
 Expected: 11 tests pass (5 PermissionsGate + 3 LocalLogService + 3 HotkeyHandler).
 
 - [ ] **Step 6: Commit**
@@ -1185,6 +1210,7 @@ capture-failure (no present, log errored)."
 ### Task 9: Remove the `installPlaceholderBinding` deprecated alias
 
 **Files:**
+
 - Modify: `TAELMacAgent/TAELMacAgent/Hotkey/HotkeyManager.swift`
 
 **Why:** Task 5's deprecated alias was scaffolding for clean per-task commits. Now that `AppDelegate` calls `installBinding()` directly (Task 6), the alias is dead.
@@ -1205,6 +1231,7 @@ In `TAELMacAgent/TAELMacAgent/Hotkey/HotkeyManager.swift`, delete:
 ```bash
 grep -rn "installPlaceholderBinding" TAELMacAgent/
 ```
+
 Expected: zero matches.
 
 - [ ] **Step 3: Build and test**
@@ -1214,6 +1241,7 @@ xcodebuild -project TAELMacAgent/TAELMacAgent.xcodeproj \
   -scheme TAELMacAgent -configuration Debug \
   -destination 'platform=macOS' CODE_SIGNING_ALLOWED=NO test
 ```
+
 Expected: 11 tests pass, no warnings.
 
 - [ ] **Step 4: Commit**
@@ -1233,6 +1261,7 @@ Task 6 updated the AppDelegate call site. Both tasks have landed."
 ### Task 10: Update `ManualTestChecklist.md` and `Week1Heartbeat.md`
 
 **Files:**
+
 - Modify: `docs/ManualTestChecklist.md`
 - Modify: `docs/Week1Heartbeat.md`
 
@@ -1324,6 +1353,7 @@ xcodebuild -project TAELMacAgent/TAELMacAgent.xcodeproj \
   -scheme TAELMacAgent -configuration Debug \
   -destination 'platform=macOS' CODE_SIGNING_ALLOWED=NO clean test
 ```
+
 Expected: 11 tests pass.
 
 - [ ] **Step 2: Confirm the branch is ahead of develop**
@@ -1331,6 +1361,7 @@ Expected: 11 tests pass.
 ```bash
 git log origin/develop..HEAD --oneline
 ```
+
 Expected: 10 commits (Task 1 + Tasks 2–10), one per task, conventional-commit format.
 
 - [ ] **Step 3: Push**
@@ -1386,6 +1417,7 @@ Plan: \`docs/superpowers/plans/2026-04-26-pr2-week1-heartbeat.md\`. Codex-driven
 EOF
 )"
 ```
+
 Expected: PR URL printed. Notify Ozzy.
 
 ---
@@ -1395,12 +1427,14 @@ Expected: PR URL printed. Notify Ozzy.
 After writing the plan and before handing off:
 
 **1. Spec coverage:**
+
 - v0.3 §12.2 Week 1 deliverables: menubar app ✓ (PR 1), KeyboardShortcuts (Task 1), global hotkey works (Tasks 4–6), PermissionsChecker (PR 1), PermissionsGate (PR 1), Screen Recording gate (PR 1 + Task 6 wire-up), Week 1 screenshot target (Task 3 cursor + fallback), SCScreenshotManager.captureImage (Task 3), explicit width/height (Task 3 backingScaleFactor), NSPanel HUD displays image (Task 7). All covered.
 - v0.3 §23.5 first-13 tickets: 6 (KeyboardShortcuts) → Tasks 1, 4, 5; 8 (ScreenCaptureService real) → Task 3; 9 (wire-up) → Task 6; 10 (HUD render) → Task 7; 11 (InvocationLog) → Task 6 wire + records via logService. All covered.
 
 **2. Placeholder scan:** No "TBD", "implement later", "add appropriate error handling" patterns. Each step has concrete code or commands.
 
 **3. Type consistency:**
+
 - `DisplayScreenshotCapturing` is the protocol name in Tasks 2, 3, 6, 8. ✓
 - `KeyboardShortcuts.Name.toggleTAEL` declared in Task 4, used in Task 5. ✓
 - `HotkeyInvocationHandler` introduced in Task 8 (extraction); `AppDelegate.handleHotkeyInvocation` from Task 6 is replaced by the handler — Task 8 explicitly removes it. ✓

--- a/docs/superpowers/plans/2026-04-26-pr2-week1-heartbeat.md
+++ b/docs/superpowers/plans/2026-04-26-pr2-week1-heartbeat.md
@@ -1,0 +1,1421 @@
+# PR 2 — Week 1 Heartbeat Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use `superpowers:subagent-driven-development` (recommended) or `superpowers:executing-plans`. Steps use checkbox (`- [ ]`) syntax. **Project-specific:** "subagent" maps to Codex via the `agent-codex:codex` skill; Claude Opus 4.7 reviews each commit. Tasks 1 (SPM dep) and 11 (PR creation) are maestro-only because Codex's sandbox blocks network and `gh` writes.
+
+**Goal:** Ship the Week 1 heartbeat — `global hotkey → PermissionsGate → SCScreenshotManager → non-activating NSPanel HUD with screenshot PNG`. This is the loop v0.3 §1 calls "the first product heartbeat."
+
+**Architecture:** Replace PR 1's typed stubs with real implementations. Add `KeyboardShortcuts` SPM dependency. Wire `AppDelegate` so the hotkey closure runs `permissionsGate.withPermission(.screenRecording) { grant in screenCaptureService.captureDisplayScreenshot(grant) }` and presents the result via `HUDPanelController`. Introduce a thin `DisplayScreenshotCapturing` protocol so the wire-up is unit-testable without TCC. Populate `LocalLogService` per invocation with `InvocationLog` rows including latency.
+
+**Tech stack:** Swift 5.10, ScreenCaptureKit (`SCShareableContent`, `SCContentFilter`, `SCStreamConfiguration`, `SCScreenshotManager.captureImage(contentFilter:configuration:)`), KeyboardShortcuts package (`sindresorhus/KeyboardShortcuts`), AppKit + SwiftUI, XCTest, XcodeGen for SPM dep regen, macOS 14.0+, Xcode 16+.
+
+**Spec sources:** `TAEL_AI_mac_agent_build_plan_v0_3.md` §12.2 (Week 1 milestone), §23.10 (ScreenCaptureKit notes), §23.11 (HUD defaults), §23.5 first-13 tickets 6–11.
+
+---
+
+## Pre-flight
+
+### Task 0: Branch off develop
+
+**Files:** none
+
+- [ ] **Step 1: Sync develop and create feature branch**
+
+```bash
+git checkout develop && git pull origin develop && \
+  git checkout -b feature/pr2-week1-heartbeat && \
+  git push -u origin feature/pr2-week1-heartbeat
+```
+Expected: `Switched to a new branch 'feature/pr2-week1-heartbeat'`, branch tracks origin.
+
+---
+
+## Add the SPM dependency (maestro only)
+
+### Task 1: Add `KeyboardShortcuts` SPM dependency via XcodeGen
+
+**Files:**
+- Modify: `TAELMacAgent/project.yml`
+- Modify (regenerated): `TAELMacAgent/TAELMacAgent.xcodeproj/project.pbxproj`
+- Modify (created by Xcode/SPM resolve): `TAELMacAgent/TAELMacAgent.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved`
+
+**Why maestro-only:** SPM resolution needs network access; Codex's `workspace-write` sandbox blocks outbound requests. Also, `xcodegen` may not be in Codex's PATH. Maestro runs this; Codex resumes from Task 2.
+
+- [ ] **Step 1: Add packages and dependency to `project.yml`**
+
+In `TAELMacAgent/project.yml`, after the `options:` block and before `settings:`, add:
+
+```yaml
+packages:
+  KeyboardShortcuts:
+    url: https://github.com/sindresorhus/KeyboardShortcuts
+    from: "2.0.0"
+```
+
+Then in the `targets.TAELMacAgent` block, add a `dependencies` key:
+
+```yaml
+  TAELMacAgent:
+    type: application
+    platform: macOS
+    deploymentTarget: "14.0"
+    dependencies:
+      - package: KeyboardShortcuts
+    sources:
+      - path: TAELMacAgent
+        excludes:
+          - "Resources/Info.plist"
+          - "Resources/TAELMacAgent.entitlements"
+```
+
+- [ ] **Step 2: Confirm xcodegen is installed**
+
+```bash
+command -v xcodegen >/dev/null && echo OK || brew install xcodegen
+```
+Expected: `OK`, or `xcodegen` installed via Homebrew.
+
+- [ ] **Step 3: Regenerate `.xcodeproj`**
+
+```bash
+make xcodeproj
+```
+Expected: XcodeGen prints `Created project at ...TAELMacAgent.xcodeproj`. The pbxproj will now include the package reference, product dependency, and Frameworks build phase entry.
+
+- [ ] **Step 4: Resolve SPM dependencies**
+
+```bash
+xcodebuild -project TAELMacAgent/TAELMacAgent.xcodeproj -resolvePackageDependencies
+```
+Expected: `Resolved source packages`. Creates/updates `Package.resolved`.
+
+- [ ] **Step 5: Build to confirm KeyboardShortcuts links cleanly**
+
+```bash
+xcodebuild -project TAELMacAgent/TAELMacAgent.xcodeproj \
+  -scheme TAELMacAgent -configuration Debug \
+  -destination 'platform=macOS' CODE_SIGNING_ALLOWED=NO build
+```
+Expected: BUILD SUCCEEDED. No source code uses `KeyboardShortcuts` yet, but the link should succeed.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add TAELMacAgent/project.yml \
+        TAELMacAgent/TAELMacAgent.xcodeproj/project.pbxproj \
+        TAELMacAgent/TAELMacAgent.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+git commit -m "chore(deps): add KeyboardShortcuts SPM package
+
+sindresorhus/KeyboardShortcuts at >= 2.0.0. Used in PR 2 to register
+the global hotkey via Carbon HotKey APIs. No source code yet uses it;
+the wire-up lands in Task 6.
+
+Regenerated pbxproj via 'make xcodeproj' (XcodeGen)."
+```
+
+---
+
+## Testability seam
+
+### Task 2: Define `DisplayScreenshotCapturing` protocol and conform `ScreenCaptureService`
+
+**Files:**
+- Modify: `TAELMacAgent/TAELMacAgent/Capture/ScreenCaptureService.swift`
+
+**Why:** the hotkey wire-up in Task 6 needs to be unit-testable, but the real `ScreenCaptureService` requires TCC Screen Recording grant. A thin protocol lets Task 7's tests inject a mock without touching ScreenCaptureKit. **Do NOT pull the type into a separate file** — keep it co-located with the service per the same file-locality principle that protects `PermissionGrant` from forgery (the protocol+default is the public surface; the implementation stays one read away).
+
+- [ ] **Step 1: Add the protocol declaration above `ScreenCaptureService`**
+
+In `TAELMacAgent/TAELMacAgent/Capture/ScreenCaptureService.swift`, after the imports and existing `ScreenCaptureError` enum, add:
+
+```swift
+/// Minimal protocol the hotkey/wiring layer depends on. Lets tests
+/// inject a mock that returns a synthetic `CapturedScreenshot` without
+/// pulling in ScreenCaptureKit or requiring a real TCC grant.
+public protocol DisplayScreenshotCapturing: Sendable {
+    func captureDisplayScreenshot(
+        _ grant: PermissionGrant,
+        target: ScreenshotTarget
+    ) async throws -> CapturedScreenshot
+}
+```
+
+- [ ] **Step 2: Conform `ScreenCaptureService` and remove the default-arg duplication**
+
+The existing `captureDisplayScreenshot` already has a default `target: ScreenshotTarget = .week1Default`. Move that default to the protocol via a default-implementation extension:
+
+```swift
+public extension DisplayScreenshotCapturing {
+    func captureDisplayScreenshot(_ grant: PermissionGrant) async throws -> CapturedScreenshot {
+        try await captureDisplayScreenshot(grant, target: .week1Default)
+    }
+}
+```
+
+Then update the `ScreenCaptureService` class declaration:
+
+```swift
+public final class ScreenCaptureService: DisplayScreenshotCapturing {
+    public init() {}
+
+    public func captureDisplayScreenshot(
+        _ grant: PermissionGrant,
+        target: ScreenshotTarget
+    ) async throws -> CapturedScreenshot {
+        precondition(
+            grant.kind == .screenRecording,
+            "ScreenCaptureService requires a .screenRecording grant"
+        )
+
+        // Body still throws .notImplemented in this task; Task 3 fills
+        // in the real ScreenCaptureKit path.
+        throw ScreenCaptureError.notImplemented
+    }
+}
+```
+
+- [ ] **Step 3: Build and test**
+
+```bash
+xcodebuild -project TAELMacAgent/TAELMacAgent.xcodeproj \
+  -scheme TAELMacAgent -configuration Debug \
+  -destination 'platform=macOS' CODE_SIGNING_ALLOWED=NO test
+```
+Expected: BUILD SUCCEEDED, all 8 existing tests still pass. The protocol extraction is a refactor — behavior is unchanged.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add TAELMacAgent/TAELMacAgent/Capture/ScreenCaptureService.swift
+git commit -m "refactor(capture): extract DisplayScreenshotCapturing protocol
+
+Thin protocol with a default implementation that supplies
+target = .week1Default. Lets the hotkey wire-up tests inject a mock
+without pulling in ScreenCaptureKit or requiring a TCC grant.
+Type stays co-located with the service per file-locality discipline."
+```
+
+---
+
+## Real ScreenCaptureKit capture
+
+### Task 3: Replace `notImplemented` stub with real `SCScreenshotManager` capture
+
+**Files:**
+- Modify: `TAELMacAgent/TAELMacAgent/Capture/ScreenCaptureService.swift`
+
+**Why:** ticket 8. Replace the stub body. The PR 2 outline comment in the file already describes the shape; this task fills it in.
+
+**Why no unit test for this body:** real screen capture requires TCC Screen Recording permission, which CI (and Codex's sandbox) cannot grant. Manual verification via `make run` after Task 6 is the gate. The Task 7 wire-up tests use the mock from Task 2.
+
+- [ ] **Step 1: Add ScreenCaptureKit + AppKit imports**
+
+At the top of `TAELMacAgent/TAELMacAgent/Capture/ScreenCaptureService.swift`:
+
+```swift
+import Foundation
+#if canImport(CoreGraphics)
+import CoreGraphics
+#endif
+#if canImport(ScreenCaptureKit)
+import ScreenCaptureKit
+#endif
+#if canImport(AppKit)
+import AppKit
+#endif
+```
+
+- [ ] **Step 2: Add display resolution helper**
+
+After the `DisplayScreenshotCapturing` extension, before the `ScreenCaptureService` class, add:
+
+```swift
+/// Resolves the target display per v0.3 §23.2: cursor display first,
+/// fallback to main display, fallback to the first available display.
+/// Returns the resolved `(SCDisplay, ScreenshotTarget)` so the caller
+/// knows whether it got the cursor display or fell back.
+@available(macOS 14.0, *)
+private func resolveTargetDisplay(
+    in content: SCShareableContent,
+    requested: ScreenshotTarget
+) -> (display: SCDisplay, resolved: ScreenshotTarget)? {
+    guard !content.displays.isEmpty else { return nil }
+
+    let mainDisplayID = CGMainDisplayID()
+
+    if requested == .displayContainingCursor {
+        let cursorPoint = NSEvent.mouseLocation
+        if let nsScreen = NSScreen.screens.first(where: { $0.frame.contains(cursorPoint) }),
+           let screenNumber = nsScreen.deviceDescription[NSDeviceDescriptionKey("NSScreenNumber")] as? CGDirectDisplayID,
+           let display = content.displays.first(where: { $0.displayID == screenNumber })
+        {
+            return (display, .displayContainingCursor)
+        }
+    }
+
+    // Fallback path: main display, then first available.
+    if let main = content.displays.first(where: { $0.displayID == mainDisplayID }) {
+        return (main, .mainDisplay)
+    }
+    if let first = content.displays.first {
+        return (first, .mainDisplay)
+    }
+    return nil
+}
+```
+
+- [ ] **Step 3: Replace the stub body**
+
+Replace the current `captureDisplayScreenshot` body in `ScreenCaptureService`:
+
+```swift
+    public func captureDisplayScreenshot(
+        _ grant: PermissionGrant,
+        target: ScreenshotTarget
+    ) async throws -> CapturedScreenshot {
+        precondition(
+            grant.kind == .screenRecording,
+            "ScreenCaptureService requires a .screenRecording grant"
+        )
+
+        let content: SCShareableContent
+        do {
+            content = try await SCShareableContent.current
+        } catch {
+            throw ScreenCaptureError.captureFailed("SCShareableContent.current failed: \(error.localizedDescription)")
+        }
+
+        guard let resolved = resolveTargetDisplay(in: content, requested: target) else {
+            throw ScreenCaptureError.noDisplaysAvailable
+        }
+
+        let display = resolved.display
+        let filter = SCContentFilter(display: display, excludingWindows: [])
+
+        let cfg = SCStreamConfiguration()
+        let scale = NSScreen.screens
+            .first { ($0.deviceDescription[NSDeviceDescriptionKey("NSScreenNumber")] as? CGDirectDisplayID) == display.displayID }?
+            .backingScaleFactor ?? 2.0
+        cfg.width = display.width * Int(scale)
+        cfg.height = display.height * Int(scale)
+        cfg.showsCursor = true
+        cfg.queueDepth = 1
+
+        let cgImage: CGImage
+        do {
+            cgImage = try await SCScreenshotManager.captureImage(
+                contentFilter: filter,
+                configuration: cfg
+            )
+        } catch {
+            throw ScreenCaptureError.captureFailed("SCScreenshotManager.captureImage failed: \(error.localizedDescription)")
+        }
+
+        return CapturedScreenshot(image: cgImage, target: resolved.resolved)
+    }
+```
+
+- [ ] **Step 4: Remove the now-unused `.notImplemented` case from the error enum**
+
+Replace:
+
+```swift
+public enum ScreenCaptureError: Error, Equatable {
+    /// PR 1 placeholder. Removed when ScreenCaptureKit lands in PR 2.
+    case notImplemented
+    /// `SCShareableContent` returned no displays.
+    case noDisplaysAvailable
+    /// Underlying ScreenCaptureKit error. Wrapped to keep call sites
+    /// independent of the framework.
+    case captureFailed(String)
+}
+```
+
+With:
+
+```swift
+public enum ScreenCaptureError: Error, Equatable {
+    /// `SCShareableContent` returned no displays.
+    case noDisplaysAvailable
+    /// Underlying ScreenCaptureKit error. Wrapped to keep call sites
+    /// independent of the framework.
+    case captureFailed(String)
+}
+```
+
+- [ ] **Step 5: Build and run existing tests**
+
+```bash
+xcodebuild -project TAELMacAgent/TAELMacAgent.xcodeproj \
+  -scheme TAELMacAgent -configuration Debug \
+  -destination 'platform=macOS' CODE_SIGNING_ALLOWED=NO test
+```
+Expected: BUILD SUCCEEDED, all 8 existing tests still pass. The body change is not exercised by any current test (it's the production capture path).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add TAELMacAgent/TAELMacAgent/Capture/ScreenCaptureService.swift
+git commit -m "feat(capture): real SCScreenshotManager capture path
+
+Implements v0.3 §23.10 capture contract:
+- SCShareableContent.current for available displays
+- Cursor-display resolution with mainDisplay fallback (§23.2)
+- SCContentFilter + SCStreamConfiguration with explicit width/height
+  multiplied by NSScreen backingScaleFactor
+- SCScreenshotManager.captureImage(contentFilter:configuration:) —
+  the only allowed overload until deployment target moves to 15.2+
+
+Removes ScreenCaptureError.notImplemented (no longer reachable).
+Manual verification via 'make run' after Task 6 wires the hotkey."
+```
+
+---
+
+## Hotkey integration
+
+### Task 4: Add `KeyboardShortcuts.Name` extension
+
+**Files:**
+- Create: `TAELMacAgent/TAELMacAgent/Hotkey/HotkeyName.swift`
+
+**Why:** the KeyboardShortcuts API requires shortcut names declared as `KeyboardShortcuts.Name` static properties. Co-locate the name in its own small file under `Hotkey/` so it's findable.
+
+- [ ] **Step 1: Create the file**
+
+Create `TAELMacAgent/TAELMacAgent/Hotkey/HotkeyName.swift`:
+
+```swift
+//
+//  HotkeyName.swift
+//  TAELMacAgent
+//
+//  Declares the global hotkey name used by KeyboardShortcuts.
+//  Default chord: ⌘⇧T ("T" for TAEL). User can rebind via Settings
+//  later (post-PR 2).
+//
+
+import KeyboardShortcuts
+
+extension KeyboardShortcuts.Name {
+    /// Primary "summon TAEL" hotkey. v0.3 §1: this triggers the full
+    /// hotkey → gate → capture → HUD pipeline.
+    static let toggleTAEL = Self(
+        "toggleTAEL",
+        default: .init(.t, modifiers: [.command, .shift])
+    )
+}
+```
+
+- [ ] **Step 2: Register the new file in the Xcode project**
+
+If the project was regenerated via XcodeGen in Task 1, the new file is picked up automatically by the `sources: - path: TAELMacAgent` glob — no pbxproj edit needed. Confirm by running:
+
+```bash
+make xcodeproj
+```
+
+If the project was not regenerated (pbxproj edited by hand), Codex/maestro must add the file reference manually following the same pattern used for `LocalLogServiceTests.swift` in PR 1 (PBXBuildFile + PBXFileReference + group + Sources build phase).
+
+- [ ] **Step 3: Build to verify the name compiles**
+
+```bash
+xcodebuild -project TAELMacAgent/TAELMacAgent.xcodeproj \
+  -scheme TAELMacAgent -configuration Debug \
+  -destination 'platform=macOS' CODE_SIGNING_ALLOWED=NO build
+```
+Expected: BUILD SUCCEEDED.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add TAELMacAgent/TAELMacAgent/Hotkey/HotkeyName.swift \
+        TAELMacAgent/TAELMacAgent.xcodeproj/project.pbxproj
+git commit -m "feat(hotkey): declare KeyboardShortcuts.Name.toggleTAEL
+
+Default chord ⌘⇧T. Used in Task 5 to register the real global hotkey
+via KeyboardShortcuts.onKeyDown."
+```
+
+---
+
+### Task 5: Replace `HotkeyManager` placeholder with real registration
+
+**Files:**
+- Modify: `TAELMacAgent/TAELMacAgent/Hotkey/HotkeyManager.swift`
+
+**Why:** ticket 6. Currently `installPlaceholderBinding()` is a no-op; PR 2 wires it through `KeyboardShortcuts.onKeyDown(for:)`.
+
+- [ ] **Step 1: Replace the file contents**
+
+Replace the entire `TAELMacAgent/TAELMacAgent/Hotkey/HotkeyManager.swift`:
+
+```swift
+//
+//  HotkeyManager.swift
+//  TAELMacAgent
+//
+//  Owns the global hotkey registration via the KeyboardShortcuts
+//  package. The actual work (gate → capture → HUD) is the closure
+//  assigned to `onTrigger` by `AppDelegate`.
+//
+
+import Foundation
+import KeyboardShortcuts
+
+@MainActor
+final class HotkeyManager {
+    /// Set by `AppDelegate` to the gate→capture→HUD closure.
+    /// Read inside the KeyboardShortcuts callback.
+    var onTrigger: (() -> Void)?
+
+    /// Registers the real global hotkey with KeyboardShortcuts.
+    /// Call once during `applicationDidFinishLaunching`.
+    func installBinding() {
+        KeyboardShortcuts.onKeyDown(for: .toggleTAEL) { [weak self] in
+            self?.onTrigger?()
+        }
+    }
+
+    func tearDown() {
+        KeyboardShortcuts.disable(.toggleTAEL)
+        onTrigger = nil
+    }
+}
+```
+
+- [ ] **Step 2: Build**
+
+```bash
+xcodebuild -project TAELMacAgent/TAELMacAgent.xcodeproj \
+  -scheme TAELMacAgent -configuration Debug \
+  -destination 'platform=macOS' CODE_SIGNING_ALLOWED=NO build
+```
+Expected: BUILD SUCCEEDED. There's still a call site in `AppDelegate` to `installPlaceholderBinding()` that no longer exists — Task 6 fixes it. If you want a passing build between tasks, temporarily rename the call site too; otherwise commit Task 5 + Task 6 together.
+
+**Decision:** for cleaner per-task commits, keep `installPlaceholderBinding` as a deprecated alias that just calls `installBinding`. Replace Step 1's file with this version instead:
+
+```swift
+//
+//  HotkeyManager.swift
+//  TAELMacAgent
+//
+//  Owns the global hotkey registration via the KeyboardShortcuts
+//  package. The actual work (gate → capture → HUD) is the closure
+//  assigned to `onTrigger` by `AppDelegate`.
+//
+
+import Foundation
+import KeyboardShortcuts
+
+@MainActor
+final class HotkeyManager {
+    /// Set by `AppDelegate` to the gate→capture→HUD closure.
+    /// Read inside the KeyboardShortcuts callback.
+    var onTrigger: (() -> Void)?
+
+    /// Registers the real global hotkey with KeyboardShortcuts.
+    /// Call once during `applicationDidFinishLaunching`.
+    func installBinding() {
+        KeyboardShortcuts.onKeyDown(for: .toggleTAEL) { [weak self] in
+            self?.onTrigger?()
+        }
+    }
+
+    /// Backwards-compatible alias for the PR 1 call site. Removed in
+    /// the same commit that updates `AppDelegate` to call
+    /// `installBinding()` directly (Task 6).
+    @available(*, deprecated, renamed: "installBinding")
+    func installPlaceholderBinding() {
+        installBinding()
+    }
+
+    func tearDown() {
+        KeyboardShortcuts.disable(.toggleTAEL)
+        onTrigger = nil
+    }
+}
+```
+
+Build expectation: BUILD SUCCEEDED with one deprecation warning at the AppDelegate call site (Task 6 removes it).
+
+- [ ] **Step 3: Run existing tests**
+
+```bash
+xcodebuild -project TAELMacAgent/TAELMacAgent.xcodeproj \
+  -scheme TAELMacAgent -configuration Debug \
+  -destination 'platform=macOS' CODE_SIGNING_ALLOWED=NO test
+```
+Expected: 8 tests pass.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add TAELMacAgent/TAELMacAgent/Hotkey/HotkeyManager.swift
+git commit -m "feat(hotkey): real KeyboardShortcuts registration
+
+HotkeyManager.installBinding wires KeyboardShortcuts.onKeyDown to the
+onTrigger closure that AppDelegate assigns. tearDown disables the
+shortcut and nils the closure on app termination.
+
+installPlaceholderBinding kept as a deprecated alias to keep this
+commit's build green; removed when AppDelegate updates in Task 6."
+```
+
+---
+
+## The wire-up
+
+### Task 6: Wire `AppDelegate` — hotkey → gate → capture → HUD + log
+
+**Files:**
+- Modify: `TAELMacAgent/TAELMacAgent/App/AppDelegate.swift`
+
+**Why:** ticket 9. This is the heartbeat itself. The closure assigned to `hotkeyManager.onTrigger` runs the gate, captures, presents to HUD, records a log row.
+
+- [ ] **Step 1: Replace the file contents**
+
+Replace `TAELMacAgent/TAELMacAgent/App/AppDelegate.swift`:
+
+```swift
+//
+//  AppDelegate.swift
+//  TAELMacAgent
+//
+
+import AppKit
+import Foundation
+import os.log
+import SwiftUI
+
+@MainActor
+final class AppDelegate: NSObject, NSApplicationDelegate {
+    private var menuBarController: MenuBarController?
+    private var hotkeyManager: HotkeyManager?
+    private var hudController: HUDPanelController?
+    private var permissionsGate: PermissionsGate?
+    private var screenCaptureService: DisplayScreenshotCapturing?
+    private var logService: LocalLogService?
+    private let log = Logger(subsystem: "ai.tael.macagent", category: "AppDelegate")
+
+    func applicationDidFinishLaunching(_ notification: Notification) {
+        // Belt and braces: even though `LSUIElement = YES`, force
+        // accessory mode at runtime so the app never gets a Dock icon.
+        NSApp.setActivationPolicy(.accessory)
+
+        let logService = LocalLogService()
+        let hudController = HUDPanelController()
+        let permissionsGate = PermissionsGate(
+            checker: PermissionsChecker(),
+            permissionUI: hudController
+        )
+        let screenCaptureService = ScreenCaptureService()
+        let hotkeyManager = HotkeyManager()
+        let menuBarController = MenuBarController(
+            onShowHUD: { [weak hudController] in
+                hudController?.showPlaceholder()
+            },
+            onQuit: {
+                NSApp.terminate(nil)
+            }
+        )
+
+        self.logService = logService
+        self.hudController = hudController
+        self.permissionsGate = permissionsGate
+        self.screenCaptureService = screenCaptureService
+        self.hotkeyManager = hotkeyManager
+        self.menuBarController = menuBarController
+
+        menuBarController.install()
+
+        // Hotkey closure: gate → capture → HUD + log. Runs on the main
+        // actor (the `@MainActor` class isolation already covers it).
+        hotkeyManager.onTrigger = { [weak self] in
+            guard let self else { return }
+            Task { @MainActor in
+                await self.handleHotkeyInvocation()
+            }
+        }
+        hotkeyManager.installBinding()
+    }
+
+    func applicationWillTerminate(_ notification: Notification) {
+        hotkeyManager?.tearDown()
+        hudController?.tearDown()
+    }
+
+    /// One invocation of the Week 1 heartbeat. Captures latency,
+    /// outcome, and target metadata into a LocalLogService row.
+    private func handleHotkeyInvocation() async {
+        guard let permissionsGate, let screenCaptureService, let hudController, let logService else {
+            log.fault("Hotkey fired before AppDelegate finished launch wiring; ignoring.")
+            return
+        }
+
+        let started = Date()
+        let gateStart = started
+
+        do {
+            let screenshot = try await permissionsGate.withPermission(.screenRecording) { grant in
+                let gateEnd = Date()
+                let captureStart = gateEnd
+                let result = try await screenCaptureService.captureDisplayScreenshot(grant, target: .week1Default)
+                let captureEnd = Date()
+
+                await logService.record(InvocationLog(
+                    hotkeyTimestamp: started,
+                    gateOutcome: .granted,
+                    gateLatencyMs: gateEnd.timeIntervalSince(gateStart) * 1000,
+                    captureLatencyMs: captureEnd.timeIntervalSince(captureStart) * 1000,
+                    targetDescription: "\(result.target) \(result.width)x\(result.height)"
+                ))
+
+                return result
+            }
+            hudController.present(screenshot: screenshot)
+        } catch let error as PermissionError {
+            // PermissionsGate already invoked permissionUI.showGate.
+            // Log the outcome and stop.
+            let outcome: InvocationLog.GateOutcome
+            switch error {
+            case .missing: outcome = .denied
+            case .notImplemented: outcome = .restricted
+            }
+            await logService.record(InvocationLog(
+                hotkeyTimestamp: started,
+                gateOutcome: outcome,
+                errorDescription: error.localizedDescription
+            ))
+        } catch {
+            await logService.record(InvocationLog(
+                hotkeyTimestamp: started,
+                gateOutcome: .errored,
+                errorDescription: error.localizedDescription
+            ))
+            log.error("Hotkey invocation failed: \(error.localizedDescription, privacy: .public)")
+        }
+    }
+}
+```
+
+- [ ] **Step 2: Build and confirm the deprecation warning is gone**
+
+```bash
+xcodebuild -project TAELMacAgent/TAELMacAgent.xcodeproj \
+  -scheme TAELMacAgent -configuration Debug \
+  -destination 'platform=macOS' CODE_SIGNING_ALLOWED=NO build
+```
+Expected: BUILD SUCCEEDED, no deprecation warning. The change references `installBinding()` (Task 5) and a new `hudController.present(screenshot:)` method (added in Task 7).
+
+**Will fail at this point** — `HUDPanelController.present(screenshot:)` doesn't exist yet. That's expected; the next task adds it. **Do not commit Task 6 alone.** Commit Task 6 + Task 7 together OR add a stub `present(screenshot:)` to HUDPanelController in this commit and flesh it out in Task 7.
+
+For cleaner per-task commits, **add a one-line stub now** and flesh out in Task 7:
+
+In `TAELMacAgent/TAELMacAgent/HUD/HUDPanelController.swift`, add this method body (just the placeholder; Task 7 replaces it):
+
+```swift
+    func present(screenshot: CapturedScreenshot) {
+        // Task 7 fills this in. Stub so Task 6's AppDelegate wiring
+        // compiles in its own commit.
+        showPlaceholder()
+    }
+```
+
+Then re-run the build — it should now succeed.
+
+- [ ] **Step 3: Run existing tests**
+
+```bash
+xcodebuild -project TAELMacAgent/TAELMacAgent.xcodeproj \
+  -scheme TAELMacAgent -configuration Debug \
+  -destination 'platform=macOS' CODE_SIGNING_ALLOWED=NO test
+```
+Expected: 8 tests pass.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add TAELMacAgent/TAELMacAgent/App/AppDelegate.swift \
+        TAELMacAgent/TAELMacAgent/HUD/HUDPanelController.swift
+git commit -m "feat(app): wire hotkey → PermissionsGate → capture → HUD + log
+
+The Week 1 heartbeat. AppDelegate.handleHotkeyInvocation runs the
+gate, captures (via DisplayScreenshotCapturing protocol so it stays
+testable), presents to HUD, and records an InvocationLog row with
+gate/capture latencies plus target description.
+
+PermissionError.missing → InvocationLog.GateOutcome.denied
+PermissionError.notImplemented → .restricted (kind isn't wired)
+Any other thrown error → .errored + os_log.error
+
+HUDPanelController.present(screenshot:) currently calls showPlaceholder
+as a stub; Task 7 fleshes out the real screenshot rendering."
+```
+
+---
+
+## Show the screenshot
+
+### Task 7: HUD screenshot rendering
+
+**Files:**
+- Create: `TAELMacAgent/TAELMacAgent/HUD/HUDScreenshotView.swift`
+- Modify: `TAELMacAgent/TAELMacAgent/HUD/HUDPanelController.swift`
+
+**Why:** ticket 10. Render the captured screenshot inside the existing non-activating NSPanel. Keep the placeholder HUDView for the menubar "Show HUD" item; add a new view for screenshot display.
+
+- [ ] **Step 1: Create the screenshot view**
+
+Create `TAELMacAgent/TAELMacAgent/HUD/HUDScreenshotView.swift`:
+
+```swift
+//
+//  HUDScreenshotView.swift
+//  TAELMacAgent
+//
+//  Displays a CapturedScreenshot inside the HUD. PR 2: the shot is
+//  shown at a fixed maximum size so a full 5K display still fits in a
+//  reasonable HUD. Aspect ratio preserved.
+//
+
+import SwiftUI
+import AppKit
+
+struct HUDScreenshotView: View {
+    let screenshot: CapturedScreenshot
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text("Captured \(screenshot.width)×\(screenshot.height) — \(targetLabel)")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+
+            Image(decorative: screenshot.image, scale: 1.0, orientation: .up)
+                .resizable()
+                .aspectRatio(contentMode: .fit)
+                .frame(maxWidth: 720, maxHeight: 480)
+                .background(Color.black.opacity(0.3))
+                .cornerRadius(6)
+
+            Text(screenshot.capturedAt.formatted(date: .omitted, time: .standard))
+                .font(.caption2)
+                .foregroundStyle(.tertiary)
+        }
+        .padding(16)
+    }
+
+    private var targetLabel: String {
+        switch screenshot.target {
+        case .displayContainingCursor: return "cursor display"
+        case .mainDisplay: return "main display (fallback)"
+        }
+    }
+}
+```
+
+- [ ] **Step 2: Replace the stub `present(screenshot:)` in `HUDPanelController`**
+
+Replace the stub from Task 6's Step 2 with:
+
+```swift
+    func present(screenshot: CapturedScreenshot) {
+        presentNew(content: HUDScreenshotView(screenshot: screenshot))
+    }
+```
+
+- [ ] **Step 3: Build**
+
+```bash
+xcodebuild -project TAELMacAgent/TAELMacAgent.xcodeproj \
+  -scheme TAELMacAgent -configuration Debug \
+  -destination 'platform=macOS' CODE_SIGNING_ALLOWED=NO build
+```
+Expected: BUILD SUCCEEDED.
+
+- [ ] **Step 4: Run tests**
+
+```bash
+xcodebuild -project TAELMacAgent/TAELMacAgent.xcodeproj \
+  -scheme TAELMacAgent -configuration Debug \
+  -destination 'platform=macOS' CODE_SIGNING_ALLOWED=NO test
+```
+Expected: 8 tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add TAELMacAgent/TAELMacAgent/HUD/HUDScreenshotView.swift \
+        TAELMacAgent/TAELMacAgent/HUD/HUDPanelController.swift \
+        TAELMacAgent/TAELMacAgent.xcodeproj/project.pbxproj
+git commit -m "feat(hud): render CapturedScreenshot in non-activating HUD
+
+HUDScreenshotView shows the CGImage at a fixed max 720x480 with aspect
+ratio preserved, plus a caption with dimensions, target (cursor display
+vs main fallback), and capture timestamp.
+
+HUDPanelController.present(screenshot:) replaces the Task 6 stub."
+```
+
+---
+
+## Test the wire-up
+
+### Task 8: Wire-up tests via `DisplayScreenshotCapturing` mock (TDD)
+
+**Files:**
+- Create: `TAELMacAgent/TAELMacAgentTests/HotkeyHandlerTests.swift`
+
+**Why:** the hotkey path orchestrates four collaborators (gate, capture service, HUD, log). Without tests, regressions in the wire-up only surface in manual testing. The `DisplayScreenshotCapturing` protocol from Task 2 makes this mockable. Tests live in their own file because they exercise a different surface than `PermissionsGateTests`.
+
+**Caveat:** `AppDelegate.handleHotkeyInvocation` is `private`. Two options:
+1. Make it `internal` and `@testable import` — simpler but expands the API.
+2. Extract the body into a free function or a small `HotkeyInvocationHandler` type that AppDelegate composes — testable in isolation, no privacy widening.
+
+**Choice:** option 2. Extract a `HotkeyInvocationHandler` in this task; AppDelegate calls `handler.run()`. Cleaner boundary.
+
+- [ ] **Step 1: Extract the handler**
+
+Create `TAELMacAgent/TAELMacAgent/App/HotkeyInvocationHandler.swift`:
+
+```swift
+//
+//  HotkeyInvocationHandler.swift
+//  TAELMacAgent
+//
+//  Single invocation of the Week 1 heartbeat: gate → capture → HUD +
+//  log. Extracted from AppDelegate so the wire-up is unit-testable
+//  without spinning up a real menubar or NSPanel.
+//
+
+import Foundation
+import os.log
+
+@MainActor
+struct HotkeyInvocationHandler {
+    let permissionsGate: PermissionsGate
+    let screenCaptureService: any DisplayScreenshotCapturing
+    let presentScreenshot: (CapturedScreenshot) -> Void
+    let logService: LocalLogService
+    let now: () -> Date
+
+    init(
+        permissionsGate: PermissionsGate,
+        screenCaptureService: any DisplayScreenshotCapturing,
+        presentScreenshot: @escaping (CapturedScreenshot) -> Void,
+        logService: LocalLogService,
+        now: @escaping () -> Date = Date.init
+    ) {
+        self.permissionsGate = permissionsGate
+        self.screenCaptureService = screenCaptureService
+        self.presentScreenshot = presentScreenshot
+        self.logService = logService
+        self.now = now
+    }
+
+    private static let log = Logger(subsystem: "ai.tael.macagent", category: "HotkeyInvocationHandler")
+
+    func run() async {
+        let started = now()
+        let gateStart = started
+
+        do {
+            let screenshot = try await permissionsGate.withPermission(.screenRecording) { grant in
+                let gateEnd = self.now()
+                let captureStart = gateEnd
+                let result = try await screenCaptureService.captureDisplayScreenshot(grant, target: .week1Default)
+                let captureEnd = self.now()
+
+                await logService.record(InvocationLog(
+                    hotkeyTimestamp: started,
+                    gateOutcome: .granted,
+                    gateLatencyMs: gateEnd.timeIntervalSince(gateStart) * 1000,
+                    captureLatencyMs: captureEnd.timeIntervalSince(captureStart) * 1000,
+                    targetDescription: "\(result.target) \(result.width)x\(result.height)"
+                ))
+
+                return result
+            }
+            presentScreenshot(screenshot)
+        } catch let error as PermissionError {
+            let outcome: InvocationLog.GateOutcome
+            switch error {
+            case .missing: outcome = .denied
+            case .notImplemented: outcome = .restricted
+            }
+            await logService.record(InvocationLog(
+                hotkeyTimestamp: started,
+                gateOutcome: outcome,
+                errorDescription: error.localizedDescription
+            ))
+        } catch {
+            await logService.record(InvocationLog(
+                hotkeyTimestamp: started,
+                gateOutcome: .errored,
+                errorDescription: error.localizedDescription
+            ))
+            Self.log.error("Hotkey invocation failed: \(error.localizedDescription, privacy: .public)")
+        }
+    }
+}
+```
+
+Update `TAELMacAgent/TAELMacAgent/App/AppDelegate.swift` to use the handler. Replace the `handleHotkeyInvocation` method and the `hotkeyManager.onTrigger` assignment:
+
+```swift
+        hotkeyManager.onTrigger = { [weak self] in
+            guard let self,
+                  let permissionsGate = self.permissionsGate,
+                  let screenCaptureService = self.screenCaptureService,
+                  let hudController = self.hudController,
+                  let logService = self.logService else { return }
+            let handler = HotkeyInvocationHandler(
+                permissionsGate: permissionsGate,
+                screenCaptureService: screenCaptureService,
+                presentScreenshot: { shot in hudController.present(screenshot: shot) },
+                logService: logService
+            )
+            Task { @MainActor in
+                await handler.run()
+            }
+        }
+```
+
+Remove the `handleHotkeyInvocation` private method and the `import os.log` from `AppDelegate.swift` (it's now in `HotkeyInvocationHandler`).
+
+- [ ] **Step 2: Write the failing tests**
+
+Create `TAELMacAgent/TAELMacAgentTests/HotkeyHandlerTests.swift`:
+
+```swift
+//
+//  HotkeyHandlerTests.swift
+//  TAELMacAgentTests
+//
+
+import XCTest
+@testable import TAELMacAgent
+import CoreGraphics
+
+@MainActor
+final class HotkeyHandlerTests: XCTestCase {
+
+    // MARK: - Test doubles
+
+    private actor StubChecker: PermissionChecking {
+        private let status: PermissionStatus
+        init(_ status: PermissionStatus) { self.status = status }
+        func status(for kind: PermissionKind) async -> PermissionStatus { status }
+    }
+
+    private actor SpyUI: PermissionGatePresenting {
+        private(set) var shownKinds: [PermissionKind] = []
+        func showGate(for kind: PermissionKind) async { shownKinds.append(kind) }
+    }
+
+    private actor SpyCapture: DisplayScreenshotCapturing {
+        var thrownError: Error?
+        var capturedTargets: [ScreenshotTarget] = []
+        var stubScreenshot: CapturedScreenshot
+
+        init(stub: CapturedScreenshot) { self.stubScreenshot = stub }
+
+        func setError(_ error: Error?) { self.thrownError = error }
+        func observedTargets() -> [ScreenshotTarget] { capturedTargets }
+
+        func captureDisplayScreenshot(
+            _ grant: PermissionGrant,
+            target: ScreenshotTarget
+        ) async throws -> CapturedScreenshot {
+            precondition(grant.kind == .screenRecording)
+            capturedTargets.append(target)
+            if let thrownError { throw thrownError }
+            return stubScreenshot
+        }
+    }
+
+    /// Builds a 1x1 transparent CGImage for tests; no real capture.
+    private func makeStubScreenshot() -> CapturedScreenshot {
+        let cs = CGColorSpaceCreateDeviceRGB()
+        let ctx = CGContext(data: nil, width: 1, height: 1, bitsPerComponent: 8, bytesPerRow: 4, space: cs, bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue)!
+        let image = ctx.makeImage()!
+        return CapturedScreenshot(image: image, target: .displayContainingCursor)
+    }
+
+    // MARK: - Granted path
+
+    func test_run_whenGranted_callsCaptureAndPresentsAndLogsGranted() async {
+        let checker = StubChecker(.granted)
+        let ui = SpyUI()
+        let gate = PermissionsGate(checker: checker, permissionUI: ui)
+        let capture = SpyCapture(stub: makeStubScreenshot())
+        let logService = LocalLogService(capacity: 16)
+
+        var presented: [CapturedScreenshot] = []
+        let handler = HotkeyInvocationHandler(
+            permissionsGate: gate,
+            screenCaptureService: capture,
+            presentScreenshot: { presented.append($0) },
+            logService: logService
+        )
+
+        await handler.run()
+
+        let targets = await capture.observedTargets()
+        XCTAssertEqual(targets, [.week1Default])
+        XCTAssertEqual(presented.count, 1)
+
+        let logs = await logService.recent(10)
+        XCTAssertEqual(logs.count, 1)
+        XCTAssertEqual(logs.first?.gateOutcome, .granted)
+        XCTAssertNotNil(logs.first?.gateLatencyMs)
+        XCTAssertNotNil(logs.first?.captureLatencyMs)
+    }
+
+    // MARK: - Denied path
+
+    func test_run_whenDenied_doesNotCapture_doesNotPresent_logsDenied() async {
+        let checker = StubChecker(.denied)
+        let ui = SpyUI()
+        let gate = PermissionsGate(checker: checker, permissionUI: ui)
+        let capture = SpyCapture(stub: makeStubScreenshot())
+        let logService = LocalLogService(capacity: 16)
+
+        var presented: [CapturedScreenshot] = []
+        let handler = HotkeyInvocationHandler(
+            permissionsGate: gate,
+            screenCaptureService: capture,
+            presentScreenshot: { presented.append($0) },
+            logService: logService
+        )
+
+        await handler.run()
+
+        let targets = await capture.observedTargets()
+        XCTAssertTrue(targets.isEmpty)
+        XCTAssertTrue(presented.isEmpty)
+
+        let logs = await logService.recent(10)
+        XCTAssertEqual(logs.count, 1)
+        XCTAssertEqual(logs.first?.gateOutcome, .denied)
+        XCTAssertNotNil(logs.first?.errorDescription)
+
+        // The gate still surfaces the UI on missing permission.
+        let shown = await ui.shownKinds
+        XCTAssertEqual(shown, [.screenRecording])
+    }
+
+    // MARK: - Capture failure path
+
+    func test_run_whenCaptureFails_logsErroredOutcome() async {
+        let checker = StubChecker(.granted)
+        let ui = SpyUI()
+        let gate = PermissionsGate(checker: checker, permissionUI: ui)
+        let capture = SpyCapture(stub: makeStubScreenshot())
+        await capture.setError(ScreenCaptureError.captureFailed("simulated"))
+
+        let logService = LocalLogService(capacity: 16)
+
+        var presented: [CapturedScreenshot] = []
+        let handler = HotkeyInvocationHandler(
+            permissionsGate: gate,
+            screenCaptureService: capture,
+            presentScreenshot: { presented.append($0) },
+            logService: logService
+        )
+
+        await handler.run()
+
+        XCTAssertTrue(presented.isEmpty)
+        let logs = await logService.recent(10)
+        XCTAssertEqual(logs.count, 1)
+        XCTAssertEqual(logs.first?.gateOutcome, .errored)
+        XCTAssertEqual(logs.first?.errorDescription, "captureFailed(\"simulated\")")
+    }
+}
+```
+
+- [ ] **Step 3: Register the new files in the project**
+
+If using XcodeGen, run `make xcodeproj` to pick up `HotkeyInvocationHandler.swift` and `HotkeyHandlerTests.swift` automatically. If hand-edited pbxproj, follow the same registration pattern as `LocalLogServiceTests.swift` from PR 1.
+
+- [ ] **Step 4: Run only the new tests, confirm they pass**
+
+```bash
+xcodebuild test \
+  -project TAELMacAgent/TAELMacAgent.xcodeproj \
+  -scheme TAELMacAgent \
+  -destination 'platform=macOS' \
+  CODE_SIGNING_ALLOWED=NO \
+  -only-testing:TAELMacAgentTests/HotkeyHandlerTests
+```
+Expected: 3 tests pass.
+
+- [ ] **Step 5: Run the full suite**
+
+```bash
+xcodebuild -project TAELMacAgent/TAELMacAgent.xcodeproj \
+  -scheme TAELMacAgent -configuration Debug \
+  -destination 'platform=macOS' CODE_SIGNING_ALLOWED=NO test
+```
+Expected: 11 tests pass (5 PermissionsGate + 3 LocalLogService + 3 HotkeyHandler).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add TAELMacAgent/TAELMacAgent/App/HotkeyInvocationHandler.swift \
+        TAELMacAgent/TAELMacAgent/App/AppDelegate.swift \
+        TAELMacAgent/TAELMacAgentTests/HotkeyHandlerTests.swift \
+        TAELMacAgent/TAELMacAgent.xcodeproj/project.pbxproj
+git commit -m "feat(app): extract HotkeyInvocationHandler + tests
+
+Pulls the gate→capture→HUD+log pipeline out of AppDelegate into a
+@MainActor struct that takes its collaborators as init parameters.
+Lets us unit-test the wire-up without spinning up NSPanel or
+ScreenCaptureKit.
+
+Three tests covering: granted (capture + present + log granted),
+denied (no capture, no present, log denied + gate UI shown), and
+capture-failure (no present, log errored)."
+```
+
+---
+
+## Last cleanup
+
+### Task 9: Remove the `installPlaceholderBinding` deprecated alias
+
+**Files:**
+- Modify: `TAELMacAgent/TAELMacAgent/Hotkey/HotkeyManager.swift`
+
+**Why:** Task 5's deprecated alias was scaffolding for clean per-task commits. Now that `AppDelegate` calls `installBinding()` directly (Task 6), the alias is dead.
+
+- [ ] **Step 1: Remove the deprecated method**
+
+In `TAELMacAgent/TAELMacAgent/Hotkey/HotkeyManager.swift`, delete:
+
+```swift
+    @available(*, deprecated, renamed: "installBinding")
+    func installPlaceholderBinding() {
+        installBinding()
+    }
+```
+
+- [ ] **Step 2: Verify no references remain**
+
+```bash
+grep -rn "installPlaceholderBinding" TAELMacAgent/
+```
+Expected: zero matches.
+
+- [ ] **Step 3: Build and test**
+
+```bash
+xcodebuild -project TAELMacAgent/TAELMacAgent.xcodeproj \
+  -scheme TAELMacAgent -configuration Debug \
+  -destination 'platform=macOS' CODE_SIGNING_ALLOWED=NO test
+```
+Expected: 11 tests pass, no warnings.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add TAELMacAgent/TAELMacAgent/Hotkey/HotkeyManager.swift
+git commit -m "chore(hotkey): remove installPlaceholderBinding deprecated alias
+
+Existed only as a scaffold so Task 5's commit could build before
+Task 6 updated the AppDelegate call site. Both tasks have landed."
+```
+
+---
+
+## Documentation
+
+### Task 10: Update `ManualTestChecklist.md` and `Week1Heartbeat.md`
+
+**Files:**
+- Modify: `docs/ManualTestChecklist.md`
+- Modify: `docs/Week1Heartbeat.md`
+
+**Why:** PR 2 changes what "manual test" means. Need to add the real heartbeat verification cases. Week1Heartbeat.md should mark the heartbeat as complete.
+
+- [ ] **Step 1: Add PR-2 manual test cases**
+
+Open `docs/ManualTestChecklist.md`. After the existing PR-1 cases, add a new section:
+
+```markdown
+## PR 2 — Week 1 heartbeat manual cases
+
+PR-2.1 First-launch Screen Recording prompt
+- Quit TAEL if running.
+- `make tcc-reset` to clear ai.tael.macagent's TCC entries.
+- `make run`.
+- Press ⌘⇧T while Terminal is focused.
+- Expected: PermissionGateView appears with "TAEL needs Screen Recording permission" and "Open System Settings" / "Cancel" buttons.
+
+PR-2.2 Cancel button dismisses the gate
+- From PR-2.1's gate, click "Cancel".
+- Expected: panel disappears within ~100ms, no crash.
+
+PR-2.3 Granted path captures and renders
+- Click "Open System Settings" in the gate, grant Screen Recording for TAELMacAgent, quit/relaunch TAEL.
+- Press ⌘⇧T.
+- Expected: HUD appears within ~500ms showing the cursor display's screenshot at max 720x480 with caption "Captured WIDTHxHEIGHT — cursor display".
+- Expected: HUD does not steal focus from Terminal/VS Code/Cursor.
+
+PR-2.4 Multi-monitor — cursor display selection
+- With two displays, move the cursor to the secondary display.
+- Press ⌘⇧T.
+- Expected: HUD shows the secondary display's content, caption says "cursor display".
+
+PR-2.5 Multi-monitor — main display fallback
+- Disconnect or disable the secondary display while the cursor was on it (edge case; requires a hotplug or display-arrangement change).
+- Press ⌘⇧T.
+- Expected: HUD shows the main display, caption says "main display (fallback)".
+
+PR-2.6 Full-screen app
+- Make a Terminal or VS Code window full-screen.
+- Press ⌘⇧T.
+- Expected: HUD appears as an overlay; full-screen app stays focused; HUD shows the captured screenshot.
+
+PR-2.7 No screenshot persistence
+- After PR-2.3, check `~/Library/Application Support/TAELMacAgent/` and the project root.
+- Expected: no PNG/JPEG files created. Screenshots are in-memory only.
+
+PR-2.8 Invocation log fields
+- After several invocations, attach a debugger to TAELMacAgent and inspect `LocalLogService.recent()`.
+- Expected: each row has hotkeyTimestamp, gateOutcome, gateLatencyMs, captureLatencyMs, targetDescription. Granted-path rows have all four numeric fields populated.
+```
+
+- [ ] **Step 2: Mark heartbeat complete in `docs/Week1Heartbeat.md`**
+
+Add a status line near the top of `docs/Week1Heartbeat.md`:
+
+```markdown
+> **Status (2026-04-26): heartbeat shipped in PR 2.** Hotkey ⌘⇧T → PermissionsGate.withPermission(.screenRecording) → SCScreenshotManager.captureImage → non-activating NSPanel HUD with the captured CGImage. See `docs/ManualTestChecklist.md` PR-2.* cases for verification.
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add docs/ManualTestChecklist.md docs/Week1Heartbeat.md
+git commit -m "docs(week1): document the shipped heartbeat and PR-2 manual cases
+
+ManualTestChecklist.md gains 8 PR-2 cases covering first-launch
+prompt, Cancel, granted path, multi-monitor cursor + fallback,
+full-screen, no-persistence, and InvocationLog fields.
+
+Week1Heartbeat.md marks the heartbeat as shipped."
+```
+
+---
+
+## Wrap up (maestro only)
+
+### Task 11: Open the PR
+
+**Files:** none (orchestration)
+
+**Why maestro-only:** `gh pr create` writes to a shared external system; the maestro keeps the user in the loop on what gets surfaced.
+
+- [ ] **Step 1: Run the full clean test suite**
+
+```bash
+xcodebuild -project TAELMacAgent/TAELMacAgent.xcodeproj \
+  -scheme TAELMacAgent -configuration Debug \
+  -destination 'platform=macOS' CODE_SIGNING_ALLOWED=NO clean test
+```
+Expected: 11 tests pass.
+
+- [ ] **Step 2: Confirm the branch is ahead of develop**
+
+```bash
+git log origin/develop..HEAD --oneline
+```
+Expected: 10 commits (Task 1 + Tasks 2–10), one per task, conventional-commit format.
+
+- [ ] **Step 3: Push**
+
+```bash
+git push origin feature/pr2-week1-heartbeat
+```
+
+- [ ] **Step 4: Open the PR**
+
+```bash
+gh pr create --base develop --head feature/pr2-week1-heartbeat \
+  --title "feat: PR 2 — Week 1 heartbeat (hotkey → gate → capture → HUD)" \
+  --body "$(cat <<'EOF'
+## Summary
+
+Ships the Week 1 heartbeat per v0.3 §1: \`global hotkey → PermissionsGate → SCScreenshotManager → non-activating NSPanel HUD with screenshot PNG\`.
+
+Plan: \`docs/superpowers/plans/2026-04-26-pr2-week1-heartbeat.md\`. Codex-driven where the sandbox allowed; maestro-driven for SPM dep resolution and PR creation.
+
+## What's in
+
+- **KeyboardShortcuts SPM package** registered via XcodeGen (\`project.yml\`)
+- **Real \`SCScreenshotManager.captureImage(contentFilter:configuration:)\`** capture with cursor-display resolution + main-display fallback (v0.3 §23.2)
+- **\`DisplayScreenshotCapturing\` protocol** so the wire-up is unit-testable without TCC
+- **\`HotkeyInvocationHandler\`** extracted from AppDelegate (testable struct)
+- **\`HUDScreenshotView\`** rendering CGImage at max 720×480, aspect ratio preserved, caption with dimensions + target + timestamp
+- **\`InvocationLog\`** rows recorded per invocation: gate outcome, gate latency, capture latency, target description, error description on failure
+- **3 new tests** (\`HotkeyHandlerTests\`) covering granted / denied / capture-failure paths
+- **8 new manual test cases** in \`docs/ManualTestChecklist.md\` (PR-2.1 through PR-2.8)
+
+## Test plan
+
+- [x] \`xcodebuild ... clean test\` — 11 tests, 0 failures (5 PermissionsGate + 3 LocalLogService + 3 HotkeyHandler)
+- [ ] Manual PR-2.1 (first-launch Screen Recording prompt)
+- [ ] Manual PR-2.2 (Cancel dismisses gate)
+- [ ] Manual PR-2.3 (granted path captures and renders)
+- [ ] Manual PR-2.4 (multi-monitor cursor display)
+- [ ] Manual PR-2.5 (multi-monitor main fallback)
+- [ ] Manual PR-2.6 (full-screen app)
+- [ ] Manual PR-2.7 (no screenshot persistence)
+- [ ] Manual PR-2.8 (InvocationLog fields populated)
+
+## Out of scope
+
+- AX tree (Week 2)
+- Voice capture / WhisperKit (Week 3)
+- Planner adapter (Week 4)
+- Safe executor (Week 5)
+- Skill matcher / hardcoded skills (Weeks 6–7)
+- User-rebindable hotkey (post-PR 2)
+- Disk-persisted invocation log (after executor lands)
+EOF
+)"
+```
+Expected: PR URL printed. Notify Ozzy.
+
+---
+
+## Self-review checklist
+
+After writing the plan and before handing off:
+
+**1. Spec coverage:**
+- v0.3 §12.2 Week 1 deliverables: menubar app ✓ (PR 1), KeyboardShortcuts (Task 1), global hotkey works (Tasks 4–6), PermissionsChecker (PR 1), PermissionsGate (PR 1), Screen Recording gate (PR 1 + Task 6 wire-up), Week 1 screenshot target (Task 3 cursor + fallback), SCScreenshotManager.captureImage (Task 3), explicit width/height (Task 3 backingScaleFactor), NSPanel HUD displays image (Task 7). All covered.
+- v0.3 §23.5 first-13 tickets: 6 (KeyboardShortcuts) → Tasks 1, 4, 5; 8 (ScreenCaptureService real) → Task 3; 9 (wire-up) → Task 6; 10 (HUD render) → Task 7; 11 (InvocationLog) → Task 6 wire + records via logService. All covered.
+
+**2. Placeholder scan:** No "TBD", "implement later", "add appropriate error handling" patterns. Each step has concrete code or commands.
+
+**3. Type consistency:**
+- `DisplayScreenshotCapturing` is the protocol name in Tasks 2, 3, 6, 8. ✓
+- `KeyboardShortcuts.Name.toggleTAEL` declared in Task 4, used in Task 5. ✓
+- `HotkeyInvocationHandler` introduced in Task 8 (extraction); `AppDelegate.handleHotkeyInvocation` from Task 6 is replaced by the handler — Task 8 explicitly removes it. ✓
+- `present(screenshot:)` stub introduced in Task 6, fleshed out in Task 7. ✓
+- `installPlaceholderBinding` deprecated in Task 5, removed in Task 9. ✓
+- `InvocationLog` initializer matches the existing struct (`hotkeyTimestamp`, `gateOutcome`, `gateLatencyMs`, `captureLatencyMs`, `targetDescription`, `errorDescription`). ✓
+- `LocalLogService.record` is `async`. All call sites use `await`. ✓
+
+---
+
+## Notes for the executor
+
+- **Task 1 is maestro-only** because SPM resolution needs network. Maestro: edit project.yml, `make xcodeproj`, `xcodebuild -resolvePackageDependencies`, commit. Codex resumes from Task 2.
+- **Task 11 is maestro-only** for the PR creation step (`gh pr create` writes to GitHub).
+- **Sandbox commit pattern:** Codex's sandbox blocks `.git/index.lock` writes. The maestro commits on Codex's behalf after each task, same pattern as PR 1 cleanup. Codex stages files via `git add` if it can; otherwise leaves the working tree dirty and the maestro stages + commits.
+- **Test-runner sandbox issue:** Codex's sandbox blocks `~/Library/Developer/Xcode/DerivedData` and `testmanagerd.control`. Codex uses `-derivedDataPath /tmp/...` and confirms via `xcrun xctest` directly when needed. The maestro re-runs the canonical `xcodebuild ... test` outside the sandbox.
+- **Manual verification gate:** Tasks 3, 6, 7 cannot be unit-tested end-to-end (real Screen Recording, real hotkey, real HUD render). PR 2 ships when all 11 unit tests pass AND PR-2.1, PR-2.3, PR-2.7 manual cases pass. PR-2.4, PR-2.5, PR-2.6, PR-2.8 are nice-to-have but not blocking.
+- **Bot review gate:** open the PR, wait for Gemini + Copilot to review (CodeRabbit is rate-limited; will appear when it appears). Expect 5–15 minutes. If they flag anything substantial, batch a small follow-up commit on the same branch — don't open a separate PR for tiny bot fixes.

--- a/docs/superpowers/plans/2026-04-26-pr3-review-debt.md
+++ b/docs/superpowers/plans/2026-04-26-pr3-review-debt.md
@@ -1,0 +1,889 @@
+# PR 3 — Review-debt cleanup from PR #18
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use `superpowers:subagent-driven-development` (recommended) or `superpowers:executing-plans`. Steps use checkbox (`- [ ]`) syntax. **Project-specific:** "subagent" maps to Codex via the `agent-codex:codex` skill; Claude Opus 4.7 reviews each commit. Tasks 1 (branch + push) and 8 (PR creation) are maestro-only because Codex's sandbox blocks `.git` writes and `gh` writes.
+
+**Goal:** Land the five review items the PR #18 5-agent review surfaced and that `TODO_FOR_OZZY.md` queued under "PR-3 follow-up items." After PR-3, the heartbeat ships clean: no silent capture-failure UX, no observability gaps on partial failures, no concurrent-invocation race, full test coverage of the gate-outcome state machine.
+
+**Architecture:** Five disjoint changes. Two test-only additions, one tiny logging fix, one HotkeyManager refactor (sync trigger → async trigger with in-flight guard), one new SwiftUI view (`HUDErrorView`) plumbed through the existing `HUDPanelController` / `HotkeyInvocationHandler` pipeline. No new TCC-protected APIs touched. PermissionsGate boundary stays intact.
+
+**Tech stack:** Swift 5.10, SwiftUI, AppKit, KeyboardShortcuts, XCTest, Xcode 16+, macOS 14.0+. No new dependencies.
+
+**Spec sources:** `TODO_FOR_OZZY.md` "PR-3 follow-up items from PR #18 review" (5 checkboxes); the agent reports captured in PR #18's review thread (`silent-failure-hunter`, `pr-test-analyzer`, `code-reviewer`, `comment-analyzer`, `type-design-analyzer`).
+
+**Out of scope:**
+
+- AX tree, focused-window metadata (Week 2 — separate PR)
+- Voice / WhisperKit (Week 3)
+- Auto-dismiss timer on the error HUD (timing complexity; v1 mirrors the screenshot HUD's dismiss behavior)
+- Retry button on the error HUD (user re-presses the hotkey)
+- Refactoring `PermissionsGate` to a protocol (not needed; tests can hit `.notImplemented` via a non-implemented `PermissionKind` once the handler accepts a `kind` parameter)
+
+---
+
+## Pre-flight
+
+### Task 1: Branch off develop (maestro only)
+
+**Files:** none
+
+**Why maestro-only:** `.git/index.lock` writes are blocked by Codex's `workspace-write` sandbox.
+
+- [ ] **Step 1: Sync develop and create the feature branch**
+
+```bash
+git checkout develop && git pull origin develop && \
+  git checkout -b feature/pr3-review-debt && \
+  git push -u origin feature/pr3-review-debt
+```
+
+Expected: `Switched to a new branch 'feature/pr3-review-debt'`, branch tracks origin.
+
+---
+
+## Test-only additions
+
+### Task 2: Add `.notImplemented` → `.restricted` test (parameterize `kind`)
+
+**Files:**
+
+- Modify: `TAELMacAgent/TAELMacAgent/App/HotkeyInvocationHandler.swift`
+- Modify: `TAELMacAgent/TAELMacAgent/App/AppDelegate.swift`
+- Modify: `TAELMacAgent/TAELMacAgentTests/HotkeyHandlerTests.swift`
+
+**Why:** `HotkeyInvocationHandler.run()` maps `PermissionError.notImplemented` to `gateOutcome = .restricted`, but no test exercises that branch. The handler hardcodes `.screenRecording`, so the `.notImplemented` path is unreachable from tests today. Smallest-possible refactor: add a `kind: PermissionKind` init parameter defaulting to `.screenRecording` (production behavior unchanged), then test with `.accessibility` or `.microphone` (whose `isImplemented` returns `false` for Week 1).
+
+**Ordering:** test-only items first because they have zero production-behavior risk. If any of Tasks 4–6 regress, these tests must remain green to prove the regression is in the new code, not the test fixture.
+
+- [ ] **Step 1: Add `kind` parameter to `HotkeyInvocationHandler`**
+
+In `TAELMacAgent/TAELMacAgent/App/HotkeyInvocationHandler.swift`, modify the struct:
+
+```swift
+@MainActor
+struct HotkeyInvocationHandler {
+    let permissionsGate: PermissionsGate
+    let screenCaptureService: any DisplayScreenshotCapturing
+    let presentScreenshot: (CapturedScreenshot) -> Void
+    let logService: LocalLogService
+    let now: () -> Date
+    let kind: PermissionKind
+
+    init(
+        permissionsGate: PermissionsGate,
+        screenCaptureService: any DisplayScreenshotCapturing,
+        presentScreenshot: @escaping (CapturedScreenshot) -> Void,
+        logService: LocalLogService,
+        now: @escaping () -> Date = Date.init,
+        kind: PermissionKind = .screenRecording
+    ) {
+        self.permissionsGate = permissionsGate
+        self.screenCaptureService = screenCaptureService
+        self.presentScreenshot = presentScreenshot
+        self.logService = logService
+        self.now = now
+        self.kind = kind
+    }
+    // ... existing log + run() ...
+}
+```
+
+In `run()`, change the hardcoded `.screenRecording` to `kind`:
+
+```swift
+let screenshot = try await permissionsGate.withPermission(kind) { grant in
+    // ...
+}
+```
+
+The `precondition` inside `ScreenCaptureService.captureDisplayScreenshot` still requires `.screenRecording`, so passing any other kind through to a real capture would assert. That's correct — production stays bound to `.screenRecording`; tests using a non-`.screenRecording` kind never reach the capture call (the gate throws first).
+
+- [ ] **Step 2: AppDelegate — no change needed**
+
+The default `kind: PermissionKind = .screenRecording` means `AppDelegate` keeps calling `HotkeyInvocationHandler(...)` without specifying kind. Verify the call site doesn't need updates by `grep`-ing:
+
+```bash
+grep -n "HotkeyInvocationHandler(" TAELMacAgent/TAELMacAgent/App/AppDelegate.swift
+```
+
+Expected: one match, no `kind:` argument needed.
+
+- [ ] **Step 3: Add the new test**
+
+In `TAELMacAgent/TAELMacAgentTests/HotkeyHandlerTests.swift`, add after the capture-failure test:
+
+```swift
+// MARK: - Not-implemented kind
+
+func test_run_whenKindNotImplemented_doesNotCapture_logsRestricted() async {
+    // Use a kind whose isImplemented returns false today (Week 1
+    // implements only .screenRecording). The gate throws .notImplemented
+    // before any capture work runs.
+    let checker = StubChecker(.granted)
+    let ui = SpyUI()
+    let gate = PermissionsGate(checker: checker, permissionUI: ui)
+    let capture = SpyCapture(stub: makeStubScreenshot())
+    let logService = LocalLogService(capacity: 16)
+
+    var presented: [CapturedScreenshot] = []
+    let handler = HotkeyInvocationHandler(
+        permissionsGate: gate,
+        screenCaptureService: capture,
+        presentScreenshot: { presented.append($0) },
+        logService: logService,
+        kind: .accessibility
+    )
+
+    await handler.run()
+
+    let observed = await capture.observedTargets()
+    XCTAssertTrue(observed.isEmpty, "Capture must not run when kind is unimplemented")
+    XCTAssertTrue(presented.isEmpty)
+
+    let logs = await logService.recent(10)
+    XCTAssertEqual(logs.count, 1)
+    XCTAssertEqual(logs.first?.gateOutcome, .restricted)
+    XCTAssertNil(logs.first?.gateLatencyMs, "gate didn't grant; latency must stay nil")
+    XCTAssertNotNil(logs.first?.errorDescription)
+
+    // The gate does NOT show UI for .notImplemented (per the existing
+    // PermissionsGateTests contract: not-implemented is silent).
+    let shown = await ui.shownKinds
+    XCTAssertTrue(shown.isEmpty)
+}
+```
+
+- [ ] **Step 4: Build + run only the new test**
+
+```bash
+xcodebuild test \
+  -project TAELMacAgent/TAELMacAgent.xcodeproj \
+  -scheme TAELMacAgent \
+  -destination 'platform=macOS' \
+  CODE_SIGNING_ALLOWED=NO \
+  -only-testing:TAELMacAgentTests/HotkeyHandlerTests/test_run_whenKindNotImplemented_doesNotCapture_logsRestricted
+```
+
+Expected: 1 test passes.
+
+- [ ] **Step 5: Run the full suite**
+
+```bash
+xcodebuild -project TAELMacAgent/TAELMacAgent.xcodeproj \
+  -scheme TAELMacAgent -configuration Debug \
+  -destination 'platform=macOS' CODE_SIGNING_ALLOWED=NO test
+```
+
+Expected: 12 tests pass (5 PermissionsGate + 3 LocalLogService + 4 HotkeyHandler).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add TAELMacAgent/TAELMacAgent/App/HotkeyInvocationHandler.swift \
+        TAELMacAgent/TAELMacAgentTests/HotkeyHandlerTests.swift
+git commit -m "test(handler): cover .notImplemented → .restricted mapping
+
+HotkeyInvocationHandler maps PermissionError.notImplemented to
+GateOutcome.restricted, but the previous tests hardcoded
+.screenRecording so the branch was unreachable. Add a kind:
+PermissionKind init parameter (defaulting to .screenRecording — no
+production behavior change) and exercise the branch by passing
+.accessibility, whose isImplemented returns false for Week 1."
+```
+
+---
+
+### Task 3: Deterministic-clock latency assertions
+
+**Files:**
+
+- Modify: `TAELMacAgent/TAELMacAgentTests/HotkeyHandlerTests.swift`
+
+**Why:** existing tests assert `XCTAssertNotNil(logs.first?.gateLatencyMs)`. A regression that drops `* 1000` (units) or flips a sign or computes from the wrong baseline would not fail. The handler already accepts `now: () -> Date = Date.init` — wire a stub clock through it and pin exact ms values + ordering.
+
+- [ ] **Step 1: Add a clock helper in `HotkeyHandlerTests`**
+
+Above the test methods (after `makeStubScreenshot`), add:
+
+```swift
+/// Pops dates from a fixed sequence each time it's read. The handler
+/// reads `now()` exactly twice on the granted path (gateEnd, captureEnd)
+/// and once on the failure paths (`started` only). Provide enough slots
+/// for the longest path. Built as a class so the closure-captured `var`
+/// stays alive across reads from any actor.
+private final class StubClock: @unchecked Sendable {
+    private var ticks: [Date]
+    init(_ ticks: [Date]) { self.ticks = ticks }
+    func next() -> Date {
+        precondition(!ticks.isEmpty, "StubClock ran out of ticks")
+        return ticks.removeFirst()
+    }
+}
+```
+
+- [ ] **Step 2: Strengthen the granted test**
+
+Replace the granted-path test body with the deterministic version:
+
+```swift
+func test_run_whenGranted_callsCaptureAndPresentsAndLogsGranted() async {
+    let checker = StubChecker(.granted)
+    let ui = SpyUI()
+    let gate = PermissionsGate(checker: checker, permissionUI: ui)
+    let capture = SpyCapture(stub: makeStubScreenshot())
+    let logService = LocalLogService(capacity: 16)
+
+    // Pin exact latencies: started=0, gateEnd=0.1 (gate took 100ms),
+    // captureEnd=0.3 (capture took 200ms). 4 slots: started, gateEnd,
+    // captureStart (= gateEnd in handler, but read separately is fine
+    // since handler aliases captureStart = gateEnd via let), captureEnd.
+    let clock = StubClock([
+        Date(timeIntervalSince1970: 0),
+        Date(timeIntervalSince1970: 0.1),
+        Date(timeIntervalSince1970: 0.3),
+    ])
+
+    var presented: [CapturedScreenshot] = []
+    let handler = HotkeyInvocationHandler(
+        permissionsGate: gate,
+        screenCaptureService: capture,
+        presentScreenshot: { presented.append($0) },
+        logService: logService,
+        now: { clock.next() }
+    )
+
+    await handler.run()
+
+    let targets = await capture.observedTargets()
+    XCTAssertEqual(targets, [.week1Default])
+    XCTAssertEqual(presented.count, 1)
+
+    let logs = await logService.recent(10)
+    XCTAssertEqual(logs.count, 1)
+    let row = try XCTUnwrap(logs.first)
+    XCTAssertEqual(row.gateOutcome, .granted)
+    XCTAssertEqual(row.gateLatencyMs, 100, accuracy: 0.001,
+        "gate took 100ms (0 → 0.1 second), value must be ms not seconds")
+    XCTAssertEqual(row.captureLatencyMs, 200, accuracy: 0.001,
+        "capture took 200ms (0.1 → 0.3 second)")
+    XCTAssertGreaterThanOrEqual(row.gateLatencyMs ?? -1, 0)
+    XCTAssertGreaterThanOrEqual(row.captureLatencyMs ?? -1, 0)
+}
+```
+
+Note: `XCTUnwrap` requires `try` and the test method becomes `async throws` — change the signature.
+
+- [ ] **Step 3: Strengthen the capture-failure test similarly**
+
+Replace its body:
+
+```swift
+func test_run_whenCaptureFails_logsErroredOutcome() async throws {
+    let checker = StubChecker(.granted)
+    let ui = SpyUI()
+    let gate = PermissionsGate(checker: checker, permissionUI: ui)
+    let capture = SpyCapture(stub: makeStubScreenshot())
+    await capture.setError(ScreenCaptureError.captureFailed("simulated"))
+
+    let logService = LocalLogService(capacity: 16)
+
+    let clock = StubClock([
+        Date(timeIntervalSince1970: 0),
+        Date(timeIntervalSince1970: 0.05),
+    ])
+
+    var presented: [CapturedScreenshot] = []
+    let handler = HotkeyInvocationHandler(
+        permissionsGate: gate,
+        screenCaptureService: capture,
+        presentScreenshot: { presented.append($0) },
+        logService: logService,
+        now: { clock.next() }
+    )
+
+    await handler.run()
+
+    XCTAssertTrue(presented.isEmpty)
+    let logs = await logService.recent(10)
+    XCTAssertEqual(logs.count, 1)
+    let row = try XCTUnwrap(logs.first)
+    XCTAssertEqual(row.gateOutcome, .errored)
+    XCTAssertEqual(row.errorDescription, "captureFailed(\"simulated\")")
+    XCTAssertEqual(row.gateLatencyMs, 50, accuracy: 0.001,
+        "gate granted in 50ms before capture threw; latency must be retained")
+}
+```
+
+- [ ] **Step 4: Run the full suite**
+
+```bash
+xcodebuild -project TAELMacAgent/TAELMacAgent.xcodeproj \
+  -scheme TAELMacAgent -configuration Debug \
+  -destination 'platform=macOS' CODE_SIGNING_ALLOWED=NO test
+```
+
+Expected: 12 tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add TAELMacAgent/TAELMacAgentTests/HotkeyHandlerTests.swift
+git commit -m "test(handler): pin latency values with a deterministic clock
+
+Existing assertions only checked notNil. A units regression (missing
+* 1000) or a sign flip would have shipped silently. Inject a StubClock
+through the handler's existing now: closure parameter and assert exact
+millisecond values for both the granted path (100ms gate + 200ms
+capture) and the capture-failure path (50ms gate, latency retained
+across the failure)."
+```
+
+---
+
+## Production fixes
+
+### Task 4: Concurrent-invocation guard in `HotkeyManager`
+
+**Files:**
+
+- Modify: `TAELMacAgent/TAELMacAgent/Hotkey/HotkeyManager.swift`
+- Modify: `TAELMacAgent/TAELMacAgent/App/AppDelegate.swift`
+- Modify: `TAELMacAgent/TAELMacAgentTests/` (new file `HotkeyManagerTests.swift`)
+
+**Why:** two rapid hotkey presses spawn two concurrent `Task { await handler.run() }` blocks. The slower one's HUD wins. If invocation #1 succeeds late and #2 fails fast, the user sees invocation #1's screenshot with no signal that the most recent press failed. Fix: change `onTrigger` from `() -> Void` to `() async -> Void`, gate it with an `isInFlight` flag inside `HotkeyManager`. Drops re-entrant presses. AppDelegate adapts.
+
+**Why HotkeyManager and not the handler:** the manager is the entity that knows about hotkey events. The handler is per-invocation; making it self-aware of a sibling invocation is awkward. Manager-level debounce is the natural seam.
+
+- [ ] **Step 1: Update `HotkeyManager` to async trigger + in-flight guard**
+
+Replace `TAELMacAgent/TAELMacAgent/Hotkey/HotkeyManager.swift` body:
+
+```swift
+@MainActor
+final class HotkeyManager {
+    /// Set by `AppDelegate` to the gate→capture→HUD pipeline. Async so
+    /// the manager can `await` it and clear the in-flight guard only
+    /// after the full invocation completes.
+    var onTrigger: (() async -> Void)?
+
+    private var isInFlight = false
+
+    func installBinding() {
+        KeyboardShortcuts.onKeyDown(for: .toggleTAEL) { [weak self] in
+            self?.fireIfFree()
+        }
+    }
+
+    /// Drops the press if a previous invocation hasn't completed yet.
+    private func fireIfFree() {
+        guard !isInFlight else { return }
+        guard let onTrigger else { return }
+        isInFlight = true
+        Task { @MainActor [weak self] in
+            await onTrigger()
+            self?.isInFlight = false
+        }
+    }
+
+    func tearDown() {
+        KeyboardShortcuts.disable(.toggleTAEL)
+        onTrigger = nil
+        isInFlight = false
+    }
+
+    // MARK: - Test seam
+
+    /// Test-only entry: simulates a hotkey press without going through
+    /// the KeyboardShortcuts package. Exposed via @testable import.
+    func simulatePressForTesting() {
+        fireIfFree()
+    }
+}
+```
+
+- [ ] **Step 2: Update `AppDelegate` — onTrigger closure becomes async**
+
+The current closure does `Task { @MainActor in await handler.run() }` because `onTrigger` was `() -> Void`. With the new async signature, the inner `Task` is redundant. Replace:
+
+```swift
+hotkeyManager.onTrigger = { [weak self] in
+    guard let self,
+          let permissionsGate = self.permissionsGate,
+          let screenCaptureService = self.screenCaptureService,
+          let hudController = self.hudController,
+          let logService = self.logService else { return }
+    let handler = HotkeyInvocationHandler(
+        permissionsGate: permissionsGate,
+        screenCaptureService: screenCaptureService,
+        presentScreenshot: { shot in hudController.present(screenshot: shot) },
+        logService: logService
+    )
+    Task { @MainActor in
+        await handler.run()
+    }
+}
+```
+
+With:
+
+```swift
+hotkeyManager.onTrigger = { [weak self] in
+    guard let self,
+          let permissionsGate = self.permissionsGate,
+          let screenCaptureService = self.screenCaptureService,
+          let hudController = self.hudController,
+          let logService = self.logService else {
+        AppDelegate.log.error("Hotkey fired but app state unavailable; ignoring")
+        return
+    }
+    let handler = HotkeyInvocationHandler(
+        permissionsGate: permissionsGate,
+        screenCaptureService: screenCaptureService,
+        presentScreenshot: { shot in hudController.present(screenshot: shot) },
+        logService: logService
+    )
+    await handler.run()
+}
+```
+
+(Also addresses Task 5's teardown-race logger requirement in the same edit. Convert `private let log = Logger(...)` to `private static let log = Logger(...)` at the class level so the static reference works in the guard's else.)
+
+- [ ] **Step 3: Add `HotkeyManagerTests`**
+
+Create `TAELMacAgent/TAELMacAgentTests/HotkeyManagerTests.swift`:
+
+```swift
+//
+//  HotkeyManagerTests.swift
+//  TAELMacAgentTests
+//
+
+import XCTest
+@testable import TAELMacAgent
+
+@MainActor
+final class HotkeyManagerTests: XCTestCase {
+
+    func test_simulatePress_invokesTriggerOnce_evenIfFiredTwiceConcurrently() async {
+        let manager = HotkeyManager()
+
+        // Use an actor counter so concurrent reads/writes are safe.
+        let counter = Counter()
+
+        manager.onTrigger = {
+            await counter.increment()
+            // Hold the in-flight gate open long enough for a second press
+            // to race in. Sleep on the main actor is fine; we just need
+            // the Task to suspend.
+            try? await Task.sleep(nanoseconds: 50_000_000) // 50ms
+        }
+
+        manager.simulatePressForTesting()
+        // Second press while the first is still in-flight; must be dropped.
+        manager.simulatePressForTesting()
+
+        // Wait for the in-flight Task to complete + a margin.
+        try? await Task.sleep(nanoseconds: 100_000_000) // 100ms
+
+        let count = await counter.value
+        XCTAssertEqual(count, 1, "Re-entrant press during in-flight invocation must be dropped")
+    }
+
+    func test_simulatePress_afterPreviousCompletes_invokesTriggerAgain() async {
+        let manager = HotkeyManager()
+        let counter = Counter()
+
+        manager.onTrigger = {
+            await counter.increment()
+        }
+
+        manager.simulatePressForTesting()
+        try? await Task.sleep(nanoseconds: 20_000_000) // let it finish
+        manager.simulatePressForTesting()
+        try? await Task.sleep(nanoseconds: 20_000_000)
+
+        let count = await counter.value
+        XCTAssertEqual(count, 2, "Sequential presses must each fire once")
+    }
+
+    func test_tearDown_clearsInFlightAndOnTrigger() async {
+        let manager = HotkeyManager()
+        manager.onTrigger = { /* no-op */ }
+        manager.simulatePressForTesting()
+
+        // Tear down immediately; even though the in-flight Task may still
+        // run, the manager's state should be reset for next session.
+        manager.tearDown()
+
+        XCTAssertNil(manager.onTrigger)
+    }
+
+    private actor Counter {
+        private(set) var value = 0
+        func increment() { value += 1 }
+    }
+}
+```
+
+- [ ] **Step 4: Run the full suite**
+
+```bash
+xcodebuild -project TAELMacAgent/TAELMacAgent.xcodeproj \
+  -scheme TAELMacAgent -configuration Debug \
+  -destination 'platform=macOS' CODE_SIGNING_ALLOWED=NO test
+```
+
+Expected: 15 tests pass (12 prior + 3 HotkeyManager).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add TAELMacAgent/TAELMacAgent/Hotkey/HotkeyManager.swift \
+        TAELMacAgent/TAELMacAgent/App/AppDelegate.swift \
+        TAELMacAgent/TAELMacAgentTests/HotkeyManagerTests.swift \
+        TAELMacAgent/TAELMacAgent.xcodeproj/project.pbxproj
+git commit -m "feat(hotkey): drop re-entrant presses while invocation is in-flight
+
+Two rapid hotkey presses used to spawn two concurrent Task blocks; the
+slower invocation's HUD content won regardless of which press was most
+recent. HotkeyManager now flips an isInFlight flag when firing onTrigger
+and clears it after the awaited closure returns. Re-entrant presses are
+dropped silently.
+
+onTrigger signature changes from () -> Void to () async -> Void;
+AppDelegate adapts. The previous fire-and-forget Task wrapper at the
+call site is no longer needed because HotkeyManager owns the Task now.
+
+Also: AppDelegate.log is now a static let so the guard-failed teardown
+path can log without a self reference (silent-failure-hunter
+BLOCKER 2 from PR #18 review).
+
+Three new HotkeyManagerTests cover: re-entrant drop, sequential fire-
+again, tearDown clears state."
+```
+
+---
+
+### Task 5: Subsumed by Task 4
+
+The teardown-race logger fix folds into Task 4 (the AppDelegate guard's else clause now logs via `AppDelegate.log`). No separate task needed; this slot is intentionally empty so the task numbering matches the TODO_FOR_OZZY item count when reading both side-by-side.
+
+---
+
+### Task 6: Error HUD on capture failure
+
+**Files:**
+
+- Create: `TAELMacAgent/TAELMacAgent/HUD/HUDErrorView.swift`
+- Modify: `TAELMacAgent/TAELMacAgent/HUD/HUDPanelController.swift`
+- Modify: `TAELMacAgent/TAELMacAgent/App/HotkeyInvocationHandler.swift`
+- Modify: `TAELMacAgent/TAELMacAgent/App/AppDelegate.swift`
+- Modify: `TAELMacAgent/TAELMacAgentTests/HotkeyHandlerTests.swift`
+
+**Why:** today, capture failure writes an `InvocationLog` row + `os.log` line and returns silently. The user sees nothing — they assume the hotkey is broken and press it again, harder. v0.3 §23.4 only requires "doesn't crash," so this isn't a Week 1 blocker, but the heartbeat's UX intent is feedback. Add a parallel `HUDErrorView` and a `presentError: (String) -> Void` closure on the handler.
+
+**Design choices fixed:**
+
+- Multi-line view: title + message
+- Click to dismiss: not in v1 (would require NSPanel mouse-event interception; defer)
+- Auto-dismiss timer: not in v1 (timing complexity)
+- Dismiss behavior: same as the screenshot HUD — replaced by the next hotkey press; otherwise sticks around. Acceptable for v1.
+
+- [ ] **Step 1: Create `HUDErrorView`**
+
+Create `TAELMacAgent/TAELMacAgent/HUD/HUDErrorView.swift`:
+
+```swift
+//
+//  HUDErrorView.swift
+//  TAELMacAgent
+//
+//  Shown when a hotkey invocation reaches the capture stage and fails.
+//  Mirrors HUDScreenshotView's layout for visual consistency.
+//
+
+import SwiftUI
+
+struct HUDErrorView: View {
+    let message: String
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Label("Capture failed", systemImage: "exclamationmark.triangle.fill")
+                .font(.headline)
+                .foregroundStyle(.orange)
+
+            Text(message)
+                .font(.body)
+                .foregroundStyle(.secondary)
+                .frame(maxWidth: 480, alignment: .leading)
+                .fixedSize(horizontal: false, vertical: true)
+        }
+        .padding(16)
+    }
+}
+```
+
+- [ ] **Step 2: Add `present(error:)` to `HUDPanelController`**
+
+In `TAELMacAgent/TAELMacAgent/HUD/HUDPanelController.swift`, add the method next to `present(screenshot:)`:
+
+```swift
+func present(error message: String) {
+    presentNew(content: HUDErrorView(message: message))
+}
+```
+
+- [ ] **Step 3: Add `presentError` to `HotkeyInvocationHandler`**
+
+In `TAELMacAgent/TAELMacAgent/App/HotkeyInvocationHandler.swift`, add the property + init parameter:
+
+```swift
+let presentError: (String) -> Void
+
+init(
+    permissionsGate: PermissionsGate,
+    screenCaptureService: any DisplayScreenshotCapturing,
+    presentScreenshot: @escaping (CapturedScreenshot) -> Void,
+    presentError: @escaping (String) -> Void = { _ in },
+    logService: LocalLogService,
+    now: @escaping () -> Date = Date.init,
+    kind: PermissionKind = .screenRecording
+) {
+    self.permissionsGate = permissionsGate
+    self.screenCaptureService = screenCaptureService
+    self.presentScreenshot = presentScreenshot
+    self.presentError = presentError
+    self.logService = logService
+    self.now = now
+    self.kind = kind
+}
+```
+
+(Default `{ _ in }` so existing tests that don't care about errors still construct cleanly.)
+
+In `run()`'s generic-error catch arm, add the `presentError` call AFTER the log row is recorded (so observability lands first, then UI):
+
+```swift
+} catch {
+    await logService.record(InvocationLog(
+        hotkeyTimestamp: started,
+        gateOutcome: .errored,
+        gateLatencyMs: gateLatencyMs,
+        errorDescription: String(describing: error)
+    ))
+    presentError("Screen capture failed: \(error.localizedDescription)")
+    Self.log.error("Hotkey invocation failed: \(error.localizedDescription, privacy: .public)")
+}
+```
+
+Do NOT add `presentError` to the `PermissionError` catch arm — `PermissionsGate` already shows a permission UI. Calling `presentError` there would stack two HUD panels.
+
+- [ ] **Step 4: Wire in `AppDelegate`**
+
+In the `onTrigger` closure (already async after Task 4), update the handler construction:
+
+```swift
+let handler = HotkeyInvocationHandler(
+    permissionsGate: permissionsGate,
+    screenCaptureService: screenCaptureService,
+    presentScreenshot: { shot in hudController.present(screenshot: shot) },
+    presentError: { msg in hudController.present(error: msg) },
+    logService: logService
+)
+```
+
+- [ ] **Step 5: Strengthen the capture-failure test**
+
+In `HotkeyHandlerTests.swift`, update `test_run_whenCaptureFails_logsErroredOutcome` to also assert `presentError` was called:
+
+```swift
+var presented: [CapturedScreenshot] = []
+var presentedErrors: [String] = []
+let handler = HotkeyInvocationHandler(
+    permissionsGate: gate,
+    screenCaptureService: capture,
+    presentScreenshot: { presented.append($0) },
+    presentError: { presentedErrors.append($0) },
+    logService: logService,
+    now: { clock.next() }
+)
+
+await handler.run()
+
+XCTAssertTrue(presented.isEmpty)
+XCTAssertEqual(presentedErrors.count, 1)
+let msg = try XCTUnwrap(presentedErrors.first)
+XCTAssertTrue(msg.contains("Screen capture failed"),
+    "Error HUD message should lead with the user-facing prefix")
+```
+
+Also update the granted, denied, and `.notImplemented` tests to pass a no-op `presentError: { _ in }` (or rely on the default — verify the default is still in the init).
+
+In the granted test, ALSO assert `presentedErrors.isEmpty` — the success path must not present an error.
+
+- [ ] **Step 6: Run the full suite**
+
+```bash
+xcodebuild -project TAELMacAgent/TAELMacAgent.xcodeproj \
+  -scheme TAELMacAgent -configuration Debug \
+  -destination 'platform=macOS' CODE_SIGNING_ALLOWED=NO test
+```
+
+Expected: 15 tests pass.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add TAELMacAgent/TAELMacAgent/HUD/HUDErrorView.swift \
+        TAELMacAgent/TAELMacAgent/HUD/HUDPanelController.swift \
+        TAELMacAgent/TAELMacAgent/App/HotkeyInvocationHandler.swift \
+        TAELMacAgent/TAELMacAgent/App/AppDelegate.swift \
+        TAELMacAgent/TAELMacAgentTests/HotkeyHandlerTests.swift \
+        TAELMacAgent/TAELMacAgent.xcodeproj/project.pbxproj
+git commit -m "feat(hud): show error HUD on capture failure
+
+Capture failures used to write an InvocationLog row plus an os.log
+line and return silently — from the user's seat the hotkey just did
+nothing. Add HUDErrorView and a presentError closure on
+HotkeyInvocationHandler. The PermissionError catch arm intentionally
+does NOT call presentError because PermissionsGate already shows the
+permission UI; double-stacking would be confusing.
+
+Test asserts: granted path doesn't fire presentError; capture-failure
+path fires it exactly once with a message that leads with 'Screen
+capture failed'."
+```
+
+---
+
+## Documentation
+
+### Task 7: Mark PR-3 items complete in `TODO_FOR_OZZY.md`
+
+**Files:**
+
+- Modify: `TODO_FOR_OZZY.md`
+
+**Why:** the "PR-3 follow-up items from PR #18 review" section has 5 unchecked boxes. After the implementation tasks land, flip them to `[x]` with a short status line.
+
+- [ ] **Step 1: Edit each checkbox**
+
+For each of the 5 items:
+
+- `User-facing error HUD on capture failure` → `[x]` + "Shipped 2026-04-26 in PR-3 (Task 6). HUDErrorView + presentError closure."
+- `Hotkey closure teardown race` → `[x]` + "Shipped 2026-04-26 in PR-3 (Task 4). AppDelegate guard's else clause now logs via AppDelegate.log."
+- `Concurrent invocation guard` → `[x]` + "Shipped 2026-04-26 in PR-3 (Task 4). HotkeyManager isInFlight flag drops re-entrant presses."
+- `Test: deterministic-clock latency assertions` → `[x]` + "Shipped 2026-04-26 in PR-3 (Task 3). StubClock pins exact ms values."
+- `Test: .notImplemented → .restricted mapping` → `[x]` + "Shipped 2026-04-26 in PR-3 (Task 2). Handler accepts kind: PermissionKind init param; test uses .accessibility."
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add TODO_FOR_OZZY.md
+git commit -m "docs(todo): mark PR-3 review-debt items complete
+
+All five PR #18 review follow-ups landed in PR-3. Status updated with
+the task that addressed each item."
+```
+
+---
+
+## Wrap up (maestro only)
+
+### Task 8: Open the PR
+
+**Files:** none (orchestration)
+
+**Why maestro-only:** `gh pr create` writes to GitHub.
+
+- [ ] **Step 1: Run the full clean test suite**
+
+```bash
+xcodebuild -project TAELMacAgent/TAELMacAgent.xcodeproj \
+  -scheme TAELMacAgent -configuration Debug \
+  -destination 'platform=macOS' CODE_SIGNING_ALLOWED=NO clean test
+```
+
+Expected: 15 tests pass.
+
+- [ ] **Step 2: Confirm the branch state**
+
+```bash
+git log origin/develop..HEAD --oneline
+```
+
+Expected: 5 or 6 commits (Tasks 2, 3, 4, 6, 7; Task 5 folded into Task 4).
+
+- [ ] **Step 3: Push**
+
+```bash
+git push origin feature/pr3-review-debt
+```
+
+- [ ] **Step 4: Open the PR**
+
+```bash
+gh pr create --base develop --head feature/pr3-review-debt \
+  --title "feat: PR 3 — review-debt cleanup from PR #18" \
+  --body "$(cat <<'EOF'
+## Summary
+
+Lands the five review items the PR #18 5-agent review surfaced. Plan: `docs/superpowers/plans/2026-04-26-pr3-review-debt.md`.
+
+## What's in
+
+- **Error HUD on capture failure** — new `HUDErrorView` + `presentError` closure. Capture failures now show a user-facing error instead of returning silently.
+- **Concurrent-invocation guard** — `HotkeyManager` drops re-entrant presses while an invocation is in-flight. `onTrigger` is now `() async -> Void`.
+- **Teardown-race logger** — `AppDelegate.log` becomes static so the guard's else clause can log when the app state is unavailable during shutdown.
+- **Deterministic-clock latency assertions** — `StubClock` pins exact ms values on the granted and capture-failure paths. Catches units regressions (missing `* 1000`) and sign flips.
+- **`.notImplemented` → `.restricted` test** — `HotkeyInvocationHandler` accepts a `kind` parameter (defaulting to `.screenRecording` — no production behavior change). Test exercises the branch via `.accessibility`.
+
+## Test plan
+
+- [x] `xcodebuild ... clean test` — 15 tests, 0 failures (5 PermissionsGate + 3 LocalLogService + 4 HotkeyHandler + 3 HotkeyManager).
+- [ ] Manual: trigger a real capture failure (e.g., revoke Screen Recording mid-session) and confirm `HUDErrorView` appears with the orange triangle icon.
+- [ ] Manual: press the hotkey twice rapidly while a capture is in-flight; only one HUD should appear.
+
+## Out of scope
+
+- AX tree (Week 2)
+- Voice / WhisperKit (Week 3)
+- Auto-dismiss timer or click-to-dismiss on the error HUD (deferred for v1.1)
+- Refactoring `PermissionsGate` to a protocol (not needed for the test added here)
+EOF
+)"
+```
+
+Expected: PR URL printed. Notify Ozzy.
+
+---
+
+## Self-review checklist
+
+After writing the plan and before handing off:
+
+**1. Spec coverage:** All 5 PR-3 follow-up items in `TODO_FOR_OZZY.md` map to a task above (with Task 5 folded into Task 4). Cross-checked.
+
+**2. Placeholder scan:** No "TBD", "implement later", or "add appropriate error handling" patterns. Each step has concrete code or commands.
+
+**3. Type consistency:**
+
+- `HotkeyInvocationHandler` gains `kind: PermissionKind` (Task 2) and `presentError: (String) -> Void` (Task 6). Both have defaults so older test call sites don't need updates beyond the ones the plan calls out.
+- `HotkeyManager.onTrigger` changes from `() -> Void` to `() async -> Void` (Task 4). The single call site in `AppDelegate` is updated in the same task.
+- `HUDPanelController.present(error:)` is new (Task 6); `present(screenshot:)` stays.
+- `HUDErrorView` is a fresh SwiftUI struct, no conflicts.
+- `AppDelegate.log` migrates from `private let` to `private static let` (Task 4). All uses of `self.log` inside instance methods continue to work because `Self.log` is a valid reference; verify by `grep`.
+
+**4. Test count progression:** PR #18 left the suite at 11 tests. Plan adds: +1 (`.notImplemented`), 0 net (Task 3 strengthens existing tests), +3 (HotkeyManager). Final: 15. The PR title and commit messages must match.
+
+**5. Branch model alignment:** Feature branch off `develop`, single PR back into `develop`. Matches `project_branches` memory.
+
+---
+
+## Notes for the executor
+
+- **Tasks 1 + 8 are maestro-only** for the same reasons as PR-2: branch creation pushes to origin, PR creation hits GitHub.
+- **Sandbox commit pattern:** Codex's sandbox blocks `.git/index.lock` writes and `~/Library/Caches/org.swift.swiftpm`. Codex applies edits + reports diff; maestro stages, runs `xcodebuild test`, and commits. Same as PR #18 follow-up.
+- **Test seam for Task 4:** `HotkeyManager.simulatePressForTesting()` is a deliberate testability hook. It mirrors the pattern from `PermissionsGate` where production code only ever fires from the real path but tests have a public seam. Document it inline; do NOT remove it after PR-3 lands — Week 4+ will need it again when AX gets its own hotkey-derived workflow.
+- **Manual verification gate:** Task 6's error HUD can't be unit-tested visually. Manual case: revoke Screen Recording grant in System Settings → Privacy → Screen Recording while TAEL is running, then press the hotkey. Expected: `HUDErrorView` appears with the orange triangle and a message that contains "Screen capture failed".
+- **Bot review gate:** open the PR, wait for CodeRabbit. If it flags anything substantial, batch a follow-up commit on the same branch — don't open a separate PR.

--- a/docs/superpowers/plans/2026-04-26-pr4-accessibility-permission-gate.md
+++ b/docs/superpowers/plans/2026-04-26-pr4-accessibility-permission-gate.md
@@ -1,0 +1,510 @@
+# PR 4 — Week 2 part 1: Accessibility permission gate
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use `superpowers:subagent-driven-development` (recommended) or `superpowers:executing-plans`. Steps use checkbox (`- [ ]`) syntax. **Project-specific:** "subagent" maps to Codex via the `agent-codex:codex` skill; Claude Opus 4.7 reviews each commit. Tasks 1 (branch + push) and 7 (PR creation) are maestro-only because Codex's sandbox blocks `.git` writes and `gh` writes.
+
+**Goal:** Make the Accessibility permission flow real. `PermissionKind.accessibility.isImplemented` flips from `false` to `true`. `PermissionsChecker.status(for: .accessibility)` calls `AXIsProcessTrusted()` (no prompt — checking only, prompting stays the gate UI's job). The user-facing copy on `PermissionGateView` for `.accessibility` upgrades from "Not yet implemented" to a real explanation. After PR-4, calling `permissionsGate.withPermission(.accessibility) { ... }` actually gates against the OS state instead of throwing `.notImplemented`.
+
+**Architecture:** No new types, no new files. PR-4 only flips bits and fills in a real `AXIsProcessTrusted()` call. The existing `PermissionsGate` machinery (token, gate UI, checker) already handles `.accessibility` — PR-1 wired it as a placeholder. PR-3's `.notImplemented` → `.restricted` test that uses `.accessibility` becomes incorrect when AX is implemented; the test swaps to `.microphone` (which stays unimplemented until Week 3).
+
+**Tech stack:** Swift 5.10, ApplicationServices framework (`AXIsProcessTrusted`), AppKit, SwiftUI, XCTest. No new SPM dependencies.
+
+**Spec sources:** `TAEL_AI_mac_agent_build_plan_v0_3.md` §12.3 ("AX permission gate" deliverable), §23.0 ("Accessibility and Microphone may exist as enum placeholders, but they are not real checks until their milestones"), `docs/ProtectedAPICallPolicy.md` (the row that says "Future. Enum placeholder only" for Accessibility — gets flipped to "Active" in this PR).
+
+**Out of scope:**
+
+- AX tree reading, focused-window metadata, `AXService` (PR-5)
+- Context bundle v0 (combining screenshot + AX) (PR-5 or PR-6)
+- Any actual call to `AXUIElementCopyAttributeValue` or sibling AX read APIs (PR-5)
+- Microphone, Apple Events, Input Monitoring permissions (their own milestone weeks)
+- Real prompt UX on first launch — `AXIsProcessTrustedWithOptions([kAXTrustedCheckOptionPrompt: true])` deliberately not used; gate UI is the prompt path
+
+---
+
+## Pre-flight
+
+### Task 1: Branch off develop (maestro only)
+
+**Files:** none
+
+**Why maestro-only:** `.git/index.lock` writes are blocked by Codex's `workspace-write` sandbox.
+
+**Pre-condition:** PR #19 (PR-3 review-debt) must be merged into `develop` first, OR branch off `feature/pr3-review-debt` if PR-3 hasn't merged yet — pick the cleaner of the two when this task runs.
+
+- [ ] **Step 1: Confirm PR #19 status and pick the base**
+
+```bash
+gh pr view 19 --json state,mergeStateStatus
+```
+
+If `state: "MERGED"`, branch off `develop`. If still `OPEN` and you want PR-4 to start now anyway, branch off `feature/pr3-review-debt` (PR-4 will rebase later).
+
+- [ ] **Step 2: Sync develop and create the feature branch**
+
+```bash
+git checkout develop && git pull origin develop && \
+  git checkout -b feature/pr4-accessibility-permission-gate && \
+  git push -u origin feature/pr4-accessibility-permission-gate
+```
+
+Expected: `Switched to a new branch 'feature/pr4-accessibility-permission-gate'`, branch tracks origin.
+
+---
+
+## The permission flip
+
+### Task 2: Make `PermissionKind.accessibility.isImplemented` return `true`
+
+**Files:**
+
+- Modify: `TAELMacAgent/TAELMacAgent/Permissions/PermissionKind.swift`
+
+**Why:** the `isImplemented` flag is what makes `PermissionsGate.withPermission` short-circuit with `.notImplemented` for placeholder kinds. Flipping `.accessibility` to `true` removes the short-circuit; the gate now consults `PermissionsChecker` and either grants or shows the gate UI.
+
+- [ ] **Step 1: Edit the switch in `isImplemented`**
+
+In `TAELMacAgent/TAELMacAgent/Permissions/PermissionKind.swift`, change:
+
+```swift
+public var isImplemented: Bool {
+    switch self {
+    case .screenRecording: return true
+    case .accessibility, .microphone, .appleEvents, .inputMonitoring:
+        return false
+    }
+}
+```
+
+To:
+
+```swift
+public var isImplemented: Bool {
+    switch self {
+    case .screenRecording, .accessibility: return true
+    case .microphone, .appleEvents, .inputMonitoring:
+        return false
+    }
+}
+```
+
+- [ ] **Step 2: Commit**
+
+This commit will *break* a test (the `.notImplemented` test in `HotkeyHandlerTests` uses `.accessibility`). That's intentional — Task 4 fixes it. Commit Task 2 + Task 4 sequentially without running the suite in between, OR temporarily defer this commit until Task 4's fix is also staged. Pick the cleaner per-task split:
+
+**Decision:** stage Tasks 2, 3, 4 together and commit as one logical unit. The semantic change is "Accessibility moves from placeholder to active, and the test that exercised the placeholder branch updates accordingly." Splitting that across three commits would leave the middle one with a known-broken test. See Task 4's commit message; Tasks 2 and 3 don't get their own commits.
+
+---
+
+### Task 3: Real `PermissionsChecker.status(for: .accessibility)`
+
+**Files:**
+
+- Modify: `TAELMacAgent/TAELMacAgent/Permissions/PermissionsChecker.swift`
+
+**Why:** the checker currently returns `.notDetermined` for `.accessibility`. Replace with a real `AXIsProcessTrusted()` call. We do NOT use `AXIsProcessTrustedWithOptions([kAXTrustedCheckOptionPrompt: true])` because prompting is the gate UI's job per `docs/ProtectedAPICallPolicy.md`.
+
+- [ ] **Step 1: Add the ApplicationServices import**
+
+At the top of `PermissionsChecker.swift`, after the existing imports, add:
+
+```swift
+#if canImport(ApplicationServices)
+import ApplicationServices
+#endif
+```
+
+(Wrapped in `#if canImport` for symmetry with the existing `CoreGraphics` import. ApplicationServices is macOS-only.)
+
+- [ ] **Step 2: Add the accessibility status helper**
+
+After `screenRecordingStatus()`, add:
+
+```swift
+// MARK: - Accessibility
+
+private func accessibilityStatus() -> PermissionStatus {
+    #if os(macOS)
+    // AXIsProcessTrusted reads the current trust state without
+    // prompting. The prompting variant
+    // AXIsProcessTrustedWithOptions([kAXTrustedCheckOptionPrompt: true])
+    // is intentionally NOT used — the gate UI owns the prompt path so
+    // the user always lands in the same flow regardless of which TCC
+    // surface is missing.
+    //
+    // AX has no equivalent of CGPreflight's not-asked-yet ambiguity:
+    // a fresh process that has never been added to the Accessibility
+    // list returns false, same as one that was explicitly removed.
+    // Either way, the gate UI surfaces the recovery path.
+    return AXIsProcessTrusted() ? .granted : .notDetermined
+    #else
+    return .notDetermined
+    #endif
+}
+```
+
+- [ ] **Step 3: Route `.accessibility` through the new helper**
+
+In `status(for:)`, change:
+
+```swift
+case .accessibility, .microphone, .appleEvents, .inputMonitoring:
+    // Placeholder. Real checks land with their milestones.
+    return .notDetermined
+```
+
+To:
+
+```swift
+case .accessibility:
+    return accessibilityStatus()
+case .microphone, .appleEvents, .inputMonitoring:
+    // Placeholder. Real checks land with their milestones.
+    return .notDetermined
+```
+
+- [ ] **Step 4: Update the file header**
+
+The header currently says "PR 1: Screen Recording is implemented for real. The other kinds return `.notDetermined`...". Update to reflect that AX is now real too:
+
+```swift
+//  PR 1: Screen Recording is implemented for real.
+//  PR 4: Accessibility is implemented for real.
+//  Microphone, Apple Events, and Input Monitoring still return
+//  `.notDetermined` so the gate can be exercised by tests without
+//  making system calls until their milestones land.
+```
+
+(Trim if it gets too long; the exact wording is less important than accurately reflecting which kinds are live.)
+
+---
+
+### Task 4: Update PR-3's `.notImplemented` test
+
+**Files:**
+
+- Modify: `TAELMacAgent/TAELMacAgentTests/HotkeyHandlerTests.swift`
+- Modify: `TAELMacAgent/TAELMacAgent/HUD/PermissionGateView.swift` (explanation copy update)
+
+**Why:** PR-3 added `test_run_whenKindNotImplemented_doesNotCapture_logsRestricted` which constructs a handler with `kind: .accessibility`. That worked when `.accessibility.isImplemented` was `false`, but Task 2 flipped it to `true`. The test now needs a kind that's still unimplemented. `.microphone` is the right swap — it stays placeholder until Week 3.
+
+Also: `PermissionGateView` has a hardcoded "Not yet implemented" string for `.accessibility` that's now wrong.
+
+- [ ] **Step 1: Swap `.accessibility` to `.microphone` in the test**
+
+In `TAELMacAgent/TAELMacAgentTests/HotkeyHandlerTests.swift`, find the `.notImplemented` test:
+
+```swift
+let handler = HotkeyInvocationHandler(
+    permissionsGate: gate,
+    screenCaptureService: capture,
+    presentScreenshot: { presented.append($0) },
+    logService: logService,
+    kind: .accessibility
+)
+```
+
+Change `kind: .accessibility` to `kind: .microphone`. The test's purpose is to exercise the `.notImplemented` → `.restricted` mapping; any unimplemented kind works. `.microphone` stays unimplemented until Week 3 (see `PermissionKind.swift`).
+
+Update the test's leading comment if it mentions accessibility specifically; replace with "Use a kind whose isImplemented returns false today (Week 1 implements .screenRecording, PR 4 implements .accessibility; .microphone, .appleEvents, .inputMonitoring stay placeholders)."
+
+- [ ] **Step 2: Update the `.accessibility` explanation in `PermissionGateView`**
+
+In `TAELMacAgent/TAELMacAgent/HUD/PermissionGateView.swift`, find:
+
+```swift
+case .accessibility:
+    return "Used to read the focused window's UI tree. Not yet implemented."
+```
+
+Change to:
+
+```swift
+case .accessibility:
+    return "Used to read the focused window's UI tree (title, role, content text) so TAEL can scope context to what you're looking at. Read-only — TAEL does not synthesize keyboard or mouse events."
+```
+
+The "Read-only" sentence anticipates a likely user concern: AX permission grants the *ability* to synthesize input, not just read. We're not using the synthesis path in PR-4, but the user's mental model when granting Accessibility includes "this app could move my mouse." Calling out the read-only intent reduces reluctance. (Real input synthesis, when it lands, will be a separate `.inputMonitoring` grant per `docs/ProtectedAPICallPolicy.md`.)
+
+- [ ] **Step 3: Run the full suite**
+
+```bash
+xcodebuild -project TAELMacAgent/TAELMacAgent.xcodeproj \
+  -scheme TAELMacAgent -configuration Debug \
+  -destination 'platform=macOS' CODE_SIGNING_ALLOWED=NO test
+```
+
+Expected: 15 tests pass. If any fail, STOP — Tasks 2/3/4 are committed together so a failure means one of them needs fixing.
+
+- [ ] **Step 4: Commit Tasks 2 + 3 + 4 as one logical unit**
+
+```bash
+git add TAELMacAgent/TAELMacAgent/Permissions/PermissionKind.swift \
+        TAELMacAgent/TAELMacAgent/Permissions/PermissionsChecker.swift \
+        TAELMacAgent/TAELMacAgentTests/HotkeyHandlerTests.swift \
+        TAELMacAgent/TAELMacAgent/HUD/PermissionGateView.swift
+git commit -m "feat(perms): real Accessibility permission flow
+
+PermissionKind.accessibility.isImplemented flips from false to true.
+PermissionsChecker.accessibilityStatus() calls AXIsProcessTrusted()
+to read the current trust state without prompting; prompting stays
+the gate UI's job per docs/ProtectedAPICallPolicy.md.
+
+PermissionGateView's .accessibility copy updates from 'Not yet
+implemented' to a real explanation that calls out read-only intent —
+the synthesis path is a separate .inputMonitoring grant.
+
+HotkeyHandlerTests' .notImplemented → .restricted test was using
+.accessibility (since it was unimplemented in PR 1). Swap to
+.microphone, which stays placeholder until Week 3.
+
+After this PR, calling permissionsGate.withPermission(.accessibility)
+gates against the real OS state instead of throwing .notImplemented.
+No actual AX read happens yet — that's PR 5."
+```
+
+---
+
+## Tests
+
+### Task 5: Add `PermissionsChecker.accessibility` tests
+
+**Files:**
+
+- Modify: `TAELMacAgent/TAELMacAgentTests/PermissionsGateTests.swift` — OR create `TAELMacAgent/TAELMacAgentTests/PermissionsCheckerTests.swift` if there's no existing `Checker`-specific test file. Read both directories first to decide.
+
+**Why:** the `PermissionsCheckerTests.swift` (or equivalent) needs a test for the new `.accessibility` path. The check is hard to fully mock — `AXIsProcessTrusted()` is a global C API not parameterizable per-process. But we can at least verify:
+
+1. The checker returns either `.granted` or `.notDetermined` for `.accessibility` (never crashes, never returns a different value).
+2. The checker's behavior matches whatever the OS reports for the test process.
+
+CI test runs likely return `.notDetermined` (xcodebuild test on a CI runner is not in the Accessibility allow-list). Local dev runs may return `.granted` if the developer added Xcode/`xctest` to Accessibility for unrelated reasons. So the assertion has to accept both.
+
+- [ ] **Step 1: Find or create the test file**
+
+```bash
+find TAELMacAgent/TAELMacAgentTests -name "*Checker*" -o -name "*PermissionsChecker*"
+```
+
+If a file exists, add the test there. If not, create `TAELMacAgent/TAELMacAgentTests/PermissionsCheckerTests.swift`.
+
+- [ ] **Step 2: Write the test**
+
+Add this test to whichever file Step 1 picked:
+
+```swift
+func test_status_forAccessibility_returnsGrantedOrNotDetermined() async {
+    let checker = PermissionsChecker()
+    let status = await checker.status(for: .accessibility)
+    XCTAssertTrue(
+        status == .granted || status == .notDetermined,
+        "Accessibility status must be either .granted or .notDetermined; got \(status). The checker must never return .denied or .restricted for AX since AXIsProcessTrusted only distinguishes trusted/not-trusted."
+    )
+}
+```
+
+Why this assertion shape: `AXIsProcessTrusted()` returns `Bool`, not a four-way TCC enum, so we map `true` to `.granted` and `false` to `.notDetermined`. The test pins that mapping — if a future refactor maps `false` to `.denied` instead, this test catches it.
+
+If you created a new test file, mirror the existing test class structure:
+
+```swift
+//
+//  PermissionsCheckerTests.swift
+//  TAELMacAgentTests
+//
+
+import XCTest
+@testable import TAELMacAgent
+
+@MainActor
+final class PermissionsCheckerTests: XCTestCase {
+    // ... test method here ...
+}
+```
+
+- [ ] **Step 3: Add the test file to the Xcode project (maestro only)**
+
+If a new file was created, registration in `project.pbxproj` is required. Maestro mirrors the pattern used for `HotkeyManagerTests.swift` in PR 3 (4 entries: PBXBuildFile, PBXFileReference, PBXGroup `TAELMacAgentTests` children, PBXSourcesBuildPhase test target). Generate two fresh UUIDs:
+
+```bash
+openssl rand -hex 12 | tr 'a-f' 'A-F' && openssl rand -hex 12 | tr 'a-f' 'A-F'
+```
+
+Insert the 4 entries by reading the corresponding sections in `project.pbxproj` and using `Edit` with `old_string`/`new_string` blocks anchored to `HotkeyManagerTests`-style entries.
+
+- [ ] **Step 4: Run the full suite**
+
+```bash
+xcodebuild -project TAELMacAgent/TAELMacAgent.xcodeproj \
+  -scheme TAELMacAgent -configuration Debug \
+  -destination 'platform=macOS' CODE_SIGNING_ALLOWED=NO test
+```
+
+Expected: 16 tests pass (15 prior + 1 new accessibility checker test).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add TAELMacAgent/TAELMacAgentTests/PermissionsCheckerTests.swift \
+        TAELMacAgent/TAELMacAgent.xcodeproj/project.pbxproj
+git commit -m "test(perms): pin AXIsProcessTrusted → granted/notDetermined mapping
+
+PermissionsChecker.status(for: .accessibility) maps AXIsProcessTrusted
+true to .granted and false to .notDetermined. AXIsProcessTrusted
+returns Bool, so .denied and .restricted are not reachable through
+this path. Test asserts the value is one of those two and never the
+other two."
+```
+
+(Adjust `git add` if Task 5 added the test to an existing file rather than creating a new one — drop the pbxproj path in that case.)
+
+---
+
+## Documentation
+
+### Task 6: Update `docs/ProtectedAPICallPolicy.md` and `docs/PermissionNotes.md`
+
+**Files:**
+
+- Modify: `docs/ProtectedAPICallPolicy.md`
+- Modify: `docs/PermissionNotes.md`
+
+**Why:** the policy doc has a row that says Accessibility is "Future. Enum placeholder only; no real check yet." After PR-4, that's wrong. PermissionNotes (if it has milestone-tracking content) needs the same update.
+
+- [ ] **Step 1: Flip the Accessibility row in the policy table**
+
+In `docs/ProtectedAPICallPolicy.md`, find the table row for Accessibility:
+
+```markdown
+| Accessibility tree | `AXUIElement*`, `AXObserver*` | Accessibility | Future. Enum placeholder only; no real check yet. |
+```
+
+Replace the rightmost cell:
+
+```markdown
+| Accessibility tree | `AXUIElement*`, `AXObserver*` | Accessibility | **Active (PR 4)** — gated through `PermissionsGate` with `.accessibility`. PR 4 lands the permission check (`AXIsProcessTrusted`); the actual AX tree read lands in PR 5. |
+```
+
+If the surrounding text says "For PR 1, only Screen Recording is active. The rest are future policy entries...", update that paragraph too:
+
+> "For PR 4, Screen Recording and Accessibility are active. Microphone, Apple Events, and Input Monitoring remain future policy entries — their enum cases exist (so the gate has a complete vocabulary) but `PermissionsChecker` does not query them, and no service consumes their grants yet."
+
+- [ ] **Step 2: Update `docs/PermissionNotes.md` if it has a Status table**
+
+Read `docs/PermissionNotes.md`. If there's a per-kind status table or a "what's wired" section, flip Accessibility from placeholder to active. If it's narrative-only and AX isn't called out, no change needed.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add docs/ProtectedAPICallPolicy.md docs/PermissionNotes.md
+git commit -m "docs(perms): mark Accessibility permission as active in PR 4
+
+ProtectedAPICallPolicy.md flips the Accessibility row from 'Future.
+Enum placeholder only' to 'Active (PR 4) — gated through
+PermissionsGate'. AX tree read itself remains future (PR 5).
+PermissionNotes.md updated to match."
+```
+
+---
+
+## Wrap up (maestro only)
+
+### Task 7: Open the PR
+
+**Files:** none (orchestration)
+
+**Why maestro-only:** `gh pr create` writes to GitHub.
+
+- [ ] **Step 1: Run the full clean test suite**
+
+```bash
+xcodebuild -project TAELMacAgent/TAELMacAgent.xcodeproj \
+  -scheme TAELMacAgent -configuration Debug \
+  -destination 'platform=macOS' CODE_SIGNING_ALLOWED=NO clean test
+```
+
+Expected: 16 tests pass.
+
+- [ ] **Step 2: Confirm the branch state**
+
+```bash
+git log origin/develop..HEAD --oneline
+```
+
+Expected: 3 commits — one for the perms flip + test swap (Tasks 2/3/4), one for the new accessibility checker test (Task 5), one for docs (Task 6).
+
+- [ ] **Step 3: Push and open the PR**
+
+```bash
+git push origin feature/pr4-accessibility-permission-gate
+gh pr create --base develop --head feature/pr4-accessibility-permission-gate \
+  --title "feat: PR 4 — Accessibility permission gate (Week 2 part 1)" \
+  --body "$(cat <<'EOF'
+## Summary
+
+Lands the AX permission flow as the foundation for Week 2 (focused-window context). Plan: `docs/superpowers/plans/2026-04-26-pr4-accessibility-permission-gate.md`.
+
+After this PR, calling `permissionsGate.withPermission(.accessibility) { ... }` gates against the real OS state. No AX tree read happens yet — that's PR 5.
+
+## What's in
+
+- **`PermissionKind.accessibility.isImplemented` flips to `true`** — gate stops short-circuiting with `.notImplemented` for AX.
+- **`PermissionsChecker.accessibilityStatus()`** — calls `AXIsProcessTrusted()` (no-prompt variant); returns `.granted` for trusted, `.notDetermined` otherwise. Prompting stays the gate UI's job per `docs/ProtectedAPICallPolicy.md`.
+- **Updated `PermissionGateView` copy for `.accessibility`** — replaces "Not yet implemented" with a real explanation that calls out read-only intent.
+- **Test fixup** — PR-3's `.notImplemented` test was using `.accessibility` to exercise the unimplemented branch; swapped to `.microphone` since AX is now implemented.
+- **New test** for the `AXIsProcessTrusted` → `.granted`/`.notDetermined` mapping.
+- **`ProtectedAPICallPolicy.md`** flips the AX row from "Future" to "Active (PR 4)".
+
+## Test plan
+
+- [x] `xcodebuild ... clean test` — 16 tests, 0 failures.
+- [ ] Manual: with TAEL not yet in System Settings → Privacy & Security → Accessibility, call `await permissionsGate.withPermission(.accessibility) { _ in }` from a debug menu (no menu item lands in PR 4 — verify via the next hotkey-driven flow once PR 5 wires it). Expected: gate UI appears with the new copy and the "Open System Settings" deep link routes to the AX pane.
+- [ ] Manual: grant TAEL accessibility in System Settings, relaunch, retry the same call. Expected: gate UI does NOT appear; the closure runs.
+
+## Out of scope
+
+- AX tree reading, `AXService` (PR 5)
+- Focused-window metadata (PR 5)
+- Context bundle v0 (PR 5 or PR 6)
+- Microphone, Apple Events, Input Monitoring permission flows (their own milestone weeks)
+EOF
+)"
+```
+
+Expected: PR URL printed.
+
+---
+
+## Self-review checklist
+
+**1. Spec coverage:**
+
+- v0.3 §12.3 deliverable "AX permission gate" — covered by Task 2 + Task 3.
+- v0.3 §23.0 ("Accessibility... not real checks until their milestones") — Task 2 + Task 3 cross the milestone boundary correctly.
+- v0.3 §12.3 deliverable "missing AX permission handled" — covered by the existing `PermissionsGate` + `PermissionGateView` machinery (no new code needed).
+- v0.3 §12.3 deliverables NOT in this PR (frontmost app detection, focused window title, AX tree dump, context bundle v0, local debug JSON) — explicit "Out of scope" callout. PR-5.
+
+**2. Placeholder scan:** No "TBD", "implement later" patterns. Each step has concrete code or commands.
+
+**3. Type consistency:**
+
+- `PermissionKind.accessibility` stays the same enum case; only `isImplemented` flips.
+- `PermissionsChecker.status(for:)` signature unchanged.
+- `PermissionGateView` signature unchanged; only the copy strings inside `explanation` switch change.
+- `HotkeyHandlerTests` preserves the test's name; only the kind argument flips.
+
+**4. Test count progression:** PR-3 left the suite at 15. Task 5 adds 1 → 16. PR title and commit messages match.
+
+**5. Branch model alignment:** Feature branch off `develop`, single PR back into `develop`. Pre-condition: PR #19 merged or branch off PR-3's tip with rebase intent.
+
+**6. Breaking-change concern:** flipping `PermissionKind.accessibility.isImplemented` is a behavior change for any downstream code that branched on this. The only such caller today is the test in PR-3 (Task 4 fixes it). No production code depends on `.isImplemented` of `.accessibility` returning `false`.
+
+---
+
+## Notes for the executor
+
+- **Tasks 1 + 7 are maestro-only** for the same reasons as PR-2 / PR-3: branch creation pushes to origin, PR creation hits GitHub.
+- **Sandbox commit pattern:** unchanged from PR-3. Codex applies edits + reports diff; maestro stages, runs `xcodebuild test`, commits.
+- **Tasks 2/3/4 commit together:** the plan deliberately bundles them because an intermediate commit (e.g. flipping `isImplemented` without updating the test) would leave the suite red.
+- **No new pbxproj work for Tasks 2-4:** they only modify existing files. Task 5 may add a new test file, in which case maestro does the 4-entry pbxproj registration with mirroring (same pattern as `HotkeyManagerTests` in PR-3).
+- **`AXIsProcessTrusted()` vs `AXIsProcessTrustedWithOptions(nil)`:** functionally identical. The plan uses the simpler no-arg version. If a future need arises for the prompting variant, it goes in the gate UI (the user's "Open System Settings" path), NOT in the checker.
+- **CI/local divergence on Task 5's test:** the test allows both `.granted` and `.notDetermined` because the result depends on whether the test process is trusted by AX. CI runners are not; local dev machines may or may not be. Don't tighten the assertion to one specific value.
+- **Why not bundle PR-5's AXService into PR-4:** PR-5 introduces a new service, new types, and is the first time we're actually consuming an AX grant. That's the natural review surface for AX-as-a-feature. PR-4 is intentionally narrow so reviewers can verify the permission flow without wading through tree-read logic.

--- a/docs/superpowers/plans/2026-04-26-pr5-axservice-focused-window.md
+++ b/docs/superpowers/plans/2026-04-26-pr5-axservice-focused-window.md
@@ -1,0 +1,489 @@
+# PR 5 — Week 2 part 2: AXService + focused-window metadata
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use `superpowers:subagent-driven-development` (recommended) or `superpowers:executing-plans`. Steps use checkbox (`- [ ]`) syntax. **Project-specific:** "subagent" maps to Codex via the `agent-codex:codex` skill; Claude Opus 4.7 reviews each commit. Tasks 1 (branch + push) and 8 (PR creation) are maestro-only because Codex's sandbox blocks `.git` writes and `gh` writes.
+
+**Goal:** Add focused-window context to the heartbeat. After PR-5, a hotkey invocation captures both a screenshot AND focused-window metadata (frontmost app bundle ID + name, focused window title + role) bundled into a single `ContextBundle` value. The HUD renders both. PR-4's AX permission gate now actually does work — `withPermission(.accessibility)` grants a token that `AXService` consumes.
+
+**Architecture:** `AXService` (parallel to `ScreenCaptureService`) reads window metadata via Accessibility APIs, gated by the same `PermissionGrant` token pattern. A `FocusedWindowReading` protocol mirrors `DisplayScreenshotCapturing` for test substitution. A new `ContextBundle` value type wraps `(screenshot: CapturedScreenshot?, window: FocusedWindowMetadata?)` — both optional because either one may fail without taking down the other (graceful degradation). `HotkeyInvocationHandler` runs both reads in parallel via `async let` and presents the bundle.
+
+**Tech stack:** Swift 5.10, ApplicationServices framework (`AXUIElementCreateApplication`, `AXUIElementCopyAttributeValue`, `kAXFocusedWindowAttribute`, `kAXTitleAttribute`, `kAXRoleAttribute`), AppKit (`NSWorkspace.shared.frontmostApplication`), SwiftUI for the HUD additions, XCTest. No new SPM dependencies.
+
+**Spec sources:** `TAEL_AI_mac_agent_build_plan_v0_3.md` §12.3 deliverables: "frontmost app detection, focused window title, bundle ID" — all in PR-5. The "AX tree dump" deliverable is intentionally deferred to PR-6.
+
+**Out of scope:**
+
+- AX tree dump (`kAXChildrenAttribute` walk + trimming) — PR-6
+- Local debug JSON dump of the bundle — PR-6 or later
+- Voice / WhisperKit (Week 3)
+- Planner adapter (Week 4)
+- Per-app bundle-ID allowlist for AX reads (PR-7+)
+- Sandboxed apps that do not expose AX metadata (handled gracefully — return `nil` window, do not crash)
+
+---
+
+## Pre-flight
+
+### Task 1: Branch off develop (autopilot writes the plan first; later cycles execute)
+
+**Files:** none
+
+**Why maestro/autopilot only:** The plan file lands as the first commit on `feature/pr5-axservice-focused-window`. Subsequent cycles execute Tasks 2-8 against that branch.
+
+- [x] **Step 1: Branch and commit the plan** (this cycle)
+
+```bash
+git checkout develop && git pull origin develop && \
+  git checkout -b feature/pr5-axservice-focused-window
+# The plan file lands as the first commit; tasks below run in subsequent cycles.
+```
+
+---
+
+## New types
+
+### Task 2: `FocusedWindowMetadata` value type
+
+**Files:**
+
+- Create: `TAELMacAgent/TAELMacAgent/Capture/FocusedWindowMetadata.swift`
+
+**Why:** structured carrier for window context. Optional fields because AX may report any subset depending on app state (sandboxed apps, hidden windows, etc.).
+
+- [ ] **Step 1: Create the file**
+
+```swift
+//
+//  FocusedWindowMetadata.swift
+//  TAELMacAgent
+//
+//  Snapshot of the frontmost app's focused window taken alongside
+//  the screenshot during a hotkey invocation. All fields optional
+//  because AX availability varies by app, sandbox, and visibility.
+//
+
+import Foundation
+
+public struct FocusedWindowMetadata: Equatable, Sendable {
+    public let appBundleID: String?
+    public let appName: String?
+    public let windowTitle: String?
+    public let windowRole: String?
+    public let capturedAt: Date
+
+    public init(
+        appBundleID: String?,
+        appName: String?,
+        windowTitle: String?,
+        windowRole: String?,
+        capturedAt: Date = Date()
+    ) {
+        self.appBundleID = appBundleID
+        self.appName = appName
+        self.windowTitle = windowTitle
+        self.windowRole = windowRole
+        self.capturedAt = capturedAt
+    }
+
+    /// True iff at least one field beyond capturedAt is populated.
+    public var hasAnyData: Bool {
+        appBundleID != nil || appName != nil || windowTitle != nil || windowRole != nil
+    }
+}
+```
+
+- [ ] **Step 2: Build, no test yet** (the type is exercised by Task 4)
+
+```bash
+xcodebuild -project TAELMacAgent/TAELMacAgent.xcodeproj \
+  -scheme TAELMacAgent -configuration Debug \
+  -destination 'platform=macOS' CODE_SIGNING_ALLOWED=NO build
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add TAELMacAgent/TAELMacAgent/Capture/FocusedWindowMetadata.swift \
+        TAELMacAgent/TAELMacAgent.xcodeproj/project.pbxproj
+git commit -m "feat(capture): FocusedWindowMetadata value type
+
+Snapshot of the frontmost app's focused window — bundle ID, app name,
+window title, window role, capturedAt. All optional because AX
+availability varies by app/sandbox/visibility."
+```
+
+(The maestro registers the new file in pbxproj manually with mirroring edits — same pattern as PR-3's HotkeyManagerTests and PR-4's PermissionsCheckerTests.)
+
+---
+
+### Task 3: `ContextBundle` and `FocusedWindowReading` protocol
+
+**Files:**
+
+- Modify: `TAELMacAgent/TAELMacAgent/Capture/ScreenCaptureService.swift` (add the protocol next to `DisplayScreenshotCapturing`)
+- Create: `TAELMacAgent/TAELMacAgent/Capture/ContextBundle.swift`
+
+**Why:** the protocol lets tests inject a fake AX reader; `ContextBundle` is what the handler returns and what the HUD renders.
+
+- [ ] **Step 1: Add `FocusedWindowReading` protocol**
+
+In `ScreenCaptureService.swift` (or a co-located new file — keep it next to `DisplayScreenshotCapturing` so the testability surface lives together), add:
+
+```swift
+public protocol FocusedWindowReading: Sendable {
+    func readFocusedWindow(_ grant: PermissionGrant) async throws -> FocusedWindowMetadata
+}
+```
+
+- [ ] **Step 2: Create `ContextBundle.swift`**
+
+```swift
+//
+//  ContextBundle.swift
+//  TAELMacAgent
+//
+//  What a single hotkey invocation captures. PR-5 has screenshot +
+//  focused-window metadata; PR-6 will add AX tree dump.
+//
+
+import Foundation
+
+public struct ContextBundle: Equatable, Sendable {
+    public let screenshot: CapturedScreenshot?
+    public let window: FocusedWindowMetadata?
+    public let capturedAt: Date
+
+    public init(
+        screenshot: CapturedScreenshot?,
+        window: FocusedWindowMetadata?,
+        capturedAt: Date = Date()
+    ) {
+        self.screenshot = screenshot
+        self.window = window
+        self.capturedAt = capturedAt
+    }
+}
+```
+
+`CapturedScreenshot` may not yet conform to `Equatable` (it carries a `CGImage` which doesn't). If the build fails at the `Equatable` synthesis, drop `Equatable` from `ContextBundle` and use a custom comparison helper if needed in tests. Treat this as a real possibility, not a maybe — verify on build.
+
+- [ ] **Step 3: Build + commit**
+
+```bash
+xcodebuild -project TAELMacAgent/TAELMacAgent.xcodeproj \
+  -scheme TAELMacAgent -configuration Debug \
+  -destination 'platform=macOS' CODE_SIGNING_ALLOWED=NO build
+```
+
+```bash
+git add TAELMacAgent/TAELMacAgent/Capture/ScreenCaptureService.swift \
+        TAELMacAgent/TAELMacAgent/Capture/ContextBundle.swift \
+        TAELMacAgent/TAELMacAgent.xcodeproj/project.pbxproj
+git commit -m "feat(capture): ContextBundle + FocusedWindowReading protocol"
+```
+
+---
+
+## Real AX read
+
+### Task 4: `AXService` implementing `FocusedWindowReading`
+
+**Files:**
+
+- Create: `TAELMacAgent/TAELMacAgent/Capture/AXService.swift`
+
+**Why:** the production reader. Asserts `grant.kind == .accessibility` (mirroring how `ScreenCaptureService` asserts `.screenRecording`).
+
+- [ ] **Step 1: Create the file**
+
+```swift
+//
+//  AXService.swift
+//  TAELMacAgent
+//
+//  Reads the frontmost app's focused window via Accessibility APIs.
+//  Gated through PermissionsGate with the .accessibility kind.
+//
+//  PR-5: title + role + app bundle/name only. AX tree dump is PR-6.
+//
+
+import Foundation
+#if canImport(AppKit)
+import AppKit
+#endif
+#if canImport(ApplicationServices)
+import ApplicationServices
+#endif
+
+public enum AXReadError: Error, Equatable {
+    case noFrontmostApp
+    case axElementUnavailable
+    case attributeFailed(String)
+}
+
+public final class AXService: FocusedWindowReading {
+    public init() {}
+
+    public func readFocusedWindow(_ grant: PermissionGrant) async throws -> FocusedWindowMetadata {
+        precondition(
+            grant.kind == .accessibility,
+            "AXService requires a .accessibility grant"
+        )
+
+        #if os(macOS)
+        guard let frontApp = NSWorkspace.shared.frontmostApplication else {
+            throw AXReadError.noFrontmostApp
+        }
+
+        let appBundleID = frontApp.bundleIdentifier
+        let appName = frontApp.localizedName
+        let pid = frontApp.processIdentifier
+
+        let axApp = AXUIElementCreateApplication(pid)
+        var focusedWindowRef: CFTypeRef?
+        let focusErr = AXUIElementCopyAttributeValue(
+            axApp,
+            kAXFocusedWindowAttribute as CFString,
+            &focusedWindowRef
+        )
+
+        guard focusErr == .success, let focusedWindow = focusedWindowRef else {
+            // Frontmost app may have no focused window (e.g. menu bar agents).
+            // Return what we have without throwing.
+            return FocusedWindowMetadata(
+                appBundleID: appBundleID,
+                appName: appName,
+                windowTitle: nil,
+                windowRole: nil
+            )
+        }
+
+        let axWindow = focusedWindow as! AXUIElement
+
+        let title = copyStringAttribute(axWindow, kAXTitleAttribute as CFString)
+        let role = copyStringAttribute(axWindow, kAXRoleAttribute as CFString)
+
+        return FocusedWindowMetadata(
+            appBundleID: appBundleID,
+            appName: appName,
+            windowTitle: title,
+            windowRole: role
+        )
+        #else
+        throw AXReadError.axElementUnavailable
+        #endif
+    }
+
+    private func copyStringAttribute(_ element: AXUIElement, _ attr: CFString) -> String? {
+        var ref: CFTypeRef?
+        let err = AXUIElementCopyAttributeValue(element, attr, &ref)
+        guard err == .success else { return nil }
+        return ref as? String
+    }
+}
+```
+
+- [ ] **Step 2: Build (no unit test for AXService body — real AX requires real apps + permission)**
+
+```bash
+xcodebuild -project TAELMacAgent/TAELMacAgent.xcodeproj \
+  -scheme TAELMacAgent -configuration Debug \
+  -destination 'platform=macOS' CODE_SIGNING_ALLOWED=NO build
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add TAELMacAgent/TAELMacAgent/Capture/AXService.swift \
+        TAELMacAgent/TAELMacAgent.xcodeproj/project.pbxproj
+git commit -m "feat(capture): AXService reads focused-window metadata
+
+Implementation of FocusedWindowReading using ApplicationServices.
+AXUIElementCreateApplication on the frontmost app's pid, then
+kAXFocusedWindowAttribute, kAXTitleAttribute, kAXRoleAttribute.
+
+Bundle ID + app name come from NSWorkspace.frontmostApplication. App-
+without-focused-window case (menu bar agents) returns metadata with
+nil title/role — graceful, not an error.
+
+AX tree dump (kAXChildrenAttribute walk + trimming) is PR-6."
+```
+
+---
+
+## Wire into the heartbeat
+
+### Task 5: `HotkeyInvocationHandler` captures both screenshot AND window
+
+**Files:**
+
+- Modify: `TAELMacAgent/TAELMacAgent/App/HotkeyInvocationHandler.swift`
+- Modify: `TAELMacAgent/TAELMacAgent/App/AppDelegate.swift`
+- Modify: `TAELMacAgent/TAELMacAgentTests/HotkeyHandlerTests.swift`
+
+**Why:** today the handler returns a `CapturedScreenshot`. PR-5 makes it return a `ContextBundle` (screenshot + optional window). Both reads happen in parallel via `async let`. Either failing logs but doesn't take down the other — graceful degradation.
+
+- [ ] **Step 1: Add `axService` and `presentBundle` parameters to the handler**
+
+The struct gains `axService: any FocusedWindowReading` and the `presentScreenshot: (CapturedScreenshot) -> Void` closure becomes `presentBundle: (ContextBundle) -> Void`. Both with sensible defaults (a no-op AX reader and the existing screenshot-presenter as a fallback if `presentBundle` not provided).
+
+Actually — DON'T break the existing test surface in this commit. Add the new parameters with defaults; existing tests keep working. Only the production wire-up at AppDelegate constructs with the real AX service and the bundle presenter.
+
+- [ ] **Step 2: Inside `run()`, parallelize**
+
+```swift
+async let screenshotResult: CapturedScreenshot? = (try? await captureScreenshotPath())
+async let windowResult: FocusedWindowMetadata? = (try? await captureWindowPath())
+
+let screenshot = await screenshotResult
+let window = await windowResult
+
+let bundle = ContextBundle(screenshot: screenshot, window: window)
+presentBundle(bundle)
+```
+
+(This is sketch — actual implementation needs to keep gate latencies recorded per InvocationLog. Decide: record two latency rows or one combined? Recommendation: one combined row with `gateLatencyMs`/`captureLatencyMs` capturing the LONGER of the two paths plus a new `axLatencyMs` field. That's an InvocationLog schema bump — flag for explicit decision in this task.)
+
+- [ ] **Step 3: Update `AppDelegate` to construct with `axService: AXService()` and `presentBundle:` closure**
+
+- [ ] **Step 4: Add test that exercises the parallel paths**
+
+`SpyAXReader` actor returns a stub `FocusedWindowMetadata`. Test asserts that the bundle has BOTH screenshot and window populated on the granted path; AX-failure path produces a bundle with `screenshot != nil, window == nil` and a log row noting the AX failure.
+
+- [ ] **Step 5: Build, run full suite, commit**
+
+Expected: 17+ tests pass (existing 16 plus new bundle-path test).
+
+---
+
+## HUD rendering
+
+### Task 6: `HUDScreenshotView` becomes `HUDBundleView` (or similar)
+
+**Files:**
+
+- Rename or modify: `TAELMacAgent/TAELMacAgent/HUD/HUDScreenshotView.swift`
+- Modify: `TAELMacAgent/TAELMacAgent/HUD/HUDPanelController.swift`
+
+**Why:** the HUD now renders both screenshot and window context. Decision: rename `HUDScreenshotView` → `HUDBundleView` and update to take a `ContextBundle`, OR keep `HUDScreenshotView` and add a new `HUDBundleView` that composes screenshot + window. **Recommendation:** rename. The screenshot-only HUD never appears in production after this PR.
+
+- [ ] **Step 1: Rewrite the view**
+
+```swift
+struct HUDBundleView: View {
+    let bundle: ContextBundle
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            if let win = bundle.window, win.hasAnyData {
+                HStack(spacing: 6) {
+                    Text(win.appName ?? win.appBundleID ?? "Unknown app")
+                        .font(.caption.bold())
+                    if let title = win.windowTitle {
+                        Text("— \(title)")
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                            .lineLimit(1)
+                    }
+                }
+            }
+
+            if let shot = bundle.screenshot {
+                Text("Captured \(shot.width)×\(shot.height) — \(targetLabel(shot.target))")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+
+                Image(decorative: shot.image, scale: 1.0, orientation: .up)
+                    .resizable()
+                    .aspectRatio(contentMode: .fit)
+                    .frame(maxWidth: 720, maxHeight: 480)
+                    .background(Color.black.opacity(0.3))
+                    .cornerRadius(6)
+            } else {
+                Text("Screenshot unavailable")
+                    .font(.caption)
+                    .foregroundStyle(.orange)
+            }
+        }
+        .padding(16)
+    }
+
+    private func targetLabel(_ target: ScreenshotTarget) -> String {
+        switch target {
+        case .displayContainingCursor: return "cursor display"
+        case .mainDisplay:             return "main display (fallback)"
+        }
+    }
+}
+```
+
+- [ ] **Step 2: `HUDPanelController.present(screenshot:)` becomes `present(bundle:)`**
+
+Update call sites in `AppDelegate` and `HotkeyInvocationHandler`.
+
+- [ ] **Step 3: Manual verify (no unit test for SwiftUI view)**
+
+- [ ] **Step 4: Commit**
+
+---
+
+## Documentation
+
+### Task 7: Update `docs/Architecture.md`, `docs/Week1Heartbeat.md`, `docs/PermissionNotes.md`
+
+**Files:**
+
+- Modify: `docs/Architecture.md` — add the AXService + ContextBundle to the diagram
+- Modify: `docs/Week1Heartbeat.md` — note that PR-5 extends the heartbeat to a context bundle (Week 2 territory now, but the heartbeat doc should acknowledge it)
+- Modify: `docs/PermissionNotes.md` — Accessibility section gains a "PR 5: actual reads" note
+
+- [ ] **Step 1: Edit each file**
+- [ ] **Step 2: Commit**
+
+---
+
+## Wrap up (maestro only)
+
+### Task 8: Open the PR
+
+**Files:** none (orchestration)
+
+- [ ] **Step 1: Final clean test run** — `xcodebuild ... clean test`. Expected: 17+ tests pass.
+- [ ] **Step 2: Push** — `git push origin feature/pr5-axservice-focused-window`
+- [ ] **Step 3: Open PR** with body summarizing what's in PR-5 and what's deferred to PR-6.
+
+---
+
+## Self-review checklist
+
+**1. Spec coverage:**
+
+- v0.3 §12.3 deliverables in PR-5: frontmost app detection ✓ (`NSWorkspace.frontmostApplication`), focused window title ✓ (`kAXTitleAttribute`), bundle ID ✓.
+- Deferred: AX tree dump (PR-6), local debug JSON (PR-6 or later), context bundle UX iterations (post-Week 2).
+
+**2. Type consistency:**
+
+- `FocusedWindowMetadata` is a value type, mirrors `CapturedScreenshot`'s shape.
+- `FocusedWindowReading` mirrors `DisplayScreenshotCapturing` (test-substitutable, takes `PermissionGrant`).
+- `AXService` asserts `.accessibility` grant kind via `precondition`, mirroring `ScreenCaptureService`'s `.screenRecording` precondition.
+- `ContextBundle` may need to drop `Equatable` if `CapturedScreenshot` doesn't synthesize it — flagged in Task 3.
+
+**3. Failure-mode coverage:**
+
+- AX-disabled or no-frontmost-app: returns a metadata with everything but `appBundleID`/`appName` nil, doesn't throw.
+- Screenshot fails but AX succeeds: bundle has `screenshot=nil, window=metadata`.
+- Both fail: bundle has both nil, presented HUD shows "Screenshot unavailable" (already there) and just no window header.
+
+**4. Test count progression:** PR-4 left the suite at 16. Task 5 adds 1+ → 17 minimum. PR title and commit messages reflect.
+
+**5. Branch model alignment:** Feature branch off `develop`, single PR back into `develop`.
+
+---
+
+## Notes for the executor
+
+- **Tasks 1 + 8 are maestro/autopilot-only** — branch creation pushes to origin, PR creation hits GitHub. Codex's sandbox can't do either.
+- **`async let` parallelization** — `screenshotResult` and `windowResult` run concurrently. The handler must `await` both before constructing the bundle. Make sure both run on the MainActor (the handler is `@MainActor`).
+- **Two PermissionGrants in one invocation** — this is the first time the handler needs grants from two different kinds (`.screenRecording` AND `.accessibility`). Two separate `withPermission` calls, NOT a single multi-kind call. The gate enforces one grant per call site.
+- **InvocationLog schema bump** — adding `axLatencyMs` and `axOutcome` fields probably needs to land in PR-5. Decide explicitly: extend `InvocationLog` in this PR, or do it as a small precursor commit.
+- **Equatable conformance landmines** — `CapturedScreenshot` carries a `CGImage`. If you put it inside an `Equatable` struct, the compiler may not synthesize. Drop `Equatable` from `ContextBundle` if so.
+- **Manual verification gate** — Task 4 (AXService) and Task 6 (HUDBundleView) cannot be unit-tested end-to-end. Manual matrix should add at least: PR-5.1 (focused window title appears in HUD when invoked from VS Code), PR-5.2 (bundle ID appears for sandboxed apps like Safari), PR-5.3 (menu-bar agent has nil window title but app name still appears).

--- a/scripts/package-alpha-dmg.sh
+++ b/scripts/package-alpha-dmg.sh
@@ -55,6 +55,7 @@ require_command xcodebuild
 require_command xcrun
 require_command hdiutil
 require_command codesign
+require_command security
 require_command spctl
 require_command ditto
 

--- a/scripts/package-alpha-dmg.sh
+++ b/scripts/package-alpha-dmg.sh
@@ -1,0 +1,125 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+PROJECT="$ROOT_DIR/TAELMacAgent/TAELMacAgent.xcodeproj"
+SCHEME="TAELMacAgent"
+TEAM_ID="${TEAM_ID:-4X8U3NCLQ8}"
+APP_NAME="TAELMacAgent"
+VERSION="${VERSION:-0.1.0-alpha}"
+BUILD_DIR="$ROOT_DIR/dist/alpha"
+ARCHIVE_PATH="$BUILD_DIR/$APP_NAME.xcarchive"
+APP_ZIP="$BUILD_DIR/$APP_NAME-$VERSION.app.zip"
+DMG_PATH="$BUILD_DIR/$APP_NAME-$VERSION.dmg"
+DEVELOPER_ID_APPLICATION="${DEVELOPER_ID_APPLICATION:-}"
+NOTARYTOOL_PROFILE="${NOTARYTOOL_PROFILE:-}"
+
+usage() {
+    cat <<EOF
+Usage:
+  DEVELOPER_ID_APPLICATION="Developer ID Application: ..." \\
+  NOTARYTOOL_PROFILE="tael-notary" \\
+  VERSION="0.1.0-alpha.1" \\
+  $0
+
+Required:
+  DEVELOPER_ID_APPLICATION  Developer ID Application signing identity.
+  NOTARYTOOL_PROFILE        Keychain profile created with xcrun notarytool store-credentials.
+
+Output:
+  $DMG_PATH
+EOF
+}
+
+require_value() {
+    local name="$1"
+    local value="$2"
+    if [[ -z "$value" ]]; then
+        echo "error: $name is required." >&2
+        usage >&2
+        exit 2
+    fi
+}
+
+require_command() {
+    local name="$1"
+    if ! command -v "$name" >/dev/null 2>&1; then
+        echo "error: required command not found: $name" >&2
+        exit 2
+    fi
+}
+
+require_value "DEVELOPER_ID_APPLICATION" "$DEVELOPER_ID_APPLICATION"
+require_value "NOTARYTOOL_PROFILE" "$NOTARYTOOL_PROFILE"
+require_command xcodebuild
+require_command xcrun
+require_command hdiutil
+require_command codesign
+require_command spctl
+require_command ditto
+
+if ! security find-identity -v -p codesigning | grep -F "$DEVELOPER_ID_APPLICATION" >/dev/null; then
+    echo "error: Developer ID identity not found in keychain: $DEVELOPER_ID_APPLICATION" >&2
+    echo "Install the Developer ID Application certificate before packaging alpha DMGs." >&2
+    exit 2
+fi
+
+rm -rf "$BUILD_DIR"
+mkdir -p "$BUILD_DIR"
+
+echo "==> Archiving $APP_NAME $VERSION"
+xcodebuild \
+    -project "$PROJECT" \
+    -scheme "$SCHEME" \
+    -configuration Release \
+    -destination 'generic/platform=macOS' \
+    -archivePath "$ARCHIVE_PATH" \
+    DEVELOPMENT_TEAM="$TEAM_ID" \
+    CODE_SIGN_STYLE=Manual \
+    CODE_SIGN_IDENTITY="$DEVELOPER_ID_APPLICATION" \
+    archive
+
+APP_PATH="$ARCHIVE_PATH/Products/Applications/$APP_NAME.app"
+if [[ ! -d "$APP_PATH" ]]; then
+    echo "error: archive did not produce $APP_PATH" >&2
+    exit 1
+fi
+
+echo "==> Verifying app signature"
+codesign --verify --deep --strict --verbose=2 "$APP_PATH"
+
+echo "==> Submitting app for notarization"
+ditto -c -k --keepParent "$APP_PATH" "$APP_ZIP"
+xcrun notarytool submit "$APP_ZIP" \
+    --keychain-profile "$NOTARYTOOL_PROFILE" \
+    --wait
+
+echo "==> Stapling app notarization ticket"
+xcrun stapler staple "$APP_PATH"
+xcrun stapler validate "$APP_PATH"
+
+echo "==> Gatekeeper app assessment"
+spctl -a -vvv "$APP_PATH"
+
+echo "==> Creating DMG"
+rm -f "$DMG_PATH"
+hdiutil create \
+    -volname "TAEL AI Alpha" \
+    -srcfolder "$APP_PATH" \
+    -ov \
+    -format UDZO \
+    "$DMG_PATH"
+
+echo "==> Submitting DMG for notarization"
+xcrun notarytool submit "$DMG_PATH" \
+    --keychain-profile "$NOTARYTOOL_PROFILE" \
+    --wait
+
+echo "==> Stapling notarization ticket"
+xcrun stapler staple "$DMG_PATH"
+xcrun stapler validate "$DMG_PATH"
+
+echo "==> Gatekeeper DMG assessment"
+spctl -a -vvv --type open "$DMG_PATH"
+
+echo "Alpha DMG ready: $DMG_PATH"


### PR DESCRIPTION
# Summary

Roll-up of Weeks 1–2 (PRs 1–5 plus review-fix series) from `develop` into `main`.

What ships:
- Real global hotkey **⌘⇧T** via `KeyboardShortcuts` SPM package
- Real `SCScreenshotManager.captureImage(contentFilter:configuration:)` with cursor-display → main-display fallback (v0.3 §23.2)
- New `AXService` reading frontmost app + focused-window title/role through `PermissionsGate.withPermission(.accessibility, showMissingUI: false)`
- `ContextBundle` (screenshot + AX metadata) and matching HUD view; AX missing degrades gracefully without a second permission gate
- Extracted, unit-testable `HotkeyInvocationHandler` with deterministic clock
- Re-entrant hotkey guard (drop overlapping presses)
- HUD: non-activating `NSPanel`, screenshot / context-bundle / error / permission-gate views
- Alpha DMG signing + notarization script (`scripts/package-alpha-dmg.sh`) + checklist
- Latency instrumentation (`gateLatencyMs`, `captureLatencyMs`)
- **NEW** `xcodebuild build && test` CI on macos-14
- **NEW** Curated user-facing capture-error HUD copy (no raw `localizedDescription`)
- **NEW** Pure `resolveDisplay` resolver + 6 unit tests pinning the §23.2 rule

## Scope check (v0.3)

- [x] Inside the v0.3 milestone scope (Weeks 1–2; no scope creep)
- [x] No protected macOS API call bypasses `PermissionsGate`
- [x] Screen Recording **and** Accessibility are real (Accessibility added in PR 4)
- [x] Screenshot path uses `SCScreenshotManager.captureImage(contentFilter:configuration:)` (not `captureImage(in:)`)
- [x] No screenshot, audio, or transcript persisted to disk
- [x] New third-party packages documented in `docs/Architecture.md` (`KeyboardShortcuts`)

## Permissions impact

- **Screen Recording** — required for the heartbeat. `PermissionsChecker` reads `CGPreflightScreenCaptureAccess`. Missing/denied → `PermissionGateView` with deep-link to System Settings.
- **Accessibility** — required for focused-window metadata. Optional: missing AX does **not** block the screenshot heartbeat and does **not** show a second gate during the hotkey flow (`showMissingUI: false`). `PermissionsChecker` reads `AXIsProcessTrusted`.
- All other `PermissionKind` cases (microphone, appleEvents, inputMonitoring) remain enum placeholders; `withPermission` throws `.notImplemented` for them.

## Test plan

- [x] `xcodebuild ... clean build` succeeds locally on macOS 14.0+
- [x] `xcodebuild ... test` passes locally
- [x] CI workflow runs `xcodebuild build` + `xcodebuild test` on every push/PR (added in this branch — first run pending)
- [ ] App launches as menubar utility and quits cleanly from menu *(manual)*
- [ ] `docs/ManualTestChecklist.md` PR-2 and PR-5 rows green *(manual, run before final merge)*
- [ ] Alpha DMG smoke test (rows A.1–A.6 in `ManualTestChecklist.md`) *(manual, blocked on local Developer ID identity)*

## Out of scope / follow-ups

- AI planner, voice/STT, AX tree reads beyond focused-window, executor paths, YAML skills (per v0.3 milestone schedule)
- App Sandbox + hardened runtime decision before public alpha (currently OFF, deliberate)
- `PermissionsChecker.screenRecordingStatus()` denied↔notDetermined UX copy improvement
- Sparkle auto-update (deferred per `AlphaReleaseChecklist.md`)

## Risk

- [ ] Low — purely additive, behind a feature
- [x] **Medium — touches `PermissionsGate` and the capture path**
- [ ] High — touches signing, entitlements, or executor

This adds the second active permission kind (Accessibility) and the first real protected-API consumer beyond the screenshot path. The architectural boundary (`PermissionGrant` `fileprivate init` in `PermissionsGate.swift`) is preserved; new services `precondition` on the grant kind they expect.

## Screenshots / recordings

See PR-2 / PR-5 manual checklist rows in `docs/ManualTestChecklist.md`.

---

## Review-fix log on this PR

Direct commits onto `develop` after the initial review:

| Commit | Item | Notes |
|---|---|---|
| `e4fe429` | refactor: rename `.week1Default` → `.defaultTarget` | Week 2 has shipped; alias name was dated. |
| `babad45` | ci: `xcodebuild build + test` on macOS 14 | Closes the no-CI-gate gap. |
| `590137a` | fix(hud): scrub raw `localizedDescription` | Curated copy + 2 tests. |
| `71acb58` | test(capture): pure `resolveDisplay` + 6 tests | Pins v0.3 §23.2 cursor → main → first-available rule. |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
